### PR TITLE
Transifex URL updated

### DIFF
--- a/_posts/2016-8-17-transifex.md
+++ b/_posts/2016-8-17-transifex.md
@@ -7,4 +7,4 @@ date: 2016-08-27 21:20:00 -0500
 
 Armory is now accepting Transifex translations to allow for future multi-language support. There will also be Transifex translations for the website coming soon.
 
-Please help us translate at https://transifex.com/bitcoin-armory
+Please help us translate at https://www.transifex.com/bitcoin-armory/public/


### PR DESCRIPTION
The Transifex URL doesn't seem to work (gives a 404), when you're not part of the Transifex team. Postfix with "/public" and it works for me.