### PR TITLE
Fix message signing and verifying

### DIFF
--- a/jasvet.py
+++ b/jasvet.py
@@ -636,7 +636,7 @@ def ASv0(privkey, msg):
 
 def ASv1CS(privkey, msg):
    sig=ASv0(privkey, FormatText(msg))
-   r=BEGIN_MARKER+CLEARSIGN_MSG_TYPE_MARKER+DASHX5+RN+BITCOIN_ARMORY_COMMENT+RNRN
+   r=BEGIN_MARKER+CLEARSIGN_MSG_TYPE_MARKER+DASHX5+RN+BITCOIN_ARMORY_COMMENT+RN
    r+=FormatText(msg)+RN
    r+=ASCIIArmory(sig['signature'], BITCOIN_SIG_TYPE_MARKER)
    return r

--- a/ui/toolsDialogs.py
+++ b/ui/toolsDialogs.py
@@ -15,7 +15,6 @@ from qtdefines import *
 from qtdialogs import MIN_PASSWD_WIDTH, DlgPasswd3, createAddrBookButton,\
    DlgUnlockWallet
 from armoryengine.ArmoryUtils import isASCII
-#from announcefetch import ANNOUNCE_SIGN_PUBKEY
 
 class MessageSigningVerificationDialog(ArmoryDialog):
 
@@ -220,31 +219,16 @@ class SignatureVerificationWidget(QWidget):
       self.lblSigResult.setText('')
       
    def displayVerifiedBox(self, addrB58, messageString):
-      atihash160 = hash160(hex_to_binary(ANNOUNCE_SIGN_PUBKEY))
-      addrDisp = addrB58
-      if addrB58==hash160_to_addrStr(atihash160):
-         addrDisp = '<b>Armory Technologies, Inc.</b>'
-         if CLI_OPTIONS.testAnnounceCode:
-            ownerStr = tr("""
-               <font color="%s"><b>Armory Technologies, Inc.
-               (testing key)</b></font> has signed the following
-               block of text:<br>""") % htmlColor('TextGreen')
-         else:
-            ownerStr = tr("""
-               <font color="%s"><b>Armory Technologies, Inc.</b></font> 
-               has signed the following block of text:<br>""") % \
-               htmlColor('TextGreen')
-      else:
-         ownerStr = tr("""
-         The owner of the following Bitcoin address...
-         <br>
-         <blockquote>
-         <font face="Courier" size=4 color="#000060"><b>%s</b></font>
-         </blockquote>
-         <br>
-         ... has produced a <b><u>valid</u></b> signature for 
-         the following message:<br>
-         """) % addrB58
+      ownerStr = tr("""
+      The owner of the following Bitcoin address...
+      <br>
+      <blockquote>
+      <font face="Courier" size=4 color="#000060"><b>%s</b></font>
+      </blockquote>
+      <br>
+      ... has produced a <b><u>valid</u></b> signature for
+      the following message:<br>
+      """) % addrB58
          
       if addrB58:
          msg = messageString.replace('\r\n','\n')
@@ -264,7 +248,7 @@ class SignatureVerificationWidget(QWidget):
             unless it is made
             from a recognized address!""") % (ownerStr, msg, addrB58[:10]))
          self.lblSigResult.setText(\
-            '<font color="green">Valid Signature by %s</font>' % addrDisp)
+            '<font color="green">Valid Signature by %s</font>' % addrB58)
       else:
          self.displayInvalidSignatureMessage()
 


### PR DESCRIPTION
Fixes Armory's message signing and verifying stuff to properly verify messages. I removed the stuff related to verifying signed messages from Armory which was breaking the code due to a variable not existing. I also removed one blank line from the Clearsign signed messages which fixes the verification problem with them.