### PR TITLE
Fix OS X build.

### DIFF
--- a/cppForSwig/BlockUtils.cpp
+++ b/cppForSwig/BlockUtils.cpp
@@ -702,7 +702,7 @@ private:
 ////
 ////////////////////////////////////////////////////////////////////////////////
 const string BlockDataManagerConfig::dbDirExtention_ = "/databases";
-#if defined(_WIN32) || defined(__APPLE__)
+#if defined(_WIN32)
 const string BlockDataManagerConfig::defaultDataDir_ = "~/Armory";
 const string BlockDataManagerConfig::defaultBlkFileLocation_ = "~/Bitcoin/blocks";
 
@@ -711,6 +711,15 @@ const string BlockDataManagerConfig::defaultTestnetBlkFileLocation_ = "~/Bitcoin
 
 const string BlockDataManagerConfig::defaultRegtestDataDir_ = "~/Armory/regtest";
 const string BlockDataManagerConfig::defaultRegtestBlkFileLocation_ = "~/Bitcoin/regtest/blocks";
+#elif defined(__APPLE__)
+const string BlockDataManagerConfig::defaultDataDir_ = "~/Library/Application Support/Armory";
+const string BlockDataManagerConfig::defaultBlkFileLocation_ = "~/Library/Application Support/Bitcoin/blocks";
+
+const string BlockDataManagerConfig::defaultTestnetDataDir_ = "~/Library/Application Support/Armory/testnet3";
+const string BlockDataManagerConfig::defaultTestnetBlkFileLocation_ = "~/Library/Application Support/Bitcoin/testnet3/blocks";
+
+const string BlockDataManagerConfig::defaultRegtestDataDir_ = "~/Library/Application Support/Armory/regtest";
+const string BlockDataManagerConfig::defaultRegtestBlkFileLocation_ = "~/Library/Application Support/Bitcoin/regtest/blocks";
 #else
 const string BlockDataManagerConfig::defaultDataDir_ = "~/.armory";
 const string BlockDataManagerConfig::defaultBlkFileLocation_ = "~/.bitcoin/blocks";

--- a/cppForSwig/CppBlockUtils.i
+++ b/cppForSwig/CppBlockUtils.i
@@ -36,10 +36,12 @@
 %typedef unsigned short     uint16_t;
 %typedef unsigned int       uint32_t;
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__WIN32__) || defined(__CYGWIN__)
 %typedef unsigned long long uint64_t;
 #else
+#if defined(__GNUC__) // Linux
 %typedef long unsigned int uint64_t;
+#endif
 #endif
 
 %typedef char               int8_t;

--- a/cppForSwig/FcgiMessage.cpp
+++ b/cppForSwig/FcgiMessage.cpp
@@ -9,6 +9,9 @@
 #include "FcgiMessage.h"
 #include <cstring>
 #include <stdexcept>
+#if defined(__APPLE__)
+#include <cstdlib>
+#endif
 
 ///////////////////////////////////////////////////////////////////////////////
 //

--- a/osxbuild/objc_armory/ArmoryMac.pro
+++ b/osxbuild/objc_armory/ArmoryMac.pro
@@ -20,8 +20,8 @@
 # macx-clang-libc++ option like Qt. (macx-g++ is all it can muster for now.)
 # NB: The "version" values must be updated alongside build-app.py!!!
 QTVER = 4.8.7
-SIPVER = 4.17
-PYVER = 2.7.11
+SIPVER = 4.18.1
+PYVER = 2.7.12
 QT_UNPACK_BASE = ../workspace/unpackandbuild/qt-everywhere-opensource-src-$${QTVER}
 SIP_UNPACK_BASE = ../workspace/unpackandbuild/sip-$${SIPVER}
 PYTHON_UNPACK_BASE = ../workspace/unpackandbuild/Python-$${PYVER}


### PR DESCRIPTION
- Fixed broken SWIG typedef for uint64_t (unsigned long long on OS X by default). This solution is slightly clunky but necessary due to how SWIG is set up (no OSX-specific macros, just Windows and __GNUC__ and GNUC-related macros).
- Ensure that rand() call doesn't cause an error.
- Fix up OS X build script to use various new bits of software and infrastructure, and fix a bug that prevented Armory from being built in some cases.
- Include ArmoryDB binary when compiling the Armory app.