### PR TITLE
Fix startup script to respect $(PREFIX) and launcher to use Python 2.

### DIFF
--- a/ArmoryQt.py
+++ b/ArmoryQt.py
@@ -1422,7 +1422,7 @@ class ArmoryMainWindow(QMainWindow):
 
          def setAsDefault():
             LOGINFO('Setting up Armory as default URI handler...')
-            execAndWait('gconftool-2 -t string -s /desktop/gnome/url-handlers/bitcoin/command "python /usr/lib/armory/ArmoryQt.py \"%s\""')
+            execAndWait('gconftool-2 -t string -s /desktop/gnome/url-handlers/bitcoin/command "python2 %s \"%%s\""' % __file__)
             execAndWait('gconftool-2 -s /desktop/gnome/url-handlers/bitcoin/needs_terminal false -t bool')
             execAndWait('gconftool-2 -t bool -s /desktop/gnome/url-handlers/bitcoin/enabled true')
             execAndWait('xdg-mime default armory.desktop x-scheme-handler/bitcoin')

--- a/dpkgfiles/armory
+++ b/dpkgfiles/armory
@@ -2,4 +2,4 @@
 
 unset CDPATH
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-exec python "$DIR"/../lib/armory/ArmoryQt.py "$@"
+exec python2 "$DIR"/../lib/armory/ArmoryQt.py "$@"

--- a/dpkgfiles/armory
+++ b/dpkgfiles/armory
@@ -1,2 +1,5 @@
-#!/bin/sh
-exec python /usr/lib/armory/ArmoryQt.py "$@"
+#!/bin/bash
+
+unset CDPATH
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+exec python "$DIR"/../lib/armory/ArmoryQt.py "$@"


### PR DESCRIPTION
Supersedes https://github.com/goatpig/BitcoinArmory/pull/52.