### PR TITLE
Add contributors.rb plugin from bitcoin.org

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+_cache
 _site
 .DS_Store
 .jekyll

--- a/_layouts/contribute.html
+++ b/_layouts/contribute.html
@@ -1,0 +1,25 @@
+---
+layout: default
+---
+
+<article class="page">
+
+  <h1>{{ page.title }}</h1>
+
+  <div class="entry">
+    {{ content }}
+    <section id="contributors">
+      <h2 id="bitcoin-core-contributors">{{ contributors }}</h2>
+      <p>{{ contributorsorder }}</p>
+      <div class="contributors">
+        {% for c in site.corecontributors %}
+        <div>
+          <div>{% if c.avatar_url %}<img src="{{c.avatar_url}}" alt="icon" />{% else %}<img alt="icon" />{% endif %}</div>
+          <div><a{% if c.login %} href="https://github.com/{{c.login}}"{% endif %}>{{ c.name | htmlescape }}</a></div>
+          <div>({{ c.contributions }})</div>
+        </div>
+        {% endfor %}
+      </div>
+    </section> 
+  </div>
+</article>

--- a/_plugins/contributors.rb
+++ b/_plugins/contributors.rb
@@ -1,0 +1,152 @@
+# This file is licensed under the MIT License (MIT) available on
+# http://opensource.org/licenses/MIT.
+
+#contributors.rb fetches Bitcoin Core contributors list and set
+#site.contributors array. This is later used to display the
+#list of contributors on the "Development" page.
+
+require 'open-uri'
+require 'json'
+
+module Jekyll
+
+  class CategoryGenerator < Generator
+
+    def contributors(repo, aliases)
+      contributors = []
+      # Call GitHub API with 100 results per page
+      page = 1
+      data = []
+      while page < 10 do
+        begin
+          ar = JSON.parse(open("https://api.github.com/repos/"+repo+"/contributors?page=#{page}&per_page=100","User-Agent"=>"Ruby/#{RUBY_VERSION}").read)
+        # Prevent any error to stop the build process, return an empty array instead
+        rescue
+          print 'GitHub API Call Failed!'
+          break
+        end
+        if !ar.is_a?(Array)
+          print 'GitHub API Call Failed!'
+          return contributors
+        end
+        if ar.length > 100
+          print 'GitHub API exceeding the 100 results limit!'
+          return contributors
+        end
+        # Stop calling GitHub API when no new results are returned
+        break if (ar.length == 0)
+        # Merge contributors into a single array
+        data.push(*ar)
+        page += 1
+      end
+      # Loop in returned results array
+      result = {}
+      for c in data
+        # Skip incomplete / invalid data and set contributor's name
+        next if !c.is_a?(Hash)
+        next if !c.has_key?('contributions') or !c['contributions'].is_a?(Integer) or c['contributions'] > 1000000
+        if c.has_key?('name') and c['name'].is_a?(String) and /^[A-Za-z0-9\-]{1,150}$/.match(c['name'])
+          name = c['name']
+        elsif c.has_key?('login') and c['login'].is_a?(String) and /^[A-Za-z0-9\-]{1,150}$/.match(c['login'])
+          name = c['login']
+        else
+          next
+        end
+        # Replace name by its corresponding alias if defined in _config.yml
+        name = aliases[name] if aliases.has_key?(name)
+        # Assign variables
+        x = {}
+        x['name'] = name
+        x['contributions'] = c['contributions']
+        # Set avatar_url when available
+        if c.has_key?('avatar_url') and c['avatar_url'].is_a?(String) and /^https:\/\/avatars\.githubusercontent\.com\/u\/[0-9]{1,10}\?v=[0-9]{1,2}$/.match(c['avatar_url'])
+          x['avatar_url'] = c['avatar_url'] + '&amp;size=16'
+        end
+        # Set login when available
+        if c.has_key?('login') and c['login'].is_a?(String) and /^[A-Za-z0-9\-]{1,150}$/.match(c['login'])
+          x['login'] = c['login']
+        end
+        # Add new contributor to the array, or increase contributions if it already exists
+        if result.has_key?(name)
+          result[name]['contributions'] += x['contributions']
+        else
+          result[name] = x
+        end
+      end
+      # Generate final ordered contributors array
+      result.each do |key, value|
+        contributors.push(value)
+      end
+      contributors.sort_by{|c| - c['contributions']}
+    end
+
+    def generate(site)
+      # Set site.contributors global variables for liquid/jekyll
+      class << site
+        attr_accessor :corecontributors
+        attr_accessor :sitecontributors
+        alias contrib_site_payload site_payload
+        def site_payload
+          h = contrib_site_payload
+          payload = h["site"]
+          payload["corecontributors"] = self.corecontributors
+          payload["sitecontributors"] = self.sitecontributors
+          h["site"] = payload
+          h
+        end
+      end
+
+      # Set site.corecontributors and site.sitecontributors arrays
+      site.corecontributors = {}
+      site.sitecontributors = {}
+
+      #Do nothing if plugin is disabled
+      if !ENV['ENABLED_PLUGINS'].nil? and ENV['ENABLED_PLUGINS'].index('contributors').nil?
+        print 'Contributors disabled' + "\n"
+        return
+      end
+
+      ## Create cache directory if it doesn't exist
+      if !File.exists?('_cache')
+        Dir.mkdir('_cache')
+      end
+
+      # Populate site.corecontributors and site.sitecontributors with
+      # data from GitHub.com. Store data in the cache and only
+      # re-retrieve the data if 86,400 seconds (24 hours) passes from
+      # the retrieval date or if the cache file is deleted.  For
+      # simplicity, updates on the two cache files are linked, so if one
+      # file has to be updated, they both get updated.
+      corecontributors_cache = '_cache/corecontributors.marshall'
+      sitecontributors_cache = '_cache/sitecontributors.marshall'
+      if File.exists?(corecontributors_cache) && File.exists?(sitecontributors_cache)
+        corecontributors_cache_age = (Time.now - File.stat(corecontributors_cache).mtime).to_i
+        sitecontributors_cache_age = (Time.now - File.stat(sitecontributors_cache).mtime).to_i
+      else
+        corecontributors_cache_age = Time.now.to_i
+        sitecontributors_cache_age = Time.now.to_i
+      end
+
+      if corecontributors_cache_age > 86400 || sitecontributors_cache_age > 86400
+        site.corecontributors = contributors('goatpig/BitcoinArmory',{})
+        File.open(corecontributors_cache,'w') do |file|
+          Marshal.dump(site.corecontributors, file)
+        end
+        site.sitecontributors = contributors('bitcoin-dot-org/bitcoin.org',{})
+        File.open(sitecontributors_cache,'w') do |file|
+          Marshal.dump(site.sitecontributors, file)
+        end
+      else
+        File.open(corecontributors_cache,'r') do |file|
+          site.corecontributors = Marshal.load(file)
+        end
+        File.open(sitecontributors_cache,'r') do |file|
+          site.sitecontributors = Marshal.load(file)
+        end
+      end
+
+    end
+
+  end
+
+end

--- a/contribute/contribute.md
+++ b/contribute/contribute.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: contribute
 title: Contribute
 permalink: /contribute/
 id: contribute
@@ -32,14 +32,3 @@ Armory and the Armory Website both will accept translations through Transifex. T
 ### Contributors
 
 Thank you to the following who have contributed to this project and the website
-
- - Alan Rainer (etotheipi)
- - Farhod Fathpour (goatpig)
- - Andy O'Fiesh (andyOfiesh)
- - Charles Samuels (njaard)
- - Douglas Roark (droark)
- - Jimmy Song (jimmysong)
- - Andrew Chow (achow101)
- - Michael Ford (fanquake)
- - James Hilliard (jameshilliard)
- - Jeffery Lin (AnAverageHuman)

--- a/style.scss
+++ b/style.scss
@@ -366,6 +366,34 @@ footer {
 	font-weight: 700;
 }
 
+//
+// .contributors
+//
+
+.contributors div {
+	display:inline-block;
+	overflow: hidden;
+	padding:8px 0;
+	vertical-align:top;
+	width:215px;
+}
+
+.contributors div div {
+	padding: 0;
+	width: auto;
+}
+
+.contributors div div:first-child+div {
+	max-width: 150px;
+	margin: 0 2px;
+	white-space: nowrap;
+}
+
+.contributors img {
+	width:16px;
+	height:16px;
+}
+
 // Settled on moving the import of syntax highlighting to the bottom of the CSS
 // ... Otherwise it really bloats up the top of the CSS file and makes it difficult to find the start
 @import "highlights";


### PR DESCRIPTION
Does not make use of aliases feature to replace GitHub usernames with real names. Styled essentially the same as the bitcoin.org version.