### PR TITLE
Remove stuff related to ATI

### DIFF
--- a/ArmoryQt.py
+++ b/ArmoryQt.py
@@ -180,10 +180,10 @@ class ArmoryMainWindow(QMainWindow):
       # reconnecting connection, so we keep it around.
       self.SingletonConnectedNetworkingFactory = None
 
-      # Kick off announcement checking, unless they explicitly disabled it
-      # The fetch happens in the background, we check the results periodically
-      self.announceFetcher = None
-      self.setupAnnouncementFetcher()
+      # # Kick off announcement checking, unless they explicitly disabled it
+      # # The fetch happens in the background, we check the results periodically
+      # self.announceFetcher = None
+      # self.setupAnnouncementFetcher()
 
       #delayed URI parsing dict
       self.delayedURIData = {}
@@ -522,8 +522,8 @@ class ArmoryMainWindow(QMainWindow):
       self.tabActivity = QWidget()
       self.tabActivity.setLayout(ledgLayout)
 
-      self.tabAnnounce = QWidget()
-      self.setupAnnounceTab()
+      #self.tabAnnounce = QWidget()
+      #self.setupAnnounceTab()
 
 
       # Add the available tabs to the main tab widget
@@ -531,7 +531,7 @@ class ArmoryMainWindow(QMainWindow):
 
       self.mainDisplayTabs.addTab(self.tabDashboard, tr('Dashboard'))
       self.mainDisplayTabs.addTab(self.tabActivity,  tr('Transactions'))
-      self.mainDisplayTabs.addTab(self.tabAnnounce,  tr('Announcements'))
+      #self.mainDisplayTabs.addTab(self.tabAnnounce,  tr('Announcements'))
 
       ##########################################################################
       if not CLI_OPTIONS.disableModules:
@@ -749,36 +749,36 @@ class ArmoryMainWindow(QMainWindow):
       self.menusList[MENUS.Wallets].addSeparator()
       self.menusList[MENUS.Wallets].addAction(actRecoverWlt)
 
-      def execVersion():
-         self.explicitCheckAnnouncements()
-         self.mainDisplayTabs.setCurrentIndex(self.MAINTABS.Announce)
+      # def execVersion():
+      #    self.explicitCheckAnnouncements()
+      #    self.mainDisplayTabs.setCurrentIndex(self.MAINTABS.Announce)
 
       execAbout   = lambda: DlgHelpAbout(self).exec_()
-      execTrouble = lambda: webbrowser.open('https://bitcoinarmory.com/troubleshooting/')
-      execBugReport = lambda: DlgBugReport(self, self).exec_()
+      # execTrouble = lambda: webbrowser.open('https://bitcoinarmory.com/troubleshooting/')
+      # execBugReport = lambda: DlgBugReport(self, self).exec_()
 
 
       execVerifySigned = lambda: VerifyOfflinePackageDialog(self, self).exec_()
       actAboutWindow  = self.createAction(tr('&About Armory...'), execAbout)
-      actVersionCheck = self.createAction(tr('Armory Version'), execVersion)
-      actDownloadUpgrade = self.createAction(tr('Update Software...'), self.openDownloaderAll)
+      # actVersionCheck = self.createAction(tr('Armory Version'), execVersion)
+      # actDownloadUpgrade = self.createAction(tr('Update Software...'), self.openDownloaderAll)
       actVerifySigned = self.createAction(tr('Verify Signed Package...'), execVerifySigned)
-      actTroubleshoot = self.createAction(tr('Troubleshooting Armory'), execTrouble)
-      actSubmitBug    = self.createAction(tr('Submit Bug Report'), execBugReport)
+      # actTroubleshoot = self.createAction(tr('Troubleshooting Armory'), execTrouble)
+      # actSubmitBug    = self.createAction(tr('Submit Bug Report'), execBugReport)
       actClearMemPool = self.createAction(tr('Clear All Unconfirmed'), self.clearMemoryPool)
       actRescanDB     = self.createAction(tr('Rescan Databases'), self.rescanNextLoad)
       actRebuildDB    = self.createAction(tr('Rebuild and Rescan Databases'), self.rebuildNextLoad)
       actFactoryReset = self.createAction(tr('Factory Reset'), self.factoryReset)
-      actPrivacyPolicy = self.createAction(tr('Armory Privacy Policy'), self.showPrivacyGeneric)
+      # actPrivacyPolicy = self.createAction(tr('Armory Privacy Policy'), self.showPrivacyGeneric)
 
       self.menusList[MENUS.Help].addAction(actAboutWindow)
-      self.menusList[MENUS.Help].addAction(actVersionCheck)
-      self.menusList[MENUS.Help].addAction(actDownloadUpgrade)
+      # self.menusList[MENUS.Help].addAction(actVersionCheck)
+      # self.menusList[MENUS.Help].addAction(actDownloadUpgrade)
       self.menusList[MENUS.Help].addAction(actVerifySigned)
       self.menusList[MENUS.Help].addSeparator()
-      self.menusList[MENUS.Help].addAction(actTroubleshoot)
-      self.menusList[MENUS.Help].addAction(actSubmitBug)
-      self.menusList[MENUS.Help].addAction(actPrivacyPolicy)
+      # self.menusList[MENUS.Help].addAction(actTroubleshoot)
+      # self.menusList[MENUS.Help].addAction(actSubmitBug)
+      # self.menusList[MENUS.Help].addAction(actPrivacyPolicy)
       self.menusList[MENUS.Help].addSeparator()
       self.menusList[MENUS.Help].addAction(actClearMemPool)
       self.menusList[MENUS.Help].addAction(actRescanDB)
@@ -1853,86 +1853,86 @@ class ArmoryMainWindow(QMainWindow):
 
 
 
-   #############################################################################
-   def setupAnnouncementFetcher(self):
-      # Decide if disable OS/version reporting sent with announce fetches
-      skipStats1 = self.getSettingOrSetDefault('SkipStatsReport', False)
-      skipStats2 = CLI_OPTIONS.skipStatsReport
-      self.skipStatsReport = skipStats1 or skipStats2
-
-      # This determines if we should disable all of it
-      skipChk1 = self.getSettingOrSetDefault('SkipAnnounceCheck', False)
-      skipChk2 = CLI_OPTIONS.skipAnnounceCheck
-      skipChk3 = CLI_OPTIONS.offline and not CLI_OPTIONS.testAnnounceCode
-      skipChk4  = CLI_OPTIONS.useTorSettings 
-      skipChk5  = self.getSettingOrSetDefault('UseTorSettings', False)
-      self.skipAnnounceCheck = \
-                  skipChk1 or skipChk2 or skipChk3 or skipChk4 or skipChk5
-
-
-      url1 = ANNOUNCE_URL
-      url2 = ANNOUNCE_URL_BACKUP
-      fetchPath = os.path.join(ARMORY_HOME_DIR, 'atisignedannounce')
-      if self.announceFetcher is None:
-
-         # We keep an ID in the settings file that can be used by ATI's
-         # statistics aggregator to remove duplicate reports.  We store
-         # the month&year that the ID was generated, so that we can change
-         # it every month for privacy reasons
-         idData = self.getSettingOrSetDefault('MonthlyID', '0000_00000000')
-         storedYM,currID = idData.split('_')
-         monthyear = unixTimeToFormatStr(RightNow(), '%m%y')
-         if not storedYM == monthyear:
-            currID = SecureBinaryData().GenerateRandom(4).toHexStr()
-            self.settings.set('MonthlyID', '%s_%s' % (monthyear, currID))
-            
-         self.announceFetcher = AnnounceDataFetcher(url1, url2, fetchPath, currID)
-         self.announceFetcher.setStatsDisable(self.skipStatsReport)
-         self.announceFetcher.setFullyDisabled(self.skipAnnounceCheck)
-         self.announceFetcher.start()
-
-         # Set last-updated vals to zero to force processing at startup
-         for fid in ['changelog, downloads','notify','bootstrap']:
-            self.lastAnnounceUpdate[fid] = 0
-
-      # If we recently updated the settings to enable or disable checking...
-      if not self.announceFetcher.isRunning() and not self.skipAnnounceCheck:
-         self.announceFetcher.setFullyDisabled(False)
-         self.announceFetcher.setFetchInterval(DEFAULT_FETCH_INTERVAL)
-         self.announceFetcher.start()
-      elif self.announceFetcher.isRunning() and self.skipAnnounceCheck:
-         self.announceFetcher.setFullyDisabled(True)
-         self.announceFetcher.shutdown()
-
-
-
-   #############################################################################
-   def processAnnounceData(self, forceCheck=False, forceWait=5):
-
-      adf = self.announceFetcher
-
-
-
-      # The ADF always fetches everything all the time.  If forced, do the
-      # regular fetch first, then examine the individual files without forcing
-      if forceCheck:
-         adf.fetchRightNow(forceWait)
-
-      # Check each of the individual files for recent modifications
-      idFuncPairs = [
-                      ['announce',  self.updateAnnounceTab],
-                      ['changelog', self.processChangelog],
-                      ['downloads', self.processDownloads],
-                      ['notify',    self.processNotifications],
-                      ['bootstrap', self.processBootstrap] ]
-
-      # If modified recently
-      for fid,func in idFuncPairs:
-         if not fid in self.lastAnnounceUpdate or \
-            adf.getFileModTime(fid) > self.lastAnnounceUpdate[fid]:
-            self.lastAnnounceUpdate[fid] = RightNow()
-            fileText = adf.getAnnounceFile(fid)
-            func(fileText)
+   # #############################################################################
+   # def setupAnnouncementFetcher(self):
+   #    # Decide if disable OS/version reporting sent with announce fetches
+   #    skipStats1 = self.getSettingOrSetDefault('SkipStatsReport', False)
+   #    skipStats2 = CLI_OPTIONS.skipStatsReport
+   #    self.skipStatsReport = skipStats1 or skipStats2
+   #
+   #    # This determines if we should disable all of it
+   #    skipChk1 = self.getSettingOrSetDefault('SkipAnnounceCheck', False)
+   #    skipChk2 = CLI_OPTIONS.skipAnnounceCheck
+   #    skipChk3 = CLI_OPTIONS.offline and not CLI_OPTIONS.testAnnounceCode
+   #    skipChk4  = CLI_OPTIONS.useTorSettings
+   #    skipChk5  = self.getSettingOrSetDefault('UseTorSettings', False)
+   #    self.skipAnnounceCheck = \
+   #                skipChk1 or skipChk2 or skipChk3 or skipChk4 or skipChk5
+   #
+   #
+   #    url1 = ANNOUNCE_URL
+   #    url2 = ANNOUNCE_URL_BACKUP
+   #    fetchPath = os.path.join(ARMORY_HOME_DIR, 'atisignedannounce')
+   #    if self.announceFetcher is None:
+   #
+   #       # We keep an ID in the settings file that can be used by ATI's
+   #       # statistics aggregator to remove duplicate reports.  We store
+   #       # the month&year that the ID was generated, so that we can change
+   #       # it every month for privacy reasons
+   #       idData = self.getSettingOrSetDefault('MonthlyID', '0000_00000000')
+   #       storedYM,currID = idData.split('_')
+   #       monthyear = unixTimeToFormatStr(RightNow(), '%m%y')
+   #       if not storedYM == monthyear:
+   #          currID = SecureBinaryData().GenerateRandom(4).toHexStr()
+   #          self.settings.set('MonthlyID', '%s_%s' % (monthyear, currID))
+   #
+   #       self.announceFetcher = AnnounceDataFetcher(url1, url2, fetchPath, currID)
+   #       self.announceFetcher.setStatsDisable(self.skipStatsReport)
+   #       self.announceFetcher.setFullyDisabled(self.skipAnnounceCheck)
+   #       self.announceFetcher.start()
+   #
+   #       # Set last-updated vals to zero to force processing at startup
+   #       for fid in ['changelog, downloads','notify','bootstrap']:
+   #          self.lastAnnounceUpdate[fid] = 0
+   #
+   #    # If we recently updated the settings to enable or disable checking...
+   #    if not self.announceFetcher.isRunning() and not self.skipAnnounceCheck:
+   #       self.announceFetcher.setFullyDisabled(False)
+   #       self.announceFetcher.setFetchInterval(DEFAULT_FETCH_INTERVAL)
+   #       self.announceFetcher.start()
+   #    elif self.announceFetcher.isRunning() and self.skipAnnounceCheck:
+   #       self.announceFetcher.setFullyDisabled(True)
+   #       self.announceFetcher.shutdown()
+   #
+   #
+   #
+   # #############################################################################
+   # def processAnnounceData(self, forceCheck=False, forceWait=5):
+   #
+   #    adf = self.announceFetcher
+   #
+   #
+   #
+   #    # The ADF always fetches everything all the time.  If forced, do the
+   #    # regular fetch first, then examine the individual files without forcing
+   #    if forceCheck:
+   #       adf.fetchRightNow(forceWait)
+   #
+   #    # Check each of the individual files for recent modifications
+   #    idFuncPairs = [
+   #                    ['announce',  self.updateAnnounceTab],
+   #                    ['changelog', self.processChangelog],
+   #                    ['downloads', self.processDownloads],
+   #                    ['notify',    self.processNotifications],
+   #                    ['bootstrap', self.processBootstrap] ]
+   #
+   #    # If modified recently
+   #    for fid,func in idFuncPairs:
+   #       if not fid in self.lastAnnounceUpdate or \
+   #          adf.getFileModTime(fid) > self.lastAnnounceUpdate[fid]:
+   #          self.lastAnnounceUpdate[fid] = RightNow()
+   #          fileText = adf.getAnnounceFile(fid)
+   #          func(fileText)
 
 
 
@@ -1978,313 +1978,313 @@ class ArmoryMainWindow(QMainWindow):
          self.writeSetting('IgnoreAlerts', ",".join([str(i) for i in self.ignoreAlerts.keys()]))
 
 
-   #############################################################################
-   def processChangelog(self, txt):
-      try:
-         clp = changelogParser()
-         self.changelog = clp.parseChangelogText(txt)
-      except:
-         # Don't crash on an error, but do log what happened
-         LOGEXCEPT('Failed to parse changelog data')
-
-
-
-   #############################################################################
-   def processDownloads(self, txt):
-      try:
-         dlp = downloadLinkParser()
-         self.downloadLinks = dlp.parseDownloadList(txt)
-
-         if self.downloadLinks is None:
-            return
-
-         thisVer = getVersionInt(BTCARMORY_VERSION)
-
-         # Check ARMORY versions
-         if not 'Armory' in self.downloadLinks:
-            LOGWARN('No Armory links in the downloads list')
-         else:
-            maxVer = 0
-            self.versionNotification = {}
-            for verStr,vermap in self.downloadLinks['Armory'].iteritems():
-               dlVer = getVersionInt(readVersionString(verStr))
-               if dlVer > maxVer:
-                  maxVer = dlVer
-                  self.armoryVersions[1] = verStr
-                  if thisVer >= maxVer:
-                     continue
-
-                  shortDescr = tr('Armory version %s is now available!') % verStr
-                  notifyID = binary_to_hex(hash256(shortDescr)[:4])
-                  self.versionNotification['UNIQUEID'] = notifyID
-                  self.versionNotification['VERSION'] = '0'
-                  self.versionNotification['STARTTIME'] = '0'
-                  self.versionNotification['EXPIRES'] = '%d' % long(UINT64_MAX)
-                  self.versionNotification['CANCELID'] = '[]'
-                  self.versionNotification['MINVERSION'] = '*'
-                  self.versionNotification['MAXVERSION'] = '<%s' % verStr
-                  self.versionNotification['PRIORITY'] = '3072'
-                  self.versionNotification['ALERTTYPE'] = 'Upgrade'
-                  self.versionNotification['NOTIFYSEND'] = 'False'
-                  self.versionNotification['NOTIFYRECV'] = 'False'
-                  self.versionNotification['SHORTDESCR'] = shortDescr
-                  self.versionNotification['LONGDESCR'] = \
-                     self.getVersionNotifyLongDescr(verStr).replace('\n','<br>')
-                     
-            if 'ArmoryTesting' in self.downloadLinks:
-               for verStr,vermap in self.downloadLinks['ArmoryTesting'].iteritems():
-                  dlVer = getVersionInt(readVersionString(verStr))
-                  if dlVer > maxVer:
-                     maxVer = dlVer
-                     self.armoryVersions[1] = verStr
-                     if thisVer >= maxVer:
-                        continue
-
-                     shortDescr = tr('Armory Testing version %s is now available!') % verStr
-                     notifyID = binary_to_hex(hash256(shortDescr)[:4])
-                     self.versionNotification['UNIQUEID'] = notifyID
-                     self.versionNotification['VERSION'] = '0'
-                     self.versionNotification['STARTTIME'] = '0'
-                     self.versionNotification['EXPIRES'] = '%d' % long(UINT64_MAX)
-                     self.versionNotification['CANCELID'] = '[]'
-                     self.versionNotification['MINVERSION'] = '*'
-                     self.versionNotification['MAXVERSION'] = '<%s' % verStr
-                     self.versionNotification['PRIORITY'] = '1024'
-                     self.versionNotification['ALERTTYPE'] = 'upgrade-testing'
-                     self.versionNotification['NOTIFYSEND'] = 'False'
-                     self.versionNotification['NOTIFYRECV'] = 'False'
-                     self.versionNotification['SHORTDESCR'] = shortDescr
-                     self.versionNotification['LONGDESCR'] = \
-                        self.getVersionNotifyLongDescr(verStr, True).replace('\n','<br>')
-
-
-         # For Satoshi updates, we don't trigger any notifications like we
-         # do for Armory above -- we will release a proper announcement if
-         # necessary.  But we want to set a flag to
-         if not 'Satoshi' in self.downloadLinks:
-            LOGWARN('No Satoshi links in the downloads list')
-         else:
-            try:
-               maxVer = 0
-               for verStr,vermap in self.downloadLinks['Satoshi'].iteritems():
-                  dlVer = getVersionInt(readVersionString(verStr))
-                  if dlVer > maxVer:
-                     maxVer = dlVer
-                     self.satoshiVersions[1] = verStr
-
-               if not self.NetworkingFactory:
-                  return
-
-               # This is to detect the running versions of Bitcoin-Qt/bitcoind
-               if self.NetworkingFactory.getProto():
-                  thisVerStr = self.NetworkingFactory.getProto().peerInfo['subver']
-                  thisVerStr = thisVerStr.strip('/').split(':')[-1]
-
-                  if sum([0 if c in '0123456789.' else 1 for c in thisVerStr]) > 0:
-                     return
-   
-                  self.satoshiVersions[0] = thisVerStr
-               else:
-                  return
-
-            except:
-               pass
-
-
-
-
-      except:
-         # Don't crash on an error, but do log what happened
-         LOGEXCEPT('Failed to parse download link data')
-
-
-   #############################################################################
-   def getVersionNotifyLongDescr(self, verStr, testing=False):
-      shortOS = None
-      if OS_WINDOWS:
-         shortOS = 'windows'
-      elif OS_LINUX:
-         shortOS = 'ubuntu'
-      elif OS_MACOSX:
-         shortOS = 'mac'
-
-      webURL = 'https://bitcoinarmory.com/download/'
-      if shortOS is not None:
-         webURL += '#' + shortOS
-
-      if testing:
-         return tr("""
-            A new testing version of Armory is out. You can upgrade to version
-            %(ver)s through our secure downloader inside Armory (link at the bottom
-            of this notification window).
-            """) % { 'ver' : verStr}
-         
-      return tr("""
-         Your version of Armory is now outdated.  Please upgrade to version
-         %(ver)s through our secure downloader inside Armory (link at the bottom
-         of this notification window).  Alternatively, you can get the new
-         version from our website downloads page at:
-         <br><br>
-         <a href="%(url)s">%(url)s</a> """) % {'ver' : verStr, 'url' : webURL}
-
-
-
-   #############################################################################
-   def processBootstrap(self, binFile):
-      # Nothing to process, actually.  We'll grab the bootstrap from its
-      # current location, if needed
-      pass
-
-
-
-   #############################################################################
-   def notificationIsRelevant(self, notifyID, notifyMap):
-      currTime = RightNow()
-      thisVerInt = getVersionInt(BTCARMORY_VERSION)
-
-      # Ignore transactions below the requested priority
-      minPriority = self.getSettingOrSetDefault('NotifyMinPriority', 2048)
-      if int(notifyMap['PRIORITY']) < minPriority:
-         return False
-
-      # Ignore version upgrade notifications if disabled in the settings
-      if 'upgrade' in notifyMap['ALERTTYPE'].lower() and \
-         self.getSettingOrSetDefault('DisableUpgradeNotify', False):
-         return False
-
-      if notifyID in self.notifyIgnoreShort:
-         return False
-
-      if notifyMap['STARTTIME'].isdigit():
-         if currTime < long(notifyMap['STARTTIME']):
-            return False
-
-      if notifyMap['EXPIRES'].isdigit():
-         if currTime > long(notifyMap['EXPIRES']):
-            return False
-
-
-      try:
-         minVerStr  = notifyMap['MINVERSION']
-         minExclude = minVerStr.startswith('>')
-         minVerStr  = minVerStr[1:] if minExclude else minVerStr
-         minVerInt  = getVersionInt(readVersionString(minVerStr))
-         minVerInt += 1 if minExclude else 0
-         if thisVerInt < minVerInt:
-            return False
-      except:
-         pass
-
-
-      try:
-         maxVerStr  = notifyMap['MAXVERSION']
-         maxExclude = maxVerStr.startswith('<')
-         maxVerStr  = maxVerStr[1:] if maxExclude else maxVerStr
-         maxVerInt  = getVersionInt(readVersionString(maxVerStr))
-         maxVerInt -= 1 if maxExclude else 0
-         if thisVerInt > maxVerInt:
-            return False
-      except:
-         pass
-
-      return True
-
-
-   #############################################################################
-   def processNotifications(self, txt):
-
-      # Keep in mind this will always be run on startup with a blank slate, as
-      # well as every 30 min while Armory is running.  All notifications are
-      # "new" on startup (though we will allow the user to do-not-show-again
-      # and store the notification ID in the settings file).
-      try:
-         np = notificationParser()
-         currNotificationList = np.parseNotificationText(txt)
-      except:
-         # Don't crash on an error, but do log what happened
-         LOGEXCEPT('Failed to parse notifications')
-
-      if currNotificationList is None:
-         currNotificationList = {}
-
-      # If we have a new-version notification, it's not ignroed, and such
-      # notifications are not disabled, add it to the list
-      vnotify = self.versionNotification
-      if vnotify and 'UNIQUEID' in vnotify:
-         currNotificationList[vnotify['UNIQUEID']] = deepcopy(vnotify)
-
-      # Create a copy of almost all the notifications we have.
-      # All notifications >= 2048, unless they've explictly allowed testing
-      # notifications.   This will be shown on the "Announcements" tab.
-      self.almostFullNotificationList = {}
-      currMin = self.getSettingOrSetDefault('NotifyMinPriority', \
-                                                     DEFAULT_MIN_PRIORITY)
-      minmin = min(currMin, DEFAULT_MIN_PRIORITY)
-      for nid,valmap in currNotificationList.iteritems():
-         if int(valmap['PRIORITY']) >= minmin:
-            self.almostFullNotificationList[nid] = deepcopy(valmap)
-
-
-      tabPriority = 0
-      self.maxPriorityID = None
-
-      # Check for new notifications
-      addedNotifyIDs = set()
-      irrelevantIDs = set()
-      for nid,valmap in currNotificationList.iteritems():
-         if not self.notificationIsRelevant(nid, valmap):
-            # Can't remove while iterating over the map
-            irrelevantIDs.add(nid)
-            self.notifyIgnoreShort.add(nid)
-            continue
-
-         if valmap['PRIORITY'].isdigit():
-            if int(valmap['PRIORITY']) > tabPriority:
-               tabPriority = int(valmap['PRIORITY'])
-               self.maxPriorityID = nid
-
-         if not nid in self.almostFullNotificationList:
-            addedNotifyIDs.append(nid)
-
-      # Now remove them from the set that we are working with
-      for nid in irrelevantIDs:
-         del currNotificationList[nid]
-
-      # Check for notifications we had before but no long have
-      removedNotifyIDs = []
-      for nid,valmap in self.almostFullNotificationList.iteritems():
-         if not nid in currNotificationList:
-            removedNotifyIDs.append(nid)
-
-
-      #for nid in removedNotifyIDs:
-         #self.notifyIgnoreShort.discard(nid)
-         #self.notifyIgnoreLong.discard(nid)
-
-
-
-      # Change the "Announcements" tab color if something important is there
-      tabWidgetBar = self.mainDisplayTabs.tabBar()
-      tabColor = Colors.Foreground
-      if tabPriority >= 5120:
-         tabColor = Colors.TextRed
-      elif tabPriority >= 4096:
-         tabColor = Colors.TextRed
-      elif tabPriority >= 3072:
-         tabColor = Colors.TextBlue
-      elif tabPriority >= 2048:
-         tabColor = Colors.TextBlue
-
-      tabWidgetBar.setTabTextColor(self.MAINTABS.Announce, tabColor)
-      self.updateAnnounceTab()
-
-      # We only do popups for notifications >=4096, AND upgrade notify
-      if tabPriority >= 3072:
-         DlgNotificationWithDNAA(self, self, self.maxPriorityID, \
-                           currNotificationList[self.maxPriorityID]).show()
-      elif vnotify:
-         if not vnotify['UNIQUEID'] in self.notifyIgnoreShort:
-            DlgNotificationWithDNAA(self,self,vnotify['UNIQUEID'],vnotify).show()
+   # #############################################################################
+   # def processChangelog(self, txt):
+   #    try:
+   #       clp = changelogParser()
+   #       self.changelog = clp.parseChangelogText(txt)
+   #    except:
+   #       # Don't crash on an error, but do log what happened
+   #       LOGEXCEPT('Failed to parse changelog data')
+   #
+   #
+   #
+   # #############################################################################
+   # def processDownloads(self, txt):
+   #    try:
+   #       dlp = downloadLinkParser()
+   #       self.downloadLinks = dlp.parseDownloadList(txt)
+   #
+   #       if self.downloadLinks is None:
+   #          return
+   #
+   #       thisVer = getVersionInt(BTCARMORY_VERSION)
+   #
+   #       # Check ARMORY versions
+   #       if not 'Armory' in self.downloadLinks:
+   #          LOGWARN('No Armory links in the downloads list')
+   #       else:
+   #          maxVer = 0
+   #          self.versionNotification = {}
+   #          for verStr,vermap in self.downloadLinks['Armory'].iteritems():
+   #             dlVer = getVersionInt(readVersionString(verStr))
+   #             if dlVer > maxVer:
+   #                maxVer = dlVer
+   #                self.armoryVersions[1] = verStr
+   #                if thisVer >= maxVer:
+   #                   continue
+   #
+   #                shortDescr = tr('Armory version %s is now available!') % verStr
+   #                notifyID = binary_to_hex(hash256(shortDescr)[:4])
+   #                self.versionNotification['UNIQUEID'] = notifyID
+   #                self.versionNotification['VERSION'] = '0'
+   #                self.versionNotification['STARTTIME'] = '0'
+   #                self.versionNotification['EXPIRES'] = '%d' % long(UINT64_MAX)
+   #                self.versionNotification['CANCELID'] = '[]'
+   #                self.versionNotification['MINVERSION'] = '*'
+   #                self.versionNotification['MAXVERSION'] = '<%s' % verStr
+   #                self.versionNotification['PRIORITY'] = '3072'
+   #                self.versionNotification['ALERTTYPE'] = 'Upgrade'
+   #                self.versionNotification['NOTIFYSEND'] = 'False'
+   #                self.versionNotification['NOTIFYRECV'] = 'False'
+   #                self.versionNotification['SHORTDESCR'] = shortDescr
+   #                self.versionNotification['LONGDESCR'] = \
+   #                   self.getVersionNotifyLongDescr(verStr).replace('\n','<br>')
+   #
+   #          if 'ArmoryTesting' in self.downloadLinks:
+   #             for verStr,vermap in self.downloadLinks['ArmoryTesting'].iteritems():
+   #                dlVer = getVersionInt(readVersionString(verStr))
+   #                if dlVer > maxVer:
+   #                   maxVer = dlVer
+   #                   self.armoryVersions[1] = verStr
+   #                   if thisVer >= maxVer:
+   #                      continue
+   #
+   #                   shortDescr = tr('Armory Testing version %s is now available!') % verStr
+   #                   notifyID = binary_to_hex(hash256(shortDescr)[:4])
+   #                   self.versionNotification['UNIQUEID'] = notifyID
+   #                   self.versionNotification['VERSION'] = '0'
+   #                   self.versionNotification['STARTTIME'] = '0'
+   #                   self.versionNotification['EXPIRES'] = '%d' % long(UINT64_MAX)
+   #                   self.versionNotification['CANCELID'] = '[]'
+   #                   self.versionNotification['MINVERSION'] = '*'
+   #                   self.versionNotification['MAXVERSION'] = '<%s' % verStr
+   #                   self.versionNotification['PRIORITY'] = '1024'
+   #                   self.versionNotification['ALERTTYPE'] = 'upgrade-testing'
+   #                   self.versionNotification['NOTIFYSEND'] = 'False'
+   #                   self.versionNotification['NOTIFYRECV'] = 'False'
+   #                   self.versionNotification['SHORTDESCR'] = shortDescr
+   #                   self.versionNotification['LONGDESCR'] = \
+   #                      self.getVersionNotifyLongDescr(verStr, True).replace('\n','<br>')
+   #
+   #
+   #       # For Satoshi updates, we don't trigger any notifications like we
+   #       # do for Armory above -- we will release a proper announcement if
+   #       # necessary.  But we want to set a flag to
+   #       if not 'Satoshi' in self.downloadLinks:
+   #          LOGWARN('No Satoshi links in the downloads list')
+   #       else:
+   #          try:
+   #             maxVer = 0
+   #             for verStr,vermap in self.downloadLinks['Satoshi'].iteritems():
+   #                dlVer = getVersionInt(readVersionString(verStr))
+   #                if dlVer > maxVer:
+   #                   maxVer = dlVer
+   #                   self.satoshiVersions[1] = verStr
+   #
+   #             if not self.NetworkingFactory:
+   #                return
+   #
+   #             # This is to detect the running versions of Bitcoin-Qt/bitcoind
+   #             if self.NetworkingFactory.getProto():
+   #                thisVerStr = self.NetworkingFactory.getProto().peerInfo['subver']
+   #                thisVerStr = thisVerStr.strip('/').split(':')[-1]
+   #
+   #                if sum([0 if c in '0123456789.' else 1 for c in thisVerStr]) > 0:
+   #                   return
+   #
+   #                self.satoshiVersions[0] = thisVerStr
+   #             else:
+   #                return
+   #
+   #          except:
+   #             pass
+   #
+   #
+   #
+   #
+   #    except:
+   #       # Don't crash on an error, but do log what happened
+   #       LOGEXCEPT('Failed to parse download link data')
+   #
+   #
+   # #############################################################################
+   # def getVersionNotifyLongDescr(self, verStr, testing=False):
+   #    shortOS = None
+   #    if OS_WINDOWS:
+   #       shortOS = 'windows'
+   #    elif OS_LINUX:
+   #       shortOS = 'ubuntu'
+   #    elif OS_MACOSX:
+   #       shortOS = 'mac'
+   #
+   #    webURL = 'https://bitcoinarmory.com/download/'
+   #    if shortOS is not None:
+   #       webURL += '#' + shortOS
+   #
+   #    if testing:
+   #       return tr("""
+   #          A new testing version of Armory is out. You can upgrade to version
+   #          %(ver)s through our secure downloader inside Armory (link at the bottom
+   #          of this notification window).
+   #          """) % { 'ver' : verStr}
+   #
+   #    return tr("""
+   #       Your version of Armory is now outdated.  Please upgrade to version
+   #       %(ver)s through our secure downloader inside Armory (link at the bottom
+   #       of this notification window).  Alternatively, you can get the new
+   #       version from our website downloads page at:
+   #       <br><br>
+   #       <a href="%(url)s">%(url)s</a> """) % {'ver' : verStr, 'url' : webURL}
+   #
+   #
+   #
+   # #############################################################################
+   # def processBootstrap(self, binFile):
+   #    # Nothing to process, actually.  We'll grab the bootstrap from its
+   #    # current location, if needed
+   #    pass
+   #
+   #
+   #
+   # #############################################################################
+   # def notificationIsRelevant(self, notifyID, notifyMap):
+   #    currTime = RightNow()
+   #    thisVerInt = getVersionInt(BTCARMORY_VERSION)
+   #
+   #    # Ignore transactions below the requested priority
+   #    minPriority = self.getSettingOrSetDefault('NotifyMinPriority', 2048)
+   #    if int(notifyMap['PRIORITY']) < minPriority:
+   #       return False
+   #
+   #    # Ignore version upgrade notifications if disabled in the settings
+   #    if 'upgrade' in notifyMap['ALERTTYPE'].lower() and \
+   #       self.getSettingOrSetDefault('DisableUpgradeNotify', False):
+   #       return False
+   #
+   #    if notifyID in self.notifyIgnoreShort:
+   #       return False
+   #
+   #    if notifyMap['STARTTIME'].isdigit():
+   #       if currTime < long(notifyMap['STARTTIME']):
+   #          return False
+   #
+   #    if notifyMap['EXPIRES'].isdigit():
+   #       if currTime > long(notifyMap['EXPIRES']):
+   #          return False
+   #
+   #
+   #    try:
+   #       minVerStr  = notifyMap['MINVERSION']
+   #       minExclude = minVerStr.startswith('>')
+   #       minVerStr  = minVerStr[1:] if minExclude else minVerStr
+   #       minVerInt  = getVersionInt(readVersionString(minVerStr))
+   #       minVerInt += 1 if minExclude else 0
+   #       if thisVerInt < minVerInt:
+   #          return False
+   #    except:
+   #       pass
+   #
+   #
+   #    try:
+   #       maxVerStr  = notifyMap['MAXVERSION']
+   #       maxExclude = maxVerStr.startswith('<')
+   #       maxVerStr  = maxVerStr[1:] if maxExclude else maxVerStr
+   #       maxVerInt  = getVersionInt(readVersionString(maxVerStr))
+   #       maxVerInt -= 1 if maxExclude else 0
+   #       if thisVerInt > maxVerInt:
+   #          return False
+   #    except:
+   #       pass
+   #
+   #    return True
+   #
+   #
+   # #############################################################################
+   # def processNotifications(self, txt):
+   #
+   #    # Keep in mind this will always be run on startup with a blank slate, as
+   #    # well as every 30 min while Armory is running.  All notifications are
+   #    # "new" on startup (though we will allow the user to do-not-show-again
+   #    # and store the notification ID in the settings file).
+   #    try:
+   #       np = notificationParser()
+   #       currNotificationList = np.parseNotificationText(txt)
+   #    except:
+   #       # Don't crash on an error, but do log what happened
+   #       LOGEXCEPT('Failed to parse notifications')
+   #
+   #    if currNotificationList is None:
+   #       currNotificationList = {}
+   #
+   #    # If we have a new-version notification, it's not ignroed, and such
+   #    # notifications are not disabled, add it to the list
+   #    vnotify = self.versionNotification
+   #    if vnotify and 'UNIQUEID' in vnotify:
+   #       currNotificationList[vnotify['UNIQUEID']] = deepcopy(vnotify)
+   #
+   #    # Create a copy of almost all the notifications we have.
+   #    # All notifications >= 2048, unless they've explictly allowed testing
+   #    # notifications.   This will be shown on the "Announcements" tab.
+   #    self.almostFullNotificationList = {}
+   #    currMin = self.getSettingOrSetDefault('NotifyMinPriority', \
+   #                                                   DEFAULT_MIN_PRIORITY)
+   #    minmin = min(currMin, DEFAULT_MIN_PRIORITY)
+   #    for nid,valmap in currNotificationList.iteritems():
+   #       if int(valmap['PRIORITY']) >= minmin:
+   #          self.almostFullNotificationList[nid] = deepcopy(valmap)
+   #
+   #
+   #    tabPriority = 0
+   #    self.maxPriorityID = None
+   #
+   #    # Check for new notifications
+   #    addedNotifyIDs = set()
+   #    irrelevantIDs = set()
+   #    for nid,valmap in currNotificationList.iteritems():
+   #       if not self.notificationIsRelevant(nid, valmap):
+   #          # Can't remove while iterating over the map
+   #          irrelevantIDs.add(nid)
+   #          self.notifyIgnoreShort.add(nid)
+   #          continue
+   #
+   #       if valmap['PRIORITY'].isdigit():
+   #          if int(valmap['PRIORITY']) > tabPriority:
+   #             tabPriority = int(valmap['PRIORITY'])
+   #             self.maxPriorityID = nid
+   #
+   #       if not nid in self.almostFullNotificationList:
+   #          addedNotifyIDs.append(nid)
+   #
+   #    # Now remove them from the set that we are working with
+   #    for nid in irrelevantIDs:
+   #       del currNotificationList[nid]
+   #
+   #    # Check for notifications we had before but no long have
+   #    removedNotifyIDs = []
+   #    for nid,valmap in self.almostFullNotificationList.iteritems():
+   #       if not nid in currNotificationList:
+   #          removedNotifyIDs.append(nid)
+   #
+   #
+   #    #for nid in removedNotifyIDs:
+   #       #self.notifyIgnoreShort.discard(nid)
+   #       #self.notifyIgnoreLong.discard(nid)
+   #
+   #
+   #
+   #    # Change the "Announcements" tab color if something important is there
+   #    tabWidgetBar = self.mainDisplayTabs.tabBar()
+   #    tabColor = Colors.Foreground
+   #    if tabPriority >= 5120:
+   #       tabColor = Colors.TextRed
+   #    elif tabPriority >= 4096:
+   #       tabColor = Colors.TextRed
+   #    elif tabPriority >= 3072:
+   #       tabColor = Colors.TextBlue
+   #    elif tabPriority >= 2048:
+   #       tabColor = Colors.TextBlue
+   #
+   #    tabWidgetBar.setTabTextColor(self.MAINTABS.Announce, tabColor)
+   #    self.updateAnnounceTab()
+   #
+   #    # We only do popups for notifications >=4096, AND upgrade notify
+   #    if tabPriority >= 3072:
+   #       DlgNotificationWithDNAA(self, self, self.maxPriorityID, \
+   #                         currNotificationList[self.maxPriorityID]).show()
+   #    elif vnotify:
+   #       if not vnotify['UNIQUEID'] in self.notifyIgnoreShort:
+   #          DlgNotificationWithDNAA(self,self,vnotify['UNIQUEID'],vnotify).show()
 
 
 
@@ -4165,15 +4165,15 @@ class ArmoryMainWindow(QMainWindow):
    #############################################################################
    def exportLogFile(self):
       LOGDEBUG('exportLogFile')
-      reply = QMessageBox.warning(self, tr('Bug Reporting'), tr("""<qt>
-         As of version 0.91, Armory now includes a form for reporting
-         problems with the software.  Please use
-         <i>"Help"</i>→<i>"Submit Bug Report"</i>
-         to send a report directly to the Armory team, which will include
-         your log file automatically.</qt>"""), QMessageBox.Ok | QMessageBox.Cancel)
-
-      if not reply==QMessageBox.Ok:
-         return
+      # reply = QMessageBox.warning(self, tr('Bug Reporting'), tr("""<qt>
+      #    As of version 0.91, Armory now includes a form for reporting
+      #    problems with the software.  Please use
+      #    <i>"Help"</i>→<i>"Submit Bug Report"</i>
+      #    to send a report directly to the Armory team, which will include
+      #    your log file automatically.</qt>"""), QMessageBox.Ok | QMessageBox.Cancel)
+      #
+      # if not reply==QMessageBox.Ok:
+      #    return
 
       if self.logFilePrivacyWarning(wCancel=True):
          self.saveCombinedLogFile()
@@ -4190,12 +4190,6 @@ class ArmoryMainWindow(QMainWindow):
    #############################################################################
    def logFileTriplePrivacyWarning(self):
       return MsgBoxCustom(MSGBOX.Warning, tr('Privacy Warning'), tr("""
-         <b><u><font size=4>ATI Privacy Policy</font></u></b>
-         <br><br>
-         You should review the <a href="%s">Armory Technologies, Inc. privacy 
-         policy</a> before sending any data to ATI servers.
-         <br><br>
-
          <b><u><font size=3>Wallet Analysis Log Files</font></u></b>
          <br><br>
          The wallet analysis logs contain no personally-identifiable
@@ -4222,7 +4216,7 @@ class ArmoryMainWindow(QMainWindow):
          and transaction history of the wallet, but not spend any of the funds.
          <br><br>
          You may be requested to submit a watching-only copy of your wallet
-         to <i>Armory Technologies, Inc.</i> to make sure that there is no 
+         to make sure that there is no
          risk to the security of your funds.  You should not even consider 
          sending your
          watching-only wallet unless it was specifically requested by an
@@ -4232,11 +4226,6 @@ class ArmoryMainWindow(QMainWindow):
    #############################################################################
    def logFilePrivacyWarning(self, wCancel=False):
       return MsgBoxCustom(MSGBOX.Warning, tr('Privacy Warning'), tr("""
-         <b><u><font size=4>ATI Privacy Policy</font></u></b>
-         <br>
-         You should review the <a href="%s">Armory Technologies, Inc. privacy 
-         policy</a> before sending any data to ATI servers.
-         <br><br>
 
          Armory log files do not contain any <u>security</u>-sensitive
          information, but some users may consider the information to be
@@ -4601,359 +4590,358 @@ class ArmoryMainWindow(QMainWindow):
 
 
 
-   #############################################################################
-   def setupAnnounceTab(self):
-
-      self.lblAlertStr = QRichLabel(tr("""
-         <font size=4><b>Announcements and alerts from <i>Armory Technologies,
-         Inc.</i></b></font>"""), doWrap=False, hAlign=Qt.AlignHCenter)
-
-      def checkUpd():
-         lastUpdate = self.announceFetcher.getLastSuccessfulFetchTime()
-         self.explicitCheckAnnouncements(5)
-         lastUpdate2 = self.announceFetcher.getLastSuccessfulFetchTime()
-         if lastUpdate==lastUpdate2:
-            QMessageBox.warning(self, tr('Not Available'), tr("""
-               Could not access the <font color="%s"><b>Armory
-               Technologies, Inc.</b></font> announcement feeder.
-               Try again in a couple minutes.""") % \
-               htmlColor('TextGreen'), QMessageBox.Ok)
-         else:
-            QMessageBox.warning(self, tr('Update'), tr("""
-               Announcements are now up to date!"""), QMessageBox.Ok)
-
-
-      self.lblLastUpdated = QRichLabel('', doWrap=False)
-      self.btnCheckForUpdates  = QPushButton(tr('Check for Updates'))
-      self.connect(self.btnCheckForUpdates, SIGNAL(CLICKED), checkUpd)
-
-
-      frmLastUpdate = makeHorizFrame(['Stretch', \
-                                      self.lblLastUpdated, \
-                                      self.btnCheckForUpdates, \
-                                      'Stretch'])
-
-      self.icoArmorySWVersion = QLabel('')
-      self.lblArmorySWVersion = QRichLabel(tr("""
-         No version information is available"""), doWrap=False)
-      self.icoSatoshiSWVersion = QLabel('')
-      self.lblSatoshiSWVersion = QRichLabel('', doWrap=False)
-
-      self.btnSecureDLArmory  = QPushButton(tr('Secure Downloader'))
-      self.btnSecureDLSatoshi = QPushButton(tr('Secure Downloader'))
-      self.btnSecureDLArmory.setVisible(False)
-      self.btnSecureDLSatoshi.setVisible(False)
-      self.connect(self.btnSecureDLArmory, SIGNAL(CLICKED), self.openDLArmory)
-      self.connect(self.btnSecureDLSatoshi, SIGNAL(CLICKED), self.openDLSatoshi)
-
-
-      frmVersions = QFrame()
-      layoutVersions = QGridLayout()
-      layoutVersions.addWidget(self.icoArmorySWVersion, 0,0)
-      layoutVersions.addWidget(self.lblArmorySWVersion, 0,1)
-      layoutVersions.addWidget(self.btnSecureDLArmory,  0,2)
-      layoutVersions.addWidget(self.icoSatoshiSWVersion, 1,0)
-      layoutVersions.addWidget(self.lblSatoshiSWVersion, 1,1)
-      layoutVersions.addWidget(self.btnSecureDLSatoshi,  1,2)
-      layoutVersions.setColumnStretch(0,0)
-      layoutVersions.setColumnStretch(1,1)
-      layoutVersions.setColumnStretch(2,0)
-      frmVersions.setLayout(layoutVersions)
-      frmVersions.setFrameStyle(STYLE_RAISED)
-
-      lblVerHeader = QRichLabel(tr("""<font size=4><b>
-         Software Version Updates:</b></font>"""), doWrap=False, \
-         hAlign=Qt.AlignHCenter)
-      lblTableHeader = QRichLabel(tr("""<font size=4><b>
-         All Available Notifications:</b></font>"""), doWrap=False, \
-         hAlign=Qt.AlignHCenter)
-
-
-      # We need to generate popups when a widget is clicked, and be able
-      # change that particular widget's target, when the table is updated.
-      # Create one of these DlgGen objects for each of the 10 rows, simply
-      # update it's nid and notifyMap when the table is updated
-      class DlgGen():
-         def setParams(self, parent, nid, notifyMap):
-            self.parent = parent
-            self.nid = nid
-            self.notifyMap = notifyMap
-
-         def __call__(self):
-            return DlgNotificationWithDNAA(self.parent, self.parent, \
-                                          self.nid, self.notifyMap, False).exec_()
-
-      self.announceTableWidgets = \
-         [[QLabel(''), QRichLabel(''), QLabelButton('+'), DlgGen()] \
-                                                      for i in range(10)]
-
-
-
-      layoutTable = QGridLayout()
-      for i in range(10):
-         for j in range(3):
-            layoutTable.addWidget(self.announceTableWidgets[i][j], i,j)
-         self.connect(self.announceTableWidgets[i][2], SIGNAL(CLICKED), \
-                      self.announceTableWidgets[i][3])
-
-      layoutTable.setColumnStretch(0,0)
-      layoutTable.setColumnStretch(1,1)
-      layoutTable.setColumnStretch(2,0)
-
-      frmTable = QFrame()
-      frmTable.setLayout(layoutTable)
-      frmTable.setFrameStyle(STYLE_SUNKEN)
-
-      self.updateAnnounceTable()
-
-
-      frmEverything = makeVertFrame( [ self.lblAlertStr,
-                                       frmLastUpdate,
-                                       'Space(30)',
-                                       lblTableHeader,
-                                       frmTable,
-                                       'Space(30)',
-                                       lblVerHeader,
-                                       frmVersions,
-                                       'Stretch'])
-
-      frmEverything.setMinimumWidth(300)
-      frmEverything.setMaximumWidth(800)
-
-      frmFinal = makeHorizFrame(['Stretch', frmEverything, 'Stretch'])
-
-      self.announceScrollArea = QScrollArea()
-      self.announceScrollArea.setWidgetResizable(True)
-      self.announceScrollArea.setWidget(frmFinal)
-      scrollLayout = QVBoxLayout()
-      scrollLayout.addWidget(self.announceScrollArea)
-      self.tabAnnounce.setLayout(scrollLayout)
-
-      self.announceIsSetup = True
-
-
-   #############################################################################
-   def openDownloaderAll(self):
-      dl,cl = self.getDownloaderData()
-      if not dl is None and not cl is None:
-         UpgradeDownloaderDialog(self, self, None, dl, cl).exec_()
-
-   #############################################################################
-   def openDLArmory(self):
-      dl,cl = self.getDownloaderData()
-      if not dl is None and not cl is None:
-         UpgradeDownloaderDialog(self, self, 'Armory', dl, cl).exec_()
-
+   # #############################################################################
+   # def setupAnnounceTab(self):
+   #
+   #    self.lblAlertStr = QRichLabel(tr("""
+   #       <font size=4><b>Announcements and alerts from <i>Armory Technologies,
+   #       Inc.</i></b></font>"""), doWrap=False, hAlign=Qt.AlignHCenter)
+   #
+   #    def checkUpd():
+   #       lastUpdate = self.announceFetcher.getLastSuccessfulFetchTime()
+   #       self.explicitCheckAnnouncements(5)
+   #       lastUpdate2 = self.announceFetcher.getLastSuccessfulFetchTime()
+   #       if lastUpdate==lastUpdate2:
+   #          QMessageBox.warning(self, tr('Not Available'), tr("""
+   #             Could not access the <font color="%s"><b>Armory
+   #             Technologies, Inc.</b></font> announcement feeder.
+   #             Try again in a couple minutes.""") % \
+   #             htmlColor('TextGreen'), QMessageBox.Ok)
+   #       else:
+   #          QMessageBox.warning(self, tr('Update'), tr("""
+   #             Announcements are now up to date!"""), QMessageBox.Ok)
+   #
+   #
+   #    self.lblLastUpdated = QRichLabel('', doWrap=False)
+   #    self.btnCheckForUpdates  = QPushButton(tr('Check for Updates'))
+   #    self.connect(self.btnCheckForUpdates, SIGNAL(CLICKED), checkUpd)
+   #
+   #
+   #    frmLastUpdate = makeHorizFrame(['Stretch', \
+   #                                    self.lblLastUpdated, \
+   #                                    self.btnCheckForUpdates, \
+   #                                    'Stretch'])
+   #
+   #    self.icoArmorySWVersion = QLabel('')
+   #    self.lblArmorySWVersion = QRichLabel(tr("""
+   #       No version information is available"""), doWrap=False)
+   #    self.icoSatoshiSWVersion = QLabel('')
+   #    self.lblSatoshiSWVersion = QRichLabel('', doWrap=False)
+   #
+   #    self.btnSecureDLArmory  = QPushButton(tr('Secure Downloader'))
+   #    self.btnSecureDLSatoshi = QPushButton(tr('Secure Downloader'))
+   #    self.btnSecureDLArmory.setVisible(False)
+   #    self.btnSecureDLSatoshi.setVisible(False)
+   #    self.connect(self.btnSecureDLArmory, SIGNAL(CLICKED), self.openDLArmory)
+   #    self.connect(self.btnSecureDLSatoshi, SIGNAL(CLICKED), self.openDLSatoshi)
+   #
+   #
+   #    frmVersions = QFrame()
+   #    layoutVersions = QGridLayout()
+   #    layoutVersions.addWidget(self.icoArmorySWVersion, 0,0)
+   #    layoutVersions.addWidget(self.lblArmorySWVersion, 0,1)
+   #    layoutVersions.addWidget(self.btnSecureDLArmory,  0,2)
+   #    layoutVersions.addWidget(self.icoSatoshiSWVersion, 1,0)
+   #    layoutVersions.addWidget(self.lblSatoshiSWVersion, 1,1)
+   #    layoutVersions.addWidget(self.btnSecureDLSatoshi,  1,2)
+   #    layoutVersions.setColumnStretch(0,0)
+   #    layoutVersions.setColumnStretch(1,1)
+   #    layoutVersions.setColumnStretch(2,0)
+   #    frmVersions.setLayout(layoutVersions)
+   #    frmVersions.setFrameStyle(STYLE_RAISED)
+   #
+   #    lblVerHeader = QRichLabel(tr("""<font size=4><b>
+   #       Software Version Updates:</b></font>"""), doWrap=False, \
+   #       hAlign=Qt.AlignHCenter)
+   #    lblTableHeader = QRichLabel(tr("""<font size=4><b>
+   #       All Available Notifications:</b></font>"""), doWrap=False, \
+   #       hAlign=Qt.AlignHCenter)
+   #
+   #
+   #    # We need to generate popups when a widget is clicked, and be able
+   #    # change that particular widget's target, when the table is updated.
+   #    # Create one of these DlgGen objects for each of the 10 rows, simply
+   #    # update it's nid and notifyMap when the table is updated
+   #    class DlgGen():
+   #       def setParams(self, parent, nid, notifyMap):
+   #          self.parent = parent
+   #          self.nid = nid
+   #          self.notifyMap = notifyMap
+   #
+   #       def __call__(self):
+   #          return DlgNotificationWithDNAA(self.parent, self.parent, \
+   #                                        self.nid, self.notifyMap, False).exec_()
+   #
+   #    self.announceTableWidgets = \
+   #       [[QLabel(''), QRichLabel(''), QLabelButton('+'), DlgGen()] \
+   #                                                    for i in range(10)]
+   #
+   #
+   #
+   #    layoutTable = QGridLayout()
+   #    for i in range(10):
+   #       for j in range(3):
+   #          layoutTable.addWidget(self.announceTableWidgets[i][j], i,j)
+   #       self.connect(self.announceTableWidgets[i][2], SIGNAL(CLICKED), \
+   #                    self.announceTableWidgets[i][3])
+   #
+   #    layoutTable.setColumnStretch(0,0)
+   #    layoutTable.setColumnStretch(1,1)
+   #    layoutTable.setColumnStretch(2,0)
+   #
+   #    frmTable = QFrame()
+   #    frmTable.setLayout(layoutTable)
+   #    frmTable.setFrameStyle(STYLE_SUNKEN)
+   #
+   #    self.updateAnnounceTable()
+   #
+   #
+   #    frmEverything = makeVertFrame( [ self.lblAlertStr,
+   #                                     frmLastUpdate,
+   #                                     'Space(30)',
+   #                                     lblTableHeader,
+   #                                     frmTable,
+   #                                     'Space(30)',
+   #                                     lblVerHeader,
+   #                                     frmVersions,
+   #                                     'Stretch'])
+   #
+   #    frmEverything.setMinimumWidth(300)
+   #    frmEverything.setMaximumWidth(800)
+   #
+   #    frmFinal = makeHorizFrame(['Stretch', frmEverything, 'Stretch'])
+   #
+   #    self.announceScrollArea = QScrollArea()
+   #    self.announceScrollArea.setWidgetResizable(True)
+   #    self.announceScrollArea.setWidget(frmFinal)
+   #    scrollLayout = QVBoxLayout()
+   #    scrollLayout.addWidget(self.announceScrollArea)
+   #    self.tabAnnounce.setLayout(scrollLayout)
+   #
+   #    self.announceIsSetup = True
+   #
+   #
+   # #############################################################################
+   # def openDownloaderAll(self):
+   #    dl,cl = self.getDownloaderData()
+   #    if not dl is None and not cl is None:
+   #       UpgradeDownloaderDialog(self, self, None, dl, cl).exec_()
+   #
+   # #############################################################################
+   # def openDLArmory(self):
+   #    dl,cl = self.getDownloaderData()
+   #    if not dl is None and not cl is None:
+   #       UpgradeDownloaderDialog(self, self, 'Armory', dl, cl).exec_()
+   #
    #############################################################################
    def openDLSatoshi(self):
       dl,cl = self.getDownloaderData()
       if not dl is None and not cl is None:
          UpgradeDownloaderDialog(self, self, 'Satoshi', dl, cl).exec_()
 
-
-   #############################################################################
-   def getDownloaderData(self):
-      dl = self.announceFetcher.getAnnounceFile('downloads')
-      cl = self.announceFetcher.getAnnounceFile('changelog')
-
-      dlObj = downloadLinkParser().parseDownloadList(dl)
-      clObj = changelogParser().parseChangelogText(cl)
-
-      if dlObj is None or clObj is None:
-         QMessageBox.warning(self, tr('No Data'), tr("""
-            The secure downloader has not received any download
-            data to display.  Either the <font color="%s"><b>Armory
-            Technologies, Inc.</b></font> announcement feeder is
-            down, or this computer cannot access the server.""") % \
-            htmlColor('TextGreen'), QMessageBox.Ok)
-         return None,None
-
-      lastUpdate = self.announceFetcher.getLastSuccessfulFetchTime()
-      sinceLastUpd = RightNow() - lastUpdate
-      if lastUpdate < RightNow()-1*WEEK:
-         QMessageBox.warning(self, tr('Old Data'), tr("""
-            The last update retrieved from the <font color="%(color)s"><b>Armory
-            Technologies, Inc.</b></font> announcement feeder was <b>%(time)s</b>
-            ago.  The following downloads may not be the latest
-            available.""") % { 'color' : htmlColor("TextGreen"), \
-            'time' : secondsToHumanTime(sinceLastUpd)}, QMessageBox.Ok)
-
-      dl = self.announceFetcher.getAnnounceFile('downloads')
-      cl = self.announceFetcher.getAnnounceFile('changelog')
-
-      return dl,cl
-
-
-
-   #############################################################################
-   def updateAnnounceTab(self, *args):
-
-      if not self.announceIsSetup:
-         return
-
-      iconArmory   = ':/armory_icon_32x32.png'
-      iconSatoshi  = ':/bitcoinlogo.png'
-      iconInfoFile = ':/MsgBox_info48.png'
-      iconGoodFile = ':/MsgBox_good48.png'
-      iconWarnFile = ':/MsgBox_warning48.png'
-      iconCritFile = ':/MsgBox_critical24.png'
-
-      lastUpdate = self.announceFetcher.getLastSuccessfulFetchTime()
-      noAnnounce = (lastUpdate == 0)
-
-      if noAnnounce:
-         self.lblLastUpdated.setText(tr("No announcement data was found!"))
-         self.btnSecureDLArmory.setVisible(False)
-         self.icoArmorySWVersion.setVisible(True)
-         self.lblArmorySWVersion.setText(tr(""" You are running Armory
-            version %s""") % getVersionString(BTCARMORY_VERSION))
-      else:
-         updTimeStr = unixTimeToFormatStr(lastUpdate)
-         self.lblLastUpdated.setText(tr("<u>Last Updated</u>: %s") % updTimeStr)
-
-
-      verStrToInt = lambda s: getVersionInt(readVersionString(s))
-
-      # Notify of Armory updates
-      self.icoArmorySWVersion.setPixmap(QPixmap(iconArmory).scaled(24,24))
-      self.icoSatoshiSWVersion.setPixmap(QPixmap(iconSatoshi).scaled(24,24))
-
-      try:
-         armCurrent = verStrToInt(self.armoryVersions[0])
-         armLatest  = verStrToInt(self.armoryVersions[1])
-         if armCurrent >= armLatest:
-            dispIcon = QPixmap(iconArmory).scaled(24,24)
-            self.icoArmorySWVersion.setPixmap(dispIcon)
-            self.btnSecureDLArmory.setVisible(False)
-            self.lblArmorySWVersion.setText(tr(
-               "You are using the latest version of Armory (%s)"
-               % self.armoryVersions[0]))
-         else:
-            dispIcon = QPixmap(iconWarnFile).scaled(24,24)
-            self.icoArmorySWVersion.setPixmap(dispIcon)
-            self.btnSecureDLArmory.setVisible(True)
-            self.lblArmorySWVersion.setText(tr("""
-               <b>There is a newer version of Armory available!</b>"""))
-         self.btnSecureDLArmory.setVisible(True)
-         self.icoArmorySWVersion.setVisible(True)
-      except:
-         self.btnSecureDLArmory.setVisible(False)
-         self.lblArmorySWVersion.setText(tr(""" You are running Armory
-            version %s""") % getVersionString(BTCARMORY_VERSION))
-
-
-      try:
-         satCurrStr,satLastStr = self.satoshiVersions
-         satCurrent = verStrToInt(satCurrStr) if satCurrStr else 0
-         satLatest  = verStrToInt(satLastStr) if satLastStr else 0
-
-      # Show CoreBTC updates
-         if satCurrent and satLatest:
-            if satCurrent >= satLatest:
-               dispIcon = QPixmap(iconGoodFile).scaled(24,24)
-               self.btnSecureDLSatoshi.setVisible(False)
-               self.icoSatoshiSWVersion.setPixmap(dispIcon)
-               self.lblSatoshiSWVersion.setText(tr(""" You are using
-                  the latest version of core Bitcoin (%s)""") % satCurrStr)
-            else:
-               dispIcon = QPixmap(iconWarnFile).scaled(24,24)
-               self.btnSecureDLSatoshi.setVisible(True)
-               self.icoSatoshiSWVersion.setPixmap(dispIcon)
-               self.lblSatoshiSWVersion.setText(tr("""
-                  <b>There is a newer version of the core Bitcoin software
-                  available!</b>"""))
-         elif satCurrent:
-            # satLatest is not available
-            dispIcon = QPixmap(iconGoodFile).scaled(24,24)
-            self.btnSecureDLSatoshi.setVisible(False)
-            self.icoSatoshiSWVersion.setPixmap(None)
-            self.lblSatoshiSWVersion.setText(tr(""" You are using
-               core Bitcoin version %s""") % satCurrStr)
-         elif satLatest:
-            # only satLatest is avail (maybe offline)
-            dispIcon = QPixmap(iconSatoshi).scaled(24,24)
-            self.btnSecureDLSatoshi.setVisible(True)
-            self.icoSatoshiSWVersion.setPixmap(dispIcon)
-            self.lblSatoshiSWVersion.setText(tr("""Core Bitcoin version
-               %s is available.""") % satLastStr)
-         else:
-            # only satLatest is avail (maybe offline)
-            dispIcon = QPixmap(iconSatoshi).scaled(24,24)
-            self.btnSecureDLSatoshi.setVisible(False)
-            self.icoSatoshiSWVersion.setPixmap(dispIcon)
-            self.lblSatoshiSWVersion.setText(tr("""No version information
-               is available for core Bitcoin""") )
-
-
-
-
-         #self.btnSecureDLSatoshi.setVisible(False)
-         #if self.satoshiVersions[0]:
-            #self.lblSatoshiSWVersion.setText(tr(""" You are running
-               #core Bitcoin software version %s""") % self.satoshiVersions[0])
-         #else:
-            #self.lblSatoshiSWVersion.setText(tr("""No information is
-            #available for the core Bitcoin software"""))
-      except:
-         LOGEXCEPT('Failed to process satoshi versions')
-
-
-      self.updateAnnounceTable()
-
-
-   #############################################################################
-   def updateAnnounceTable(self):
-
-      # Default: Make everything non-visible except first row, middle column
-      for i in range(10):
-         for j in range(3):
-            self.announceTableWidgets[i][j].setVisible(i==0 and j==1)
-
-      if len(self.almostFullNotificationList)==0:
-         self.announceTableWidgets[0][1].setText(tr("""
-            There are no announcements or alerts to display"""))
-         return
-
-
-      alertsForSorting = []
-      for nid,nmap in self.almostFullNotificationList.iteritems():
-         alertsForSorting.append([nid, int(nmap['PRIORITY'])])
-
-      sortedAlerts = sorted(alertsForSorting, key=lambda a: -a[1])[:10]
-
-      i = 0
-      for nid,priority in sortedAlerts:
-         if priority>=4096:
-            pixm = QPixmap(':/MsgBox_critical64.png')
-         elif priority>=3072:
-            pixm = QPixmap(':/MsgBox_warning48.png')
-         elif priority>=2048:
-            pixm = QPixmap(':/MsgBox_info48.png')
-         else:
-            pixm = QPixmap(':/MsgBox_info48.png')
-
-
-         shortDescr = self.almostFullNotificationList[nid]['SHORTDESCR']
-         if priority>=4096:
-            shortDescr = '<font color="%s">' + shortDescr + '</font>'
-            shortDescr = shortDescr % htmlColor('TextWarn')
-
-         self.announceTableWidgets[i][0].setPixmap(pixm.scaled(24,24))
-         self.announceTableWidgets[i][1].setText(shortDescr)
-         self.announceTableWidgets[i][2].setVisible(True)
-         self.announceTableWidgets[i][3].setParams(self, nid, \
-                                 self.almostFullNotificationList[nid])
-
-         for j in range(3):
-            self.announceTableWidgets[i][j].setVisible(True)
-
-         i += 1
-
-   #############################################################################
-   def explicitCheckAnnouncements(self, waitTime=3):
-      self.announceFetcher.fetchRightNow(waitTime)
-      self.processAnnounceData()
-      self.updateAnnounceTab()
+   # #############################################################################
+   # def getDownloaderData(self):
+   #    dl = self.announceFetcher.getAnnounceFile('downloads')
+   #    cl = self.announceFetcher.getAnnounceFile('changelog')
+   #
+   #    dlObj = downloadLinkParser().parseDownloadList(dl)
+   #    clObj = changelogParser().parseChangelogText(cl)
+   #
+   #    if dlObj is None or clObj is None:
+   #       QMessageBox.warning(self, tr('No Data'), tr("""
+   #          The secure downloader has not received any download
+   #          data to display.  Either the <font color="%s"><b>Armory
+   #          Technologies, Inc.</b></font> announcement feeder is
+   #          down, or this computer cannot access the server.""") % \
+   #          htmlColor('TextGreen'), QMessageBox.Ok)
+   #       return None,None
+   #
+   #    lastUpdate = self.announceFetcher.getLastSuccessfulFetchTime()
+   #    sinceLastUpd = RightNow() - lastUpdate
+   #    if lastUpdate < RightNow()-1*WEEK:
+   #       QMessageBox.warning(self, tr('Old Data'), tr("""
+   #          The last update retrieved from the <font color="%(color)s"><b>Armory
+   #          Technologies, Inc.</b></font> announcement feeder was <b>%(time)s</b>
+   #          ago.  The following downloads may not be the latest
+   #          available.""") % { 'color' : htmlColor("TextGreen"), \
+   #          'time' : secondsToHumanTime(sinceLastUpd)}, QMessageBox.Ok)
+   #
+   #    dl = self.announceFetcher.getAnnounceFile('downloads')
+   #    cl = self.announceFetcher.getAnnounceFile('changelog')
+   #
+   #    return dl,cl
+   #
+   #
+   #
+   # #############################################################################
+   # def updateAnnounceTab(self, *args):
+   #
+   #    if not self.announceIsSetup:
+   #       return
+   #
+   #    iconArmory   = ':/armory_icon_32x32.png'
+   #    iconSatoshi  = ':/bitcoinlogo.png'
+   #    iconInfoFile = ':/MsgBox_info48.png'
+   #    iconGoodFile = ':/MsgBox_good48.png'
+   #    iconWarnFile = ':/MsgBox_warning48.png'
+   #    iconCritFile = ':/MsgBox_critical24.png'
+   #
+   #    lastUpdate = self.announceFetcher.getLastSuccessfulFetchTime()
+   #    noAnnounce = (lastUpdate == 0)
+   #
+   #    if noAnnounce:
+   #       self.lblLastUpdated.setText(tr("No announcement data was found!"))
+   #       self.btnSecureDLArmory.setVisible(False)
+   #       self.icoArmorySWVersion.setVisible(True)
+   #       self.lblArmorySWVersion.setText(tr(""" You are running Armory
+   #          version %s""") % getVersionString(BTCARMORY_VERSION))
+   #    else:
+   #       updTimeStr = unixTimeToFormatStr(lastUpdate)
+   #       self.lblLastUpdated.setText(tr("<u>Last Updated</u>: %s") % updTimeStr)
+   #
+   #
+   #    verStrToInt = lambda s: getVersionInt(readVersionString(s))
+   #
+   #    # Notify of Armory updates
+   #    self.icoArmorySWVersion.setPixmap(QPixmap(iconArmory).scaled(24,24))
+   #    self.icoSatoshiSWVersion.setPixmap(QPixmap(iconSatoshi).scaled(24,24))
+   #
+   #    try:
+   #       armCurrent = verStrToInt(self.armoryVersions[0])
+   #       armLatest  = verStrToInt(self.armoryVersions[1])
+   #       if armCurrent >= armLatest:
+   #          dispIcon = QPixmap(iconArmory).scaled(24,24)
+   #          self.icoArmorySWVersion.setPixmap(dispIcon)
+   #          self.btnSecureDLArmory.setVisible(False)
+   #          self.lblArmorySWVersion.setText(tr(
+   #             "You are using the latest version of Armory (%s)"
+   #             % self.armoryVersions[0]))
+   #       else:
+   #          dispIcon = QPixmap(iconWarnFile).scaled(24,24)
+   #          self.icoArmorySWVersion.setPixmap(dispIcon)
+   #          self.btnSecureDLArmory.setVisible(True)
+   #          self.lblArmorySWVersion.setText(tr("""
+   #             <b>There is a newer version of Armory available!</b>"""))
+   #       self.btnSecureDLArmory.setVisible(True)
+   #       self.icoArmorySWVersion.setVisible(True)
+   #    except:
+   #       self.btnSecureDLArmory.setVisible(False)
+   #       self.lblArmorySWVersion.setText(tr(""" You are running Armory
+   #          version %s""") % getVersionString(BTCARMORY_VERSION))
+   #
+   #
+   #    try:
+   #       satCurrStr,satLastStr = self.satoshiVersions
+   #       satCurrent = verStrToInt(satCurrStr) if satCurrStr else 0
+   #       satLatest  = verStrToInt(satLastStr) if satLastStr else 0
+   #
+   #    # Show CoreBTC updates
+   #       if satCurrent and satLatest:
+   #          if satCurrent >= satLatest:
+   #             dispIcon = QPixmap(iconGoodFile).scaled(24,24)
+   #             self.btnSecureDLSatoshi.setVisible(False)
+   #             self.icoSatoshiSWVersion.setPixmap(dispIcon)
+   #             self.lblSatoshiSWVersion.setText(tr(""" You are using
+   #                the latest version of core Bitcoin (%s)""") % satCurrStr)
+   #          else:
+   #             dispIcon = QPixmap(iconWarnFile).scaled(24,24)
+   #             self.btnSecureDLSatoshi.setVisible(True)
+   #             self.icoSatoshiSWVersion.setPixmap(dispIcon)
+   #             self.lblSatoshiSWVersion.setText(tr("""
+   #                <b>There is a newer version of the core Bitcoin software
+   #                available!</b>"""))
+   #       elif satCurrent:
+   #          # satLatest is not available
+   #          dispIcon = QPixmap(iconGoodFile).scaled(24,24)
+   #          self.btnSecureDLSatoshi.setVisible(False)
+   #          self.icoSatoshiSWVersion.setPixmap(None)
+   #          self.lblSatoshiSWVersion.setText(tr(""" You are using
+   #             core Bitcoin version %s""") % satCurrStr)
+   #       elif satLatest:
+   #          # only satLatest is avail (maybe offline)
+   #          dispIcon = QPixmap(iconSatoshi).scaled(24,24)
+   #          self.btnSecureDLSatoshi.setVisible(True)
+   #          self.icoSatoshiSWVersion.setPixmap(dispIcon)
+   #          self.lblSatoshiSWVersion.setText(tr("""Core Bitcoin version
+   #             %s is available.""") % satLastStr)
+   #       else:
+   #          # only satLatest is avail (maybe offline)
+   #          dispIcon = QPixmap(iconSatoshi).scaled(24,24)
+   #          self.btnSecureDLSatoshi.setVisible(False)
+   #          self.icoSatoshiSWVersion.setPixmap(dispIcon)
+   #          self.lblSatoshiSWVersion.setText(tr("""No version information
+   #             is available for core Bitcoin""") )
+   #
+   #
+   #
+   #
+   #       #self.btnSecureDLSatoshi.setVisible(False)
+   #       #if self.satoshiVersions[0]:
+   #          #self.lblSatoshiSWVersion.setText(tr(""" You are running
+   #             #core Bitcoin software version %s""") % self.satoshiVersions[0])
+   #       #else:
+   #          #self.lblSatoshiSWVersion.setText(tr("""No information is
+   #          #available for the core Bitcoin software"""))
+   #    except:
+   #       LOGEXCEPT('Failed to process satoshi versions')
+   #
+   #
+   #    self.updateAnnounceTable()
+   #
+   #
+   # #############################################################################
+   # def updateAnnounceTable(self):
+   #
+   #    # Default: Make everything non-visible except first row, middle column
+   #    for i in range(10):
+   #       for j in range(3):
+   #          self.announceTableWidgets[i][j].setVisible(i==0 and j==1)
+   #
+   #    if len(self.almostFullNotificationList)==0:
+   #       self.announceTableWidgets[0][1].setText(tr("""
+   #          There are no announcements or alerts to display"""))
+   #       return
+   #
+   #
+   #    alertsForSorting = []
+   #    for nid,nmap in self.almostFullNotificationList.iteritems():
+   #       alertsForSorting.append([nid, int(nmap['PRIORITY'])])
+   #
+   #    sortedAlerts = sorted(alertsForSorting, key=lambda a: -a[1])[:10]
+   #
+   #    i = 0
+   #    for nid,priority in sortedAlerts:
+   #       if priority>=4096:
+   #          pixm = QPixmap(':/MsgBox_critical64.png')
+   #       elif priority>=3072:
+   #          pixm = QPixmap(':/MsgBox_warning48.png')
+   #       elif priority>=2048:
+   #          pixm = QPixmap(':/MsgBox_info48.png')
+   #       else:
+   #          pixm = QPixmap(':/MsgBox_info48.png')
+   #
+   #
+   #       shortDescr = self.almostFullNotificationList[nid]['SHORTDESCR']
+   #       if priority>=4096:
+   #          shortDescr = '<font color="%s">' + shortDescr + '</font>'
+   #          shortDescr = shortDescr % htmlColor('TextWarn')
+   #
+   #       self.announceTableWidgets[i][0].setPixmap(pixm.scaled(24,24))
+   #       self.announceTableWidgets[i][1].setText(shortDescr)
+   #       self.announceTableWidgets[i][2].setVisible(True)
+   #       self.announceTableWidgets[i][3].setParams(self, nid, \
+   #                               self.almostFullNotificationList[nid])
+   #
+   #       for j in range(3):
+   #          self.announceTableWidgets[i][j].setVisible(True)
+   #
+   #       i += 1
+   #
+   # #############################################################################
+   # def explicitCheckAnnouncements(self, waitTime=3):
+   #    self.announceFetcher.fetchRightNow(waitTime)
+   #    self.processAnnounceData()
+   #    self.updateAnnounceTab()
 
    #############################################################################
    def closeExistingBitcoin(self):
@@ -6410,7 +6398,7 @@ class ArmoryMainWindow(QMainWindow):
 
       self.heartbeatCount += 1
       if self.heartbeatCount % 60 == 20:
-         self.processAnnounceData()
+      #   self.processAnnounceData()
          self.processAlerts()
 
       try:

--- a/ArmoryQt.py
+++ b/ArmoryQt.py
@@ -3751,7 +3751,7 @@ class ArmoryMainWindow(QMainWindow):
                LOGPPRINT(pytx, logging.ERROR)
                searchstr  = binary_to_hex(newTxHash, BIGENDIAN)
 
-               supportURL       = 'https://bitcoinarmory.com/support' 
+               supportURL       = 'https://github.com/goatpig/BitcoinArmory/issues'
                blkexplURL       = BLOCKEXPLORE_URL_TX % searchstr
                blkexplURL_short = BLOCKEXPLORE_URL_TX % searchstr[:20]
 
@@ -3775,8 +3775,7 @@ class ArmoryMainWindow(QMainWindow):
                   <br><br>If the transaction did fail, it is likely because the fee
                   is too low. Try again with a higher fee.
                   
-                  If the problem persists, go to "<i>Help</i>" and select 
-                  "<i>Submit Bug Report</i>".  Or use "<i>File</i>" -> 
+                  If the problem persists, go to "<i>File</i>" ->
                   "<i>Export Log File</i>" and then attach it to a support 
                   ticket at 
                   <a href="%(supporturl)s">%(supporturl)s</a>""") % {
@@ -4466,19 +4465,6 @@ class ArmoryMainWindow(QMainWindow):
       #####
       def openBitcoinOrg():
          webbrowser.open('http://www.bitcoin.org/en/download')
-
-
-      #####
-      def openInstruct():
-         if OS_WINDOWS:
-            webbrowser.open('https://www.bitcoinarmory.com/install-windows/')
-         elif OS_LINUX:
-            webbrowser.open('https://www.bitcoinarmory.com/install-linux/')
-         elif OS_MACOSX:
-            webbrowser.open('https://www.bitcoinarmory.com/install-macosx/')
-
-
-
 
 
 
@@ -5564,7 +5550,7 @@ class ArmoryMainWindow(QMainWindow):
             'accepting connections from localhost.  '
             '<br><br>'
             'If you have not changed anything, please export the log file '
-            '(from the "File" menu) and send it to support@bitcoinarmory.com')
+            '(from the "File" menu) and open an issue at https://github.com/goatpig/BitcoinArmory/issues')
          if state == 'OfflineSatoshiAvail':
             return tr( \
             'Armory does not detect internet access, but it does detect '
@@ -5624,10 +5610,8 @@ class ArmoryMainWindow(QMainWindow):
                   <br><br>
                   Unfortunately, this error is so strange, Armory does not
                   recognize it.  Please go to "Export Log File" from the "File"
-                  menu and email at as an attachment to <a href="mailto:
-                  support@bitcoinarmory.com?Subject=Bitcoind%20Crash">
-                  support@bitcoinarmory.com</a>.  We apologize for the
-                  inconvenience!"""))
+                  menu and submit an issue at https://github.com/goatpig/BitcoinArmory/issues.
+                  We apologize for the inconvenience!"""))
 
    # TODO - move out of polling and call on events
    #############################################################################
@@ -5815,9 +5799,7 @@ class ArmoryMainWindow(QMainWindow):
                   setBtnFrameVisible(True, \
                      tr('Try reinstalling the Bitcoin '
                      'software then restart Armory.  If you continue to have '
-                     'problems, please contact Armory\'s core developer at '
-                     '<a href="mailto:support@bitcoinarmory.com?Subject=Bitcoind%20Crash"'
-                     '>support@bitcoinarmory.com</a>.'))
+                     'problems, please open an issue at https://github.com/goatpig/BitcoinArmory/issues'))
                   setBtnRowVisible(DASHBTNS.Settings, True)
                   setBtnRowVisible(DASHBTNS.Install, True)
                   LOGINFO('Dashboard switched to auto-BtcdCrashed')

--- a/ArmoryQt.py
+++ b/ArmoryQt.py
@@ -3171,7 +3171,7 @@ class ArmoryMainWindow(QMainWindow):
       self.settings.set('FailedLoadCount', 0)
 
       # This will force the table to refresh with new data
-      self.updateAnnounceTab()  # make sure satoshi version info is up to date
+      # self.updateAnnounceTab()  # make sure satoshi version info is up to date
       self.removeBootstrapDat()  # if we got here, we're *really* done with it
       self.walletModel.reset()
    

--- a/cppForSwig/BtcWallet.cpp
+++ b/cppForSwig/BtcWallet.cpp
@@ -329,8 +329,8 @@ void BtcWallet::scanNonStdTx(uint32_t blknum,
       LOGERR << "ALERT:  Found non-standard transaction referencing";
       LOGERR << "        an address in your wallet.  There is no way";
       LOGERR << "        for this program to determine if you can";
-      LOGERR << "        spend these BTC or not.  Please email the";
-      LOGERR << "        following information to support@bitcoinarmory.com";
+      LOGERR << "        spend these BTC or not.  Please open an issue with the ";
+      LOGERR << "        following information at https://github.com/goatpig/BitcoinArmory/issues";
       LOGERR << "        for help identifying the transaction and how";
       LOGERR << "        to spend it:";
       LOGERR << "   Block Number: " << blknum;

--- a/qtdialogs.py
+++ b/qtdialogs.py
@@ -405,273 +405,273 @@ class DlgGenericGetPassword(ArmoryDialog):
       self.setWindowTitle(tr('Enter Password'))
       self.setWindowIcon(QIcon(self.main.iconfile))
 
-################################################################################
-class DlgBugReport(ArmoryDialog):
-
-   def __init__(self, parent=None, main=None):
-      super(DlgBugReport, self).__init__(parent, main)
-
-      tsPage = 'https://bitcoinarmory.com/troubleshooting'
-      faqPage = 'https://bitcoinarmory.com/faq'
-
-      lblDescr = QRichLabel(tr("""
-         <b><u>Send a bug report to the Armory team</u></b>
-         <br><br>
-         If you are having difficulties with Armory, you should first visit
-         our <a href="%(tsurl)s">troubleshooting page</a> and our
-         <a href="%(faqurl)s">FAQ page</a> which describe solutions to
-         many common problems.
-         <br><br>
-         If you do not find the answer to your problem on those pages,
-         please describe it in detail below, and any steps taken to
-         reproduce the problem.  The more information you provide, the
-         more likely we will be able to help you.
-         <br><br>
-         <b><font color="%(color)s">Note:</font></b>  Please keep in mind we 
-         are a small open-source company, and do not have a formal customer
-         support department.  We will do our best to help you, but cannot
-         respond to everyone!""") \
-            % {'tsurl' : tsPage, 'faqurl' : faqPage, 'color' :htmlColor('TextBlue')})
-
-      self.chkNoLog = QCheckBox(tr('Do not send log file with report'))
-      self.chkNoLog.setChecked(False)
-
-      self.btnMoreInfo = QLabelButton(tr('Privacy Info'))
-      self.connect(self.btnMoreInfo, SIGNAL(CLICKED), \
-                              self.main.logFilePrivacyWarning)
-
-      self.noLogWarn = QRichLabel(tr("""
-         <font color="%(color)s">You are unlikely to get a response unless you 
-         provide a log file and a reasonable description with your support
-         request.""") % { 'color' : htmlColor('TextWarn') })
-      self.noLogWarn.setVisible(False)
-
-      self.connect(self.chkNoLog, SIGNAL('toggled(bool)'), \
-                                           self.noLogWarn.setVisible)
-
-      self.lblEmail = QRichLabel(tr('Email Address:'))
-      self.edtEmail = QLineEdit()
-      self.edtEmail.setMaxLength(100)
-
-      self.lblSubject = QRichLabel(tr('Subject:'))
-      self.edtSubject = QLineEdit()
-      self.edtSubject.setMaxLength(64)
-      self.edtSubject.setText(tr("Bug Report"))
-
-      self.txtDescr = QTextEdit()
-      self.txtDescr.setFont(GETFONT('Fixed', 9))
-      w,h = tightSizeNChar(self, 80)
-      self.txtDescr.setMinimumWidth(w)
-      self.txtDescr.setMinimumHeight(4*h)
-      self.lblOS = QRichLabel(tr("""
-         Note: if you are using this computer to report an Armory problem
-         on another computer, please include the operating system of the
-         other computer and the version of Armory it is running."""))
-
-      self.btnSubmit = QPushButton(tr('Submit Report'))
-      self.btnCancel = QPushButton(tr('Cancel'))
-      self.btnbox = QDialogButtonBox()
-      self.btnbox.addButton(self.btnSubmit, QDialogButtonBox.AcceptRole)
-      self.btnbox.addButton(self.btnCancel, QDialogButtonBox.RejectRole)
-      self.connect(self.btnSubmit, SIGNAL(CLICKED), self.submitReport)
-      self.connect(self.btnCancel, SIGNAL(CLICKED), self, SLOT('reject()'))
-
-      armoryver = getVersionString(BTCARMORY_VERSION)
-      lblDetect = QRichLabel( tr("""
-         <b>Detected:</b> %(osname)s (%(osvariant)s) / %(mem)0.2f GB RAM / Armory version %(ver)s<br>
-         <font size=2>(this data will be submitted automatically with the
-         report)</font>""") % \
-         { 'osname' : OS_NAME, 'osvariant' : OS_VARIANT[0], 'mem' : SystemSpecs.Memory, 'ver' : armoryver})
-
-
-      layout = QGridLayout()
-      i = -1
-
-      i += 1
-      layout.addWidget(lblDescr,         i,0, 1,2)
-
-      i += 1
-      layout.addWidget(HLINE(),          i,0, 1,2)
-
-      i += 1
-      layout.addWidget(lblDetect,        i,0, 1,2)
-
-      i += 1
-      layout.addWidget(HLINE(),          i,0, 1,2)
-
-      i += 1
-      layout.addWidget(self.lblEmail,    i,0, 1,1)
-      layout.addWidget(self.edtEmail,    i,1, 1,1)
-
-      i += 1
-      layout.addWidget(self.lblSubject,  i,0, 1,1)
-      layout.addWidget(self.edtSubject,  i,1, 1,1)
-
-      i += 1
-      layout.addWidget(QLabel(tr("Description of problem:")),    i,0, 1,2)
-
-      i += 1
-      layout.addWidget(self.txtDescr,    i,0, 1,2)
-
-      i += 1
-      frmchkbtn = makeHorizFrame([self.chkNoLog, self.btnMoreInfo, 'Stretch'])
-      layout.addWidget(frmchkbtn,        i,0, 1,2)
-
-      i += 1
-      layout.addWidget(self.noLogWarn,   i,0, 1,2)
-
-      i += 1
-      layout.addWidget(self.btnbox,      i,0, 1,2)
-
-      self.setLayout(layout)
-      self.setWindowTitle(tr('Submit a Bug Report'))
-      self.setWindowIcon(QIcon(self.main.iconfile))
-
-   #############################################################################
-   def submitReport(self):
-      if self.main.getUserAgreeToPrivacy(True):
-         self.userAgreedToPrivacyPolicy = True
-      else:
-         return
-
-      emailAddr = unicode(self.edtEmail.text()).strip()
-      emailLen = lenBytes(emailAddr)
-
-      subjectText = unicode(self.edtSubject.text()).strip()
-      subjectLen = lenBytes(subjectText)
-
-      description = unicode(self.txtDescr.toPlainText()).strip()
-      descrLen = lenBytes(description)
-
-
-      if emailLen == 0 or not '@' in emailAddr:
-         reply = MsgBoxCustom(MSGBOX.Warning, tr('Missing Email'), tr("""
-            You must supply a valid email address so we can follow up on your
-            request."""), \
-            noStr=tr('Go Back'), yesStr=tr('Submit without Email'))
-
-         if not reply:
-            return
-         else:
-            emailAddr = '<NO EMAIL SUPPPLIED>'
-
-
-      if descrLen < 10:
-         QMessageBox.warning(self, tr('Empty Description'), tr("""
-            You must describe what problem you are having, and any steps
-            to reproduce the problem.  The Armory team cannot look for
-            problems in the log file if it doesn't know what those problems
-            are!."""), QMessageBox.Ok)
-         return
-
-      maxDescr = 16384
-      if descrLen > maxDescr:
-         reply = MsgBoxCustom(MSGBOX.Warning, tr('Long Description'), tr("""
-            You have exceeded the maximum size of the description that can
-            be submitted to our ticket system, which is %(bytes)d bytes.
-            If you click "Continue", the last %(last)s bytes of your description
-            will be removed before sending.""") % { 'bytes' : maxDescr, 'last' : descrLen-maxDescr}, \
-            noStr=tr('Go Back'), yesStr=tr('Continue'))
-         if not reply:
-            return
-         else:
-            description = unicode_truncate(description, maxDescr)
-
-
-      # This is a unique-but-not-traceable ID, to simply match users to log files
-      uniqID  = binary_to_base58(hash256(USER_HOME_DIR)[:4])
-      dateStr = unixTimeToFormatStr(RightNow(), '%Y%m%d_%H%M')
-      osvariant = OS_VARIANT[0] if OS_MACOSX else '-'.join(OS_VARIANT)
-
-      reportMap = {}
-      reportMap['uniqID']       = uniqID
-      reportMap['OSmajor']      = OS_NAME
-      reportMap['OSvariant']    = osvariant
-      reportMap['ArmoryVer']    = getVersionString(BTCARMORY_VERSION)
-      reportMap['TotalRAM']     = '%0.2f' % SystemSpecs.Memory
-      reportMap['isAmd64']      = str(SystemSpecs.IsX64).lower()
-      reportMap['userEmail']    = emailAddr
-      reportMap['userSubject']  = subjectText
-      reportMap['userDescr']    = description
-      reportMap['userTime']     = unixTimeToFormatStr(RightNow())
-      reportMap['userTimeUTC']  = unixTimeToFormatStr(RightNowUTC())
-      reportMap['agreedPrivacy']  = str(self.userAgreedToPrivacyPolicy)
-
-      combinedLogName = 'armory_log_%s_%s.txt' % (uniqID, dateStr)
-      combinedLogPath = os.path.join(ARMORY_HOME_DIR, combinedLogName)
-      self.main.saveCombinedLogFile(combinedLogPath)
-
-      if self.chkNoLog.isChecked():
-         reportMap['fileLog'] = '<NO LOG FILE SUBMITTED>'
-      else:
-         with open(combinedLogPath, 'r') as f:
-            reportMap['fileLog'] = f.read()
-
-      LOGDEBUG('Sending the following dictionary of values to server')
-      for key,val in reportMap.iteritems():
-         if key=='fileLog':
-            LOGDEBUG(key.ljust(12) + ': ' + binary_to_hex(sha256(val)))
-         else:
-            LOGDEBUG(key.ljust(12) + ': ' + val)
-
-      expectedResponseMap = {}
-      expectedResponseMap['logHash'] = binary_to_hex(sha256(reportMap['fileLog']))
-
-      try:
-         import urllib3
-         http = urllib3.PoolManager()
-         headers = urllib3.make_headers('ArmoryBugReportWindowNotABrowser')
-         response = http.request('POST', BUG_REPORT_URL, reportMap, headers)
-         responseMap = ast.literal_eval(response._body)
-
-
-         LOGINFO('-'*50)
-         LOGINFO('Response JSON:')
-         for key,val in responseMap.iteritems():
-            LOGINFO(key.ljust(12) + ': ' + str(val))
-
-         LOGINFO('-'*50)
-         LOGINFO('Expected JSON:')
-         for key,val in expectedResponseMap.iteritems():
-            LOGINFO(key.ljust(12) + ': ' + str(val))
-
-
-         LOGDEBUG('Connection info:')
-         LOGDEBUG('   status:  ' + str(response.status))
-         LOGDEBUG('   version: ' + str(response.version))
-         LOGDEBUG('   reason:  ' + str(response.reason))
-         LOGDEBUG('   strict:  ' + str(response.strict))
-
-
-         if responseMap==expectedResponseMap:
-            LOGINFO('Server verified receipt of log file')
-            cemail = 'contact@bitcoinarmory.com'
-            QMessageBox.information(self, tr('Submitted!'), tr("""
-               <b>Your report was submitted successfully!</b> 
-               <br><br>
-               You should receive and email shortly from our support system.
-               If you do not receive it, you should follow up your request
-               with an email to <a href="%(url)s">%(url)s</a>.  If you do, please
-               attach the following file to your email:
-               <br><br>
-               %(path)s
-               <br><br>
-               Please be aware that the team receives lots of reports, 
-               so it may take a few days for the team to get back to 
-               you.""") % {'url' : cemail, 'path' : combinedLogPath}, QMessageBox.Ok)
-            self.accept()
-         else:
-            raise ConnectionError('Failed to send bug report')
-
-      except:
-         LOGEXCEPT('Failed:')
-         bugpage = 'https://bitcoinarmory.com/support/'
-         QMessageBox.information(self, tr('Submitted!'), tr("""
-            There was a problem submitting your bug report.  It is recommended
-            that you submit this information through our webpage instead:
-            <br><br>
-            <a href="%(url)s">%(url)s</a>""") % { 'url' : bugpage }, QMessageBox.Ok)
-         self.reject()
+# ################################################################################
+# class DlgBugReport(ArmoryDialog):
+#
+#    def __init__(self, parent=None, main=None):
+#       super(DlgBugReport, self).__init__(parent, main)
+#
+#       tsPage = 'https://bitcoinarmory.com/troubleshooting'
+#       faqPage = 'https://bitcoinarmory.com/faq'
+#
+#       lblDescr = QRichLabel(tr("""
+#          <b><u>Send a bug report to the Armory team</u></b>
+#          <br><br>
+#          If you are having difficulties with Armory, you should first visit
+#          our <a href="%(tsurl)s">troubleshooting page</a> and our
+#          <a href="%(faqurl)s">FAQ page</a> which describe solutions to
+#          many common problems.
+#          <br><br>
+#          If you do not find the answer to your problem on those pages,
+#          please describe it in detail below, and any steps taken to
+#          reproduce the problem.  The more information you provide, the
+#          more likely we will be able to help you.
+#          <br><br>
+#          <b><font color="%(color)s">Note:</font></b>  Please keep in mind we
+#          are a small open-source company, and do not have a formal customer
+#          support department.  We will do our best to help you, but cannot
+#          respond to everyone!""") \
+#             % {'tsurl' : tsPage, 'faqurl' : faqPage, 'color' :htmlColor('TextBlue')})
+#
+#       self.chkNoLog = QCheckBox(tr('Do not send log file with report'))
+#       self.chkNoLog.setChecked(False)
+#
+#       self.btnMoreInfo = QLabelButton(tr('Privacy Info'))
+#       self.connect(self.btnMoreInfo, SIGNAL(CLICKED), \
+#                               self.main.logFilePrivacyWarning)
+#
+#       self.noLogWarn = QRichLabel(tr("""
+#          <font color="%(color)s">You are unlikely to get a response unless you
+#          provide a log file and a reasonable description with your support
+#          request.""") % { 'color' : htmlColor('TextWarn') })
+#       self.noLogWarn.setVisible(False)
+#
+#       self.connect(self.chkNoLog, SIGNAL('toggled(bool)'), \
+#                                            self.noLogWarn.setVisible)
+#
+#       self.lblEmail = QRichLabel(tr('Email Address:'))
+#       self.edtEmail = QLineEdit()
+#       self.edtEmail.setMaxLength(100)
+#
+#       self.lblSubject = QRichLabel(tr('Subject:'))
+#       self.edtSubject = QLineEdit()
+#       self.edtSubject.setMaxLength(64)
+#       self.edtSubject.setText(tr("Bug Report"))
+#
+#       self.txtDescr = QTextEdit()
+#       self.txtDescr.setFont(GETFONT('Fixed', 9))
+#       w,h = tightSizeNChar(self, 80)
+#       self.txtDescr.setMinimumWidth(w)
+#       self.txtDescr.setMinimumHeight(4*h)
+#       self.lblOS = QRichLabel(tr("""
+#          Note: if you are using this computer to report an Armory problem
+#          on another computer, please include the operating system of the
+#          other computer and the version of Armory it is running."""))
+#
+#       self.btnSubmit = QPushButton(tr('Submit Report'))
+#       self.btnCancel = QPushButton(tr('Cancel'))
+#       self.btnbox = QDialogButtonBox()
+#       self.btnbox.addButton(self.btnSubmit, QDialogButtonBox.AcceptRole)
+#       self.btnbox.addButton(self.btnCancel, QDialogButtonBox.RejectRole)
+#       self.connect(self.btnSubmit, SIGNAL(CLICKED), self.submitReport)
+#       self.connect(self.btnCancel, SIGNAL(CLICKED), self, SLOT('reject()'))
+#
+#       armoryver = getVersionString(BTCARMORY_VERSION)
+#       lblDetect = QRichLabel( tr("""
+#          <b>Detected:</b> %(osname)s (%(osvariant)s) / %(mem)0.2f GB RAM / Armory version %(ver)s<br>
+#          <font size=2>(this data will be submitted automatically with the
+#          report)</font>""") % \
+#          { 'osname' : OS_NAME, 'osvariant' : OS_VARIANT[0], 'mem' : SystemSpecs.Memory, 'ver' : armoryver})
+#
+#
+#       layout = QGridLayout()
+#       i = -1
+#
+#       i += 1
+#       layout.addWidget(lblDescr,         i,0, 1,2)
+#
+#       i += 1
+#       layout.addWidget(HLINE(),          i,0, 1,2)
+#
+#       i += 1
+#       layout.addWidget(lblDetect,        i,0, 1,2)
+#
+#       i += 1
+#       layout.addWidget(HLINE(),          i,0, 1,2)
+#
+#       i += 1
+#       layout.addWidget(self.lblEmail,    i,0, 1,1)
+#       layout.addWidget(self.edtEmail,    i,1, 1,1)
+#
+#       i += 1
+#       layout.addWidget(self.lblSubject,  i,0, 1,1)
+#       layout.addWidget(self.edtSubject,  i,1, 1,1)
+#
+#       i += 1
+#       layout.addWidget(QLabel(tr("Description of problem:")),    i,0, 1,2)
+#
+#       i += 1
+#       layout.addWidget(self.txtDescr,    i,0, 1,2)
+#
+#       i += 1
+#       frmchkbtn = makeHorizFrame([self.chkNoLog, self.btnMoreInfo, 'Stretch'])
+#       layout.addWidget(frmchkbtn,        i,0, 1,2)
+#
+#       i += 1
+#       layout.addWidget(self.noLogWarn,   i,0, 1,2)
+#
+#       i += 1
+#       layout.addWidget(self.btnbox,      i,0, 1,2)
+#
+#       self.setLayout(layout)
+#       self.setWindowTitle(tr('Submit a Bug Report'))
+#       self.setWindowIcon(QIcon(self.main.iconfile))
+#
+#    #############################################################################
+#    def submitReport(self):
+#       if self.main.getUserAgreeToPrivacy(True):
+#          self.userAgreedToPrivacyPolicy = True
+#       else:
+#          return
+#
+#       emailAddr = unicode(self.edtEmail.text()).strip()
+#       emailLen = lenBytes(emailAddr)
+#
+#       subjectText = unicode(self.edtSubject.text()).strip()
+#       subjectLen = lenBytes(subjectText)
+#
+#       description = unicode(self.txtDescr.toPlainText()).strip()
+#       descrLen = lenBytes(description)
+#
+#
+#       if emailLen == 0 or not '@' in emailAddr:
+#          reply = MsgBoxCustom(MSGBOX.Warning, tr('Missing Email'), tr("""
+#             You must supply a valid email address so we can follow up on your
+#             request."""), \
+#             noStr=tr('Go Back'), yesStr=tr('Submit without Email'))
+#
+#          if not reply:
+#             return
+#          else:
+#             emailAddr = '<NO EMAIL SUPPPLIED>'
+#
+#
+#       if descrLen < 10:
+#          QMessageBox.warning(self, tr('Empty Description'), tr("""
+#             You must describe what problem you are having, and any steps
+#             to reproduce the problem.  The Armory team cannot look for
+#             problems in the log file if it doesn't know what those problems
+#             are!."""), QMessageBox.Ok)
+#          return
+#
+#       maxDescr = 16384
+#       if descrLen > maxDescr:
+#          reply = MsgBoxCustom(MSGBOX.Warning, tr('Long Description'), tr("""
+#             You have exceeded the maximum size of the description that can
+#             be submitted to our ticket system, which is %(bytes)d bytes.
+#             If you click "Continue", the last %(last)s bytes of your description
+#             will be removed before sending.""") % { 'bytes' : maxDescr, 'last' : descrLen-maxDescr}, \
+#             noStr=tr('Go Back'), yesStr=tr('Continue'))
+#          if not reply:
+#             return
+#          else:
+#             description = unicode_truncate(description, maxDescr)
+#
+#
+#       # This is a unique-but-not-traceable ID, to simply match users to log files
+#       uniqID  = binary_to_base58(hash256(USER_HOME_DIR)[:4])
+#       dateStr = unixTimeToFormatStr(RightNow(), '%Y%m%d_%H%M')
+#       osvariant = OS_VARIANT[0] if OS_MACOSX else '-'.join(OS_VARIANT)
+#
+#       reportMap = {}
+#       reportMap['uniqID']       = uniqID
+#       reportMap['OSmajor']      = OS_NAME
+#       reportMap['OSvariant']    = osvariant
+#       reportMap['ArmoryVer']    = getVersionString(BTCARMORY_VERSION)
+#       reportMap['TotalRAM']     = '%0.2f' % SystemSpecs.Memory
+#       reportMap['isAmd64']      = str(SystemSpecs.IsX64).lower()
+#       reportMap['userEmail']    = emailAddr
+#       reportMap['userSubject']  = subjectText
+#       reportMap['userDescr']    = description
+#       reportMap['userTime']     = unixTimeToFormatStr(RightNow())
+#       reportMap['userTimeUTC']  = unixTimeToFormatStr(RightNowUTC())
+#       reportMap['agreedPrivacy']  = str(self.userAgreedToPrivacyPolicy)
+#
+#       combinedLogName = 'armory_log_%s_%s.txt' % (uniqID, dateStr)
+#       combinedLogPath = os.path.join(ARMORY_HOME_DIR, combinedLogName)
+#       self.main.saveCombinedLogFile(combinedLogPath)
+#
+#       if self.chkNoLog.isChecked():
+#          reportMap['fileLog'] = '<NO LOG FILE SUBMITTED>'
+#       else:
+#          with open(combinedLogPath, 'r') as f:
+#             reportMap['fileLog'] = f.read()
+#
+#       LOGDEBUG('Sending the following dictionary of values to server')
+#       for key,val in reportMap.iteritems():
+#          if key=='fileLog':
+#             LOGDEBUG(key.ljust(12) + ': ' + binary_to_hex(sha256(val)))
+#          else:
+#             LOGDEBUG(key.ljust(12) + ': ' + val)
+#
+#       expectedResponseMap = {}
+#       expectedResponseMap['logHash'] = binary_to_hex(sha256(reportMap['fileLog']))
+#
+#       try:
+#          import urllib3
+#          http = urllib3.PoolManager()
+#          headers = urllib3.make_headers('ArmoryBugReportWindowNotABrowser')
+#          response = http.request('POST', BUG_REPORT_URL, reportMap, headers)
+#          responseMap = ast.literal_eval(response._body)
+#
+#
+#          LOGINFO('-'*50)
+#          LOGINFO('Response JSON:')
+#          for key,val in responseMap.iteritems():
+#             LOGINFO(key.ljust(12) + ': ' + str(val))
+#
+#          LOGINFO('-'*50)
+#          LOGINFO('Expected JSON:')
+#          for key,val in expectedResponseMap.iteritems():
+#             LOGINFO(key.ljust(12) + ': ' + str(val))
+#
+#
+#          LOGDEBUG('Connection info:')
+#          LOGDEBUG('   status:  ' + str(response.status))
+#          LOGDEBUG('   version: ' + str(response.version))
+#          LOGDEBUG('   reason:  ' + str(response.reason))
+#          LOGDEBUG('   strict:  ' + str(response.strict))
+#
+#
+#          if responseMap==expectedResponseMap:
+#             LOGINFO('Server verified receipt of log file')
+#             cemail = 'contact@bitcoinarmory.com'
+#             QMessageBox.information(self, tr('Submitted!'), tr("""
+#                <b>Your report was submitted successfully!</b>
+#                <br><br>
+#                You should receive and email shortly from our support system.
+#                If you do not receive it, you should follow up your request
+#                with an email to <a href="%(url)s">%(url)s</a>.  If you do, please
+#                attach the following file to your email:
+#                <br><br>
+#                %(path)s
+#                <br><br>
+#                Please be aware that the team receives lots of reports,
+#                so it may take a few days for the team to get back to
+#                you.""") % {'url' : cemail, 'path' : combinedLogPath}, QMessageBox.Ok)
+#             self.accept()
+#          else:
+#             raise ConnectionError('Failed to send bug report')
+#
+#       except:
+#          LOGEXCEPT('Failed:')
+#          bugpage = 'https://bitcoinarmory.com/support/'
+#          QMessageBox.information(self, tr('Submitted!'), tr("""
+#             There was a problem submitting your bug report.  It is recommended
+#             that you submit this information through our webpage instead:
+#             <br><br>
+#             <a href="%(url)s">%(url)s</a>""") % { 'url' : bugpage }, QMessageBox.Ok)
+#          self.reject()
 
 
 ################################################################################
@@ -3403,8 +3403,7 @@ class DlgImportAddress(ArmoryDialog):
             MsgBoxCustom(MSGBOX.Error, 'Error!', tr("""
                Failed:  No addresses could be imported.
                Please check the logfile (ArmoryQt.exe.log) or the console output
-               for information about why it failed (and email support@bitcoinarmory.com
-               for help fixing the problem). """))
+               for information about why it failed. """))
             return
          else:
             if nError == 0:
@@ -4063,10 +4062,7 @@ class DlgIntroMessage(ArmoryDialog):
          'software available!</b>  But please remember, this software '
          'is still <i>Beta</i> - Armory developers will not be held responsible '
          'for loss of bitcoins resulting from the use of this software!'
-         '<br><br>'
-         'For more info about Armory, and Bitcoin itself, see '
-         '<a href="https://bitcoinarmory.com/faq">frequently '
-         'asked questions</a>.')
+         '<br><br>')
       lblDescr.setOpenExternalLinks(True)
 
       lblContact = QRichLabel(\
@@ -6155,8 +6151,7 @@ class DlgDispTxInfo(ArmoryDialog):
                   '(change outputs are displayed in light gray).')
 
       self.lblChangeDescr = QRichLabel( tr("""Some outputs might be "change."
-         <a href="https://bitcoinarmory.com/all-about-change">Click for more 
-         info</a>"""), doWrap=False)
+         """), doWrap=False)
       self.lblChangeDescr.setOpenExternalLinks(True)
         
 
@@ -7219,7 +7214,6 @@ class DlgPrintBackup(ArmoryDialog):
 
       self.scene.drawText('Paper Backup for Armory Wallet', GETFONT('Var', 11))
       self.scene.newLine()
-      self.scene.drawText('http://www.bitcoinarmory.com')
 
       self.scene.newLine(extra_dy=20)
       self.scene.drawHLine()
@@ -8677,8 +8671,8 @@ class DlgHelpAbout(ArmoryDialog):
 
       lblHead = QRichLabel(tr('Armory Bitcoin Wallet : Version %s-beta-%s') % \
                                     (getVersionString(BTCARMORY_VERSION), BTCARMORY_BUILD), doWrap=False)
-      lblWebpage = QRichLabel('<a href="https://www.bitcoinarmory.com">https://www.bitcoinarmory.com</a>')
-      lblWebpage.setOpenExternalLinks(True)
+      #lblWebpage = QRichLabel('<a href="https://www.bitcoinarmory.com">https://www.bitcoinarmory.com</a>')
+      #lblWebpage.setOpenExternalLinks(True)
       lblOldCopyright = QRichLabel(tr(u'Copyright &copy; 2011-2015 Armory Technologies, Inc.'))
       lblCopyright = QRichLabel(tr(u'Copyright &copy; 2016 Goatpig'))
       lblOldLicense = QRichLabel(tr(u'Licensed to Armory Technologies, Inc. under the '
@@ -8691,14 +8685,14 @@ class DlgHelpAbout(ArmoryDialog):
       lblLicense.setOpenExternalLinks(True)
 
       lblHead.setAlignment(Qt.AlignHCenter)
-      lblWebpage.setAlignment(Qt.AlignHCenter)
+      #lblWebpage.setAlignment(Qt.AlignHCenter)
       lblCopyright.setAlignment(Qt.AlignHCenter)
       lblOldCopyright.setAlignment(Qt.AlignHCenter)
       lblLicense.setAlignment(Qt.AlignHCenter)
       lblOldLicense.setAlignment(Qt.AlignHCenter)
 
       dlgLayout = QHBoxLayout()
-      dlgLayout.addWidget(makeVertFrame([imgLogo, lblHead, lblCopyright, lblWebpage, lblOldCopyright, STRETCH, lblLicense, lblOldLicense]))
+      dlgLayout.addWidget(makeVertFrame([imgLogo, lblHead, lblCopyright, lblOldCopyright, STRETCH, lblLicense, lblOldLicense]))
       self.setLayout(dlgLayout)
 
       self.setMinimumWidth(450)
@@ -8849,11 +8843,7 @@ class DlgSettings(ArmoryDialog):
          self.main.setupUriRegistration(justDoIt=True)
          QMessageBox.information(self, tr('Registered'), tr("""
             Armory just attempted to register itself to handle "bitcoin:"
-            links, but this does not work on all operating systems.  You can
-            test it by going to the
-            <a href="http://www.bitcoinarmory.com">Bitcoin Armory
-            website</a> and clicking the link at the bottom of the
-            homepage."""), QMessageBox.Ok)
+            links, but this does not work on all operating systems."""), QMessageBox.Ok)
 
       self.connect(btnDefaultURI, SIGNAL(CLICKED), clickRegURI)
 
@@ -9362,20 +9352,6 @@ class DlgSettings(ArmoryDialog):
       oldTorSetting = self.main.getSettingOrSetDefault('UseTorSettings', False)
       self.main.writeSetting('SkipStatsReport',self.chkPrivacyStats.isChecked())
       self.main.writeSetting('UseTorSettings', self.chkPrivacyTor.isChecked())
-
-      if self.chkPrivacyTor.isChecked() and not oldTorSetting:
-         annURL = 'https://bitcoinarmory.com/announcements/'
-         QMessageBox.warning(self, 'Disable Security Alerts?', tr("""
-            You have chosen to disable all Armory communications that are
-            incompatible with proxies/Tor.  This includes 
-            checking for security alerts.  If you leave this option
-            checked, it is highly recommended that you manually check
-            for updates in the "<i>Announcements</i>" tab on the main 
-            window from another online Armory installation and/or
-            bookmark our announcements page: 
-            <br><br>
-            <a href="%s">%s</a>""") % (annURL,annURL), QMessageBox.Ok) 
-
       
 
 
@@ -11901,9 +11877,7 @@ class DlgFragBackup(ArmoryDialog):
              <font color="%(color)s"><b>%(N)d</b></font>
          fragments are sufficient to restore your wallet, and each fragment
          has the ID, <font color="%(color)s"><b>%(prefix)s</b></font>.  All fragments with the
-         same fragment ID are compatible with each other!
-         <a href="https://bitcoinarmory.com/armory-backups-are-forever/">Click
-         here</a> to read more about our backup system.<br>""") % \
+         same fragment ID are compatible with each other!""") % \
          { 'color' : BLUE, 'M' : M, 'N' : N, 'prefix' : self.fragPrefixStr})
 
 

--- a/qtdialogs.py
+++ b/qtdialogs.py
@@ -8680,10 +8680,14 @@ class DlgHelpAbout(ArmoryDialog):
                                     (getVersionString(BTCARMORY_VERSION), BTCARMORY_BUILD), doWrap=False)
       lblWebpage = QRichLabel('<a href="https://www.bitcoinarmory.com">https://www.bitcoinarmory.com</a>')
       lblWebpage.setOpenExternalLinks(True)
-      lblCopyright = QRichLabel(tr(u'Copyright &copy; 2011-2015 Armory Technologies, Inc.'))
-      lblLicense = QRichLabel(tr(u'Licensed under the '
+      lblCopyright = QRichLabel(tr(u'Copyright &copy; 2011-2015 Armory Technologies, Inc.'),
+                                tr(u'Copyright &copy; 2016 Goatpig'))
+      lblLicense = QRichLabel(tr(u'Licensed to Armory Technologies, Inc. under the '
                               '<a href="http://www.gnu.org/licenses/agpl-3.0.html">'
-                              'Affero General Public License, Version 3</a> (AGPLv3)'))
+                              'Affero General Public License, Version 3</a> (AGPLv3)'),
+                              tr(u'Licensed to Goatpig under the '
+                              '<a href="https://opensource.org/licenses/mit-license.php">'
+                              'MIT License'))
       lblLicense.setOpenExternalLinks(True)
 
       lblHead.setAlignment(Qt.AlignHCenter)

--- a/qtdialogs.py
+++ b/qtdialogs.py
@@ -8679,12 +8679,13 @@ class DlgHelpAbout(ArmoryDialog):
                                     (getVersionString(BTCARMORY_VERSION), BTCARMORY_BUILD), doWrap=False)
       lblWebpage = QRichLabel('<a href="https://www.bitcoinarmory.com">https://www.bitcoinarmory.com</a>')
       lblWebpage.setOpenExternalLinks(True)
-      lblCopyright = QRichLabel(tr(u'Copyright &copy; 2011-2015 Armory Technologies, Inc.'),
-                                tr(u'Copyright &copy; 2016 Goatpig'))
-      lblLicense = QRichLabel(tr(u'Licensed to Armory Technologies, Inc. under the '
+      lblOldCopyright = QRichLabel(tr(u'Copyright &copy; 2011-2015 Armory Technologies, Inc.'))
+      lblCopyright = QRichLabel(tr(u'Copyright &copy; 2016 Goatpig'))
+      lblOldLicense = QRichLabel(tr(u'Licensed to Armory Technologies, Inc. under the '
                               '<a href="http://www.gnu.org/licenses/agpl-3.0.html">'
-                              'Affero General Public License, Version 3</a> (AGPLv3)'),
-                              tr(u'Licensed to Goatpig under the '
+                              'Affero General Public License, Version 3</a> (AGPLv3)'))
+      lblOldLicense.setOpenExternalLinks(True)
+      lblLicense = QRichLabel(tr(u'Licensed to Goatpig under the '
                               '<a href="https://opensource.org/licenses/mit-license.php">'
                               'MIT License'))
       lblLicense.setOpenExternalLinks(True)
@@ -8692,10 +8693,12 @@ class DlgHelpAbout(ArmoryDialog):
       lblHead.setAlignment(Qt.AlignHCenter)
       lblWebpage.setAlignment(Qt.AlignHCenter)
       lblCopyright.setAlignment(Qt.AlignHCenter)
+      lblOldCopyright.setAlignment(Qt.AlignHCenter)
       lblLicense.setAlignment(Qt.AlignHCenter)
+      lblOldLicense.setAlignment(Qt.AlignHCenter)
 
       dlgLayout = QHBoxLayout()
-      dlgLayout.addWidget(makeVertFrame([imgLogo, lblHead, lblCopyright, lblWebpage, STRETCH, lblLicense]))
+      dlgLayout.addWidget(makeVertFrame([imgLogo, lblHead, lblCopyright, lblWebpage, lblOldCopyright, STRETCH, lblLicense, lblOldLicense]))
       self.setLayout(dlgLayout)
 
       self.setMinimumWidth(450)

--- a/ui/TxFrames.py
+++ b/ui/TxFrames.py
@@ -155,16 +155,16 @@ class SendBitcoinsFrame(ArmoryFrame):
          Click this button to copy a "bitcoin:" link directly into Armory."""))
       self.connect(btnEnterURI, SIGNAL("clicked()"), self.clickEnterURI)
       fromFrameList = [self.frmSelectedWlt]
-      if not USE_TESTNET:
-         btnDonate = QPushButton("Donate to Armory Developers!")
-         ttipDonate = self.main.createToolTipWidget(\
-            'Making this software was a lot of work.  You can give back '
-            'by adding a small donation to go to the Armory developers.  '
-            'You will have the ability to change the donation amount '
-            'before finalizing the transaction.')
-         self.connect(btnDonate, SIGNAL("clicked()"), self.addDonation)
-         frmDonate = makeHorizFrame([btnDonate, ttipDonate], condenseMargins=True)
-         fromFrameList.append(frmDonate)
+      # if not USE_TESTNET:
+      #    btnDonate = QPushButton("Donate to Armory Developers!")
+      #    ttipDonate = self.main.createToolTipWidget(\
+      #       'Making this software was a lot of work.  You can give back '
+      #       'by adding a small donation to go to the Armory developers.  '
+      #       'You will have the ability to change the donation amount '
+      #       'before finalizing the transaction.')
+      #    self.connect(btnDonate, SIGNAL("clicked()"), self.addDonation)
+      #    frmDonate = makeHorizFrame([btnDonate, ttipDonate], condenseMargins=True)
+      #    fromFrameList.append(frmDonate)
 
       if not self.main.usermode == USERMODE.Standard:
          frmEnterURI = makeHorizFrame([btnEnterURI, ttipEnterURI], condenseMargins=True)
@@ -242,11 +242,11 @@ class SendBitcoinsFrame(ArmoryFrame):
       self.setMinimumHeight(self.maxHeight * 20)
       # self.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Preferred)
 
-      loadCount = self.main.settings.get('Load_Count')
-      alreadyDonated = self.main.getSettingOrSetDefault('DonateAlready', False)
-      lastPestering = self.main.getSettingOrSetDefault('DonateLastPester', 0)
-      donateFreq = self.main.getSettingOrSetDefault('DonateFreq', 20)
-      dnaaDonate = self.main.getSettingOrSetDefault('DonateDNAA', False)
+      # loadCount = self.main.settings.get('Load_Count')
+      # alreadyDonated = self.main.getSettingOrSetDefault('DonateAlready', False)
+      # lastPestering = self.main.getSettingOrSetDefault('DonateLastPester', 0)
+      # donateFreq = self.main.getSettingOrSetDefault('DonateFreq', 20)
+      # dnaaDonate = self.main.getSettingOrSetDefault('DonateDNAA', False)
 
 
       if prefill:
@@ -264,32 +264,32 @@ class SendBitcoinsFrame(ArmoryFrame):
             else:
                self.addOneRecipient(None, amount, message, label, plainText=addrStr)
 
-      elif not self.main == None and \
-           loadCount % donateFreq == (donateFreq-1) and \
-           not loadCount == lastPestering and \
-           not dnaaDonate and \
-           not USE_TESTNET:
-         result = MsgBoxWithDNAA(self, self.main, MSGBOX.Question, 'Please donate!', tr("""
-            <i>Armory</i> is the result of thousands of hours of development 
-            by very talented coders.  Yet, this software 
-            has been given to you for free to benefit the greater Bitcoin 
-            community! 
-            <br><br>
-            If you are satisfied with this software, please consider 
-            donating what you think this software would be worth as a commercial 
-            application.
-            <br><br><b>Are you willing to donate to the Armory developers?</b> If you 
-            select "Yes," a donation field will be added to your 
-            next transaction.  You will have the opportunity to remove it or change 
-            the amount before sending the transaction."""), None)
-         self.main.writeSetting('DonateLastPester', loadCount)
-
-         if result[0] == True:
-            self.addDonation()
-            self.makeRecipFrame(2)
-
-         if result[1] == True:
-            self.main.writeSetting('DonateDNAA', True)
+      # elif not self.main == None and \
+      #      loadCount % donateFreq == (donateFreq-1) and \
+      #      not loadCount == lastPestering and \
+      #      not dnaaDonate and \
+      #      not USE_TESTNET:
+      #    result = MsgBoxWithDNAA(self, self.main, MSGBOX.Question, 'Please donate!', tr("""
+      #       <i>Armory</i> is the result of thousands of hours of development
+      #       by very talented coders.  Yet, this software
+      #       has been given to you for free to benefit the greater Bitcoin
+      #       community!
+      #       <br><br>
+      #       If you are satisfied with this software, please consider
+      #       donating what you think this software would be worth as a commercial
+      #       application.
+      #       <br><br><b>Are you willing to donate to the Armory developers?</b> If you
+      #       select "Yes," a donation field will be added to your
+      #       next transaction.  You will have the opportunity to remove it or change
+      #       the amount before sending the transaction."""), None)
+      #    self.main.writeSetting('DonateLastPester', loadCount)
+      #
+      #    if result[0] == True:
+      #       self.addDonation()
+      #       self.makeRecipFrame(2)
+      #
+      #    if result[1] == True:
+      #       self.main.writeSetting('DonateDNAA', True)
 
 
 


### PR DESCRIPTION
Removes a lot of stuff related to ATI, primarily in the GUI. Most mentions of ATI have been removed. Most of the phone home code has been commented out so as to allow future reimplementation. Most links to bitcoinarmory.com have been removed.

I got a lot of stuff but there is probably some stuff that I missed. Also, I left the links to bitcoinarmory.com that show up in the text of the Dashboard tab when Armory has not yet started. I just didn't know what to do with them.

The announcements tab and bug reporting have been removed entirely (commented out).