### PR TITLE
Re-enable Raspberry Pi builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,5 @@ osxbuild/env
 /armory_*_raspbian-armhf*
 
 /dpkgfiles/control
+
+/r-pi/RPI_CROSSCOMPILE/*

--- a/cppForSwig/cryptopp/Makefile
+++ b/cppForSwig/cryptopp/Makefile
@@ -37,6 +37,7 @@ GAS210_OR_LATER = $(shell echo "" | $(AS) -v 2>&1 | $(EGREP) -c "GNU assembler v
 GAS217_OR_LATER = $(shell echo "" | $(AS) -v 2>&1 | $(EGREP) -c "GNU assembler version (2\.1[7-9]|2\.[2-9]|[3-9])")
 GAS219_OR_LATER = $(shell echo "" | $(AS) -v 2>&1 | $(EGREP) -c "GNU assembler version (2\.19|2\.[2-9]|[3-9])")
 ISMINGW = $(shell $(CXX) --version 2>&1 | $(EGREP) -c "mingw")
+CROSSCOMPILE = $(shell $(CXX) --version 2>&1 | $(EGREP) -c "crosstool-NG")
 
 ifneq ($(GCC42_OR_LATER),0)
 ifeq ($(UNAME),Darwin)
@@ -67,7 +68,11 @@ else
 ifeq ($(GAS219_OR_LATER),0)
 CXXFLAGS += -DCRYPTOPP_DISABLE_AESNI
 else
+ifeq ($(CROSSCOMPILE),0)
 CXXFLAGS += -mpclmul -mssse3 -maes -msse4
+else
+CXXFLAGS +=
+endif
 endif
 
 endif

--- a/r-pi/README.md
+++ b/r-pi/README.md
@@ -1,0 +1,20 @@
+# RASPBERRY PI CROSS-COMPILATION INSTRUCTIONS
+Armory may be run on the Raspberry Pi computer, both in online and offline mode (although offline is highly recommended due to strain placed on hardware by the online mode.) The following set of commands, run from the Armory root directory, will execute the build script. A setup location is optional and will default to the *r-pi* subdirectory inside the directory where the command is executed.
+
+    python r-pi/crosscompile.py setupcrosscompiler *setup location*
+    python r-pi/crosscompile.py *setup location*
+
+The *setupcompiler* line is required only if the cross-compilation environment hasn't been set up yet. If the environment has been set up, the line may be skipped.
+
+When completed, *armory_<armory version>_raspbian-armhf.tar.gz* will be the final file. The user may be load it onto a Raspberry Pi (1 or 2 confirmed, 3 unconfirmed as of Mar. 2016), unzipped, and executed or installed as desired. *armory* is the command used to start Armory.
+
+The initial environment setup will require upwards of 625MB worth of data to be downloaded. Please be patient.
+
+## Caveats
+Users will need to have *git*, *wget*, and the *dpkg* suite installed on their computers, on top of any materials required to compile Armory by itself. OS X users will also need the Xcode command line suite, as described in the OS X build instructions. If OS X users don't wish to compile *wget* and *dpkg* from source, the following *brew* command will work.
+
+    brew install git wget dpkg
+
+Despite the OS X instructions above, it is highly recommended for now that users not attempt to cross-compile on OS X. Tools required by the *PyQt* software suite may interfere with attempts to build Armory on OS X. For now, OS X users should install a Linux VM if they wish to cross-compile for an RPi.
+
+As written, the script works but is a little primitive. Improvements are welcomed. One example is the fact that, when asked to set up the build environment, the script always attempts to download the required contents; it doesn't check to see if the environment already exists.

--- a/r-pi/crosscompile.py
+++ b/r-pi/crosscompile.py
@@ -1,3 +1,7 @@
+# Armory -- Bitcoin Wallet Software
+# Copyright (c) 2016, goatpig <moothecowlord@gmail.com>
+# Originally written by Alan Reiner  (etotheipi@gmail.com)
+
 import os
 import shutil
 import subprocess
@@ -9,18 +13,16 @@ TOOLS_PATH  = os.path.join(CROSSCOMPILEPATH, 'tools')
 PYROOT_PATH = os.path.join(CROSSCOMPILEPATH, 'pyroot')
 RPI_REPO    = 'git://github.com/raspberrypi/tools.git'
 
-# The following two files were valid as of 04 Jan, 2015.  You might need to
+# The following two files were valid as of Mar. 4, 2016.  You might need to
 # update the links below by going to the base FTP dir and looking for the
 # latest version numbers to update the links below.  You can view the
 # directory listing in your browser:
 #
-#    http://archive.raspbian.org/raspbian/pool/main/p/python2.7/
+#    https://archive.raspbian.org/raspbian/pool/main/p/python2.7/
 #
-PY_ARMHF1   = 'http://archive.raspbian.org/raspbian/pool/main/p/python2.7/libpython2.7-dev_2.7.8-11_armhf.deb'
-PY_ARMHF2   = 'http://archive.raspbian.org/raspbian/pool/main/p/python2.7/libpython2.7-minimal_2.7.8-11_armhf.deb'
+PY_ARMHF1   = 'https://archive.raspbian.org/raspbian/pool/main/p/python2.7/libpython2.7-dev_2.7.11-4_armhf.deb'
+PY_ARMHF2   = 'https://archive.raspbian.org/raspbian/pool/main/p/python2.7/libpython2.7-minimal_2.7.11-4_armhf.deb'
 
-
-   
 if len(argv)==1 and not os.path.exists(TOOLS_PATH):
    print """ERROR: Must supply "setupcrosscompiler" or path to where it is setup.
    Use one of the following:  
@@ -31,17 +33,14 @@ if len(argv)==1 and not os.path.exists(TOOLS_PATH):
    If not specified, setuppath is: %s""" % (argv[0], argv[0], TOOLS_PATH)
    exit(1)
 
-
 SetupPath = TOOLS_PATH
 if len(argv)==1:
    DoSetup = False
 else:
    DoSetup = argv[1]=='setupcrosscompiler'
-   
 
 if (DoSetup and len(argv)>2) or (not DoSetup and len(argv)>1):
    SetupPath = argv[-1]
-   
 
 
 def popen(cmdList, cwd=None):
@@ -95,7 +94,6 @@ if os.path.exists(instDir):
    shutil.rmtree(instDir)
 os.makedirs(instDir)
 
-
 ccbin = 'arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin/'
 cxx  = os.path.abspath(os.path.join(TOOLS_PATH,  ccbin, 'arm-linux-gnueabihf-g++'))
 cc   = os.path.abspath(os.path.join(TOOLS_PATH,  ccbin, 'arm-linux-gnueabihf-gcc'))
@@ -121,5 +119,3 @@ popen(['make', 'CXX='+cxx,
 
 popen(['make', 'install', 'DESTDIR=%s'%instDir])
 popen(['tar','-zcf', targz, 'usr'], cwd=instDir)
-
-


### PR DESCRIPTION
The script results are untested but it appears that this re-enables cross-builds. Build instructions are included.