### PR TITLE
Revert to system font if specified font not found on system

### DIFF
--- a/qtdefines.py
+++ b/qtdefines.py
@@ -201,7 +201,7 @@ def tightSizeNChar(obj, nChar):
    try:
       fm = QFontMetricsF(QFont(obj.font()))
    except AttributeError:
-      fm = QFontMetricsF(QFont(obj))
+      fm = QFontMetricsF(QFont())
    szWidth,szHeight = fm.boundingRect('abcfgijklm').width(), fm.height()
    szWidth = int(szWidth * nChar/10.0 + 0.5)
    return szWidth, szHeight
@@ -212,7 +212,7 @@ def tightSizeStr(obj, theStr):
    try:
       fm = QFontMetricsF(QFont(obj.font()))
    except AttributeError:
-      fm = QFontMetricsF(QFont(obj))
+      fm = QFontMetricsF(QFont())
    szWidth,szHeight = fm.boundingRect(theStr).width(), fm.height()
    return szWidth, szHeight
    
@@ -224,7 +224,7 @@ def relaxedSizeStr(obj, theStr):
    try:
       fm = QFontMetricsF(QFont(obj.font()))
    except AttributeError:
-      fm = QFontMetricsF(QFont(obj))
+      fm = QFontMetricsF(QFont())
    szWidth,szHeight = fm.boundingRect(theStr).width(), fm.height()
    return (10 + szWidth*1.05), 1.5*szHeight
 
@@ -236,7 +236,7 @@ def relaxedSizeNChar(obj, nChar):
    try:
       fm = QFontMetricsF(QFont(obj.font()))
    except AttributeError:
-      fm = QFontMetricsF(QFont(obj))
+      fm = QFontMetricsF(QFont())
    szWidth,szHeight = fm.boundingRect('abcfg ijklm').width(), fm.height()
    szWidth = int(szWidth * nChar/10.0 + 0.5)
    return (10 + szWidth*1.05), 1.5*szHeight

--- a/qtdialogs.py
+++ b/qtdialogs.py
@@ -8070,7 +8070,7 @@ class DlgAddressBook(ArmoryDialog):
          lblToAddr.setVisible(False)
 
 
-      rowHeight = tightSizeStr(self.font, 'XygjpHI')[1]
+      rowHeight = tightSizeStr(self.font(), 'XygjpHI')[1]
 
       self.wltDispModel = AllWalletsDispModel(self.main)
       self.wltDispView = QTableView()


### PR DESCRIPTION
In certain instances, if certain calls are given a font not found on the system, Armory attempts to revert to the system font. The call for the system font is incorrect. Patch fixes this problem.