### PR TITLE
Typos in some user-facing strings corrected.

### DIFF
--- a/ArmoryQt.py
+++ b/ArmoryQt.py
@@ -870,7 +870,7 @@ class ArmoryMainWindow(QMainWindow):
       if not CLI_OPTIONS.satoshiHome in [BTC_HOME_DIR, DEFAULT]:
          QMessageBox.warning(self, tr('Bitcoin Directory'), tr("""
             Armory is using the default Bitcoin directory because
-            the Bitcoin director specified in the command line, could
+            the Bitcoin directory specified in the command line, could
             not be found."""), QMessageBox.Ok)
          
       if not self.getSettingOrSetDefault('DNAA_DeleteLevelDB', False) and \
@@ -1160,7 +1160,7 @@ class ArmoryMainWindow(QMainWindow):
          be cleared allowing you to retry any stuck transactions.""")
       if not self.doAutoBitcoind:
          msg += tr("""
-         <br><br>Make sure you also restart Bitcoin-Core
+         <br><br>Make sure you also restart Bitcoin Core
          (or bitcoind) and let it synchronize again before you restart
          Armory.  Doing so will clear its memory pool, as well""")
       QMessageBox.information(self, tr('Memory Pool'), msg, QMessageBox.Ok)
@@ -2045,7 +2045,7 @@ class ArmoryMainWindow(QMainWindow):
    #             if not self.NetworkingFactory:
    #                return
    #
-   #             # This is to detect the running versions of Bitcoin-Core/bitcoind
+   #             # This is to detect the running versions of Bitcoin Core/bitcoind
    #             if self.NetworkingFactory.getProto():
    #                thisVerStr = self.NetworkingFactory.getProto().peerInfo['subver']
    #                thisVerStr = thisVerStr.strip('/').split(':')[-1]
@@ -2302,7 +2302,7 @@ class ArmoryMainWindow(QMainWindow):
       if not satoshiIsAvailable():
          reply = MsgBoxCustom(MSGBOX.Question, tr('BitTorrent Option'), tr("""
             You are currently configured to run the core Bitcoin software
-            yourself (Bitcoin-Core or bitcoind).  <u>Normally</u>, you should
+            yourself (Bitcoin Core or bitcoind).  <u>Normally</u>, you should
             start the Bitcoin software first and wait for it to synchronize
             with the network before starting Armory.
             <br><br>
@@ -2317,16 +2317,16 @@ class ArmoryMainWindow(QMainWindow):
             software until after it is complete.
             <br><br>
             <u>To synchronize using Bitcoin P2P (fallback):</u>
-            Click "Cancel" below, then close Armory and start Bitcoin-Core
+            Click "Cancel" below, then close Armory and start Bitcoin Core
             (or bitcoind).  Do not start Armory until you see a green checkmark
-            in the bottom-right corner of the Bitcoin-Core window."""), \
+            in the bottom-right corner of the Bitcoin Core window."""), \
             wCancel=True, yesStr='Use BitTorrent')
 
          if not reply:
             QMessageBox.warning(self, tr('Synchronize'), tr("""
                When you are ready to start synchronization, close Armory and
-               start Bitcoin-Core or bitcoind.  Restart Armory only when
-               synchronization is complete.  If using Bitcoin-Core, you will see
+               start Bitcoin Core or bitcoind.  Restart Armory only when
+               synchronization is complete.  If using Bitcoin Core, you will see
                a green checkmark in the bottom-right corner"""), QMessageBox.Ok)
             return False
 
@@ -2334,7 +2334,7 @@ class ArmoryMainWindow(QMainWindow):
          reply = MsgBoxCustom(MSGBOX.Question, tr('BitTorrent Option'), tr("""
             You are currently running the core Bitcoin software, but it
             is not fully synchronized with the network, yet.  <u>Normally</u>,
-            you should close Armory until Bitcoin-Core (or bitcoind) is
+            you should close Armory until Bitcoin Core (or bitcoind) is
             finished
             <br><br>
             <b><u>However</u></b>, Armory can speed up this initial
@@ -2350,7 +2350,7 @@ class ArmoryMainWindow(QMainWindow):
             <br><br>
             <u>To synchronize using Bitcoin P2P (fallback):</u>
             Click "Cancel" below, and then close Armory until the Bitcoin
-            software is finished synchronizing.  If using Bitcoin-Core, you
+            software is finished synchronizing.  If using Bitcoin Core, you
             will see a green checkmark in the bottom-right corner of the
             main window."""), QMessageBox.Ok)
 
@@ -2365,7 +2365,7 @@ class ArmoryMainWindow(QMainWindow):
             QMessageBox.warning(self, tr('Synchronize'), tr("""
                You chose to finish synchronizing with the network using
                the Bitcoin software which is already running.  Please close
-               Armory until it is finished.  If you are running Bitcoin-Core,
+               Armory until it is finished.  If you are running Bitcoin Core,
                you will see a green checkmark in the bottom-right corner,
                when it is time to open Armory again."""), QMessageBox.Ok)
             return False
@@ -2543,7 +2543,7 @@ class ArmoryMainWindow(QMainWindow):
                return
 
             try:
-               self.showTrayMsg('Disconnected', 'Connection to Bitcoin-Core ' \
+               self.showTrayMsg('Disconnected', 'Connection to Bitcoin Core ' \
 			                    'client lost!  Armory cannot send nor ' \
 								'receive bitcoins until connection is ' \
 								're-established.', QSystemTrayIcon.Critical, \
@@ -2564,7 +2564,7 @@ class ArmoryMainWindow(QMainWindow):
 
             try:
                if self.connectCount>0:
-                  self.showTrayMsg('Connected', 'Connection to Bitcoin-Core ' \
+                  self.showTrayMsg('Connected', 'Connection to Bitcoin Core ' \
                                    're-established', \
 								   QSystemTrayIcon.Information, 10000)
                self.connectCount += 1
@@ -4288,8 +4288,8 @@ class ArmoryMainWindow(QMainWindow):
       elif self.doAutoBitcoind and not TheSDM.isRunningBitcoind():
          if satoshiIsAvailable():
             result = QMessageBox.warning(self, tr('Still Running'), tr("""
-               'Bitcoin-Core is still running.  Armory cannot start until
-               'it is closed.  Do you want Armory to close it for you?"""), \
+               Bitcoin Core is still running.  Armory cannot start until
+               it is closed.  Do you want Armory to close it for you?"""), \
                QMessageBox.Yes | QMessageBox.No)
             if result==QMessageBox.Yes:
                self.closeExistingBitcoin()
@@ -4464,16 +4464,16 @@ class ArmoryMainWindow(QMainWindow):
 
       self.dashBtns[DASHBTNS.Browse][TTIP] = self.createToolTipWidget( \
            'Will open your default browser to https://bitcoin.org where you can '
-           'download the latest version of Bitcoin-Core, and get other information '
+           'download the latest version of Bitcoin Core, and get other information '
            'and links about Bitcoin, in general.')
       self.dashBtns[DASHBTNS.Instruct][TTIP] = self.createToolTipWidget( \
            'Instructions are specific to your operating system and include '
            'information to help you verify you are installing the correct software')
       self.dashBtns[DASHBTNS.Settings][TTIP] = self.createToolTipWidget(
-           'Change Bitcoin-Core/bitcoind management settings or point Armory to '
+           'Change Bitcoin Core/bitcoind management settings or point Armory to '
            'a non-standard Bitcoin installation')
       self.dashBtns[DASHBTNS.Close][TTIP] = self.createToolTipWidget( \
-           'Armory has detected a running Bitcoin-Core or bitcoind instance and '
+           'Armory has detected a running Bitcoin Core or bitcoind instance and '
            'will force it to exit')
 
       self.dashBtns[DASHBTNS.Install][BTN].setEnabled(False)
@@ -4506,7 +4506,7 @@ class ArmoryMainWindow(QMainWindow):
             self.dashBtns[DASHBTNS.Install][LBL] = QRichLabel( tr("""
                Download and Install Bitcoin Core for Ubuntu/Debian"""))
             self.dashBtns[DASHBTNS.Install][TTIP] = self.createToolTipWidget( tr("""
-               'Will download and Bitcoin software and cryptographically verify it"""))
+               Will download Bitcoin software and cryptographically verify it"""))
       elif OS_MACOSX:
          pass
       else:
@@ -4917,7 +4917,7 @@ class ArmoryMainWindow(QMainWindow):
 
       # If got here, never found it
       QMessageBox.warning(self, 'Not Found', \
-         'Attempted to kill the running Bitcoin-Core/bitcoind instance, '
+         'Attempted to kill the running Bitcoin Core/bitcoind instance, '
          'but it was not found.  ', QMessageBox.Ok)
 
    #############################################################################
@@ -5284,10 +5284,10 @@ class ArmoryMainWindow(QMainWindow):
       elif state == 'OnlineFull2':
          return ( \
          (tr('If you experience any performance issues with Armory, '
-         'please confirm that Bitcoin-Core is running and <i>fully '
+         'please confirm that Bitcoin Core is running and <i>fully '
          'synchronized with the Bitcoin network</i>.  You will see '
          'a green checkmark in the bottom right corner of the '
-         'Bitcoin-Core window if it is synchronized.  If not, it is '
+         'Bitcoin Core window if it is synchronized.  If not, it is '
          'recommended you close Armory and restart it only when you '
          'see that checkmark.'
          '<br><br>')  if not self.doAutoBitcoind else '') + tr(
@@ -5335,7 +5335,7 @@ class ArmoryMainWindow(QMainWindow):
          'then you can restart Armory with the "--skip-online-check" '
          'option, or change it in the Armory settings.'
          '<br><br>'
-         'If you do not have Bitcoin-Core installed, you can '
+         'If you do not have Bitcoin Core installed, you can '
          'download it from <a href="https://bitcoin.org">'
          'https://bitcoin.org</a>.')
 
@@ -5349,9 +5349,9 @@ class ArmoryMainWindow(QMainWindow):
             'You are currently in offline mode, but can '
             'switch to online mode by pressing the button above.  However, '
             'it is not recommended that you switch until '
-            'Bitcoin-Core/bitcoind is fully synchronized with the bitcoin network.  '
+            'Bitcoin Core/bitcoind is fully synchronized with the bitcoin network.  '
             'You will see a green checkmark in the bottom-right corner of '
-            'the Bitcoin-Core window when it is finished.'
+            'the Bitcoin Core window when it is finished.'
             '<br><br>'
             'Switching to online mode will give you access '
             'to more Armory functionality, including sending and receiving '
@@ -5361,10 +5361,10 @@ class ArmoryMainWindow(QMainWindow):
             bitconf = os.path.join(BTC_HOME_DIR, 'bitcoin.conf')
             return tr( \
             'You are currently in offline mode because '
-            'Bitcoin-Core is not running.  To switch to online '
-            'mode, start Bitcoin-Core and let it synchronize with the network '
+            'Bitcoin Core is not running.  To switch to online '
+            'mode, start Bitcoin Core and let it synchronize with the network '
             '-- you will see a green checkmark in the bottom-right corner when '
-            'it is complete.  If Bitcoin-Core is already running and you believe '
+            'it is complete.  If Bitcoin Core is already running and you believe '
             'the lack of connection is an error (especially if using proxies), '
             'please see <a href="'
             'https://bitcointalk.org/index.php?topic=155717.msg1719077#msg1719077">'
@@ -5372,10 +5372,10 @@ class ArmoryMainWindow(QMainWindow):
             '<br><br>'
             '<b>If you prefer to have Armory do this for you</b>, '
             'then please check "Let Armory run '
-            'Bitcoin-Core in the background" under "File"->"Settings."'
+            'Bitcoin Core in the background" under "File"->"Settings."'
             '<br><br>'
             'If you already know what you\'re doing and simply need '
-            'to fetch the latest version of Bitcoin-Core, you can download it from '
+            'to fetch the latest version of Bitcoin Core, you can download it from '
             '<a href="https://bitcoin.org">https://bitcoin.org</a>.')
          elif state == 'OfflineNoInternet':
             return tr( \
@@ -5386,13 +5386,13 @@ class ArmoryMainWindow(QMainWindow):
             'or adjust the Armory settings.  Then restart Armory.'
             '<br><br>'
             'If this is intended to be an offline computer, note '
-            'that it is not necessary to have Bitcoin-Core or bitcoind '
+            'that it is not necessary to have Bitcoin Core or bitcoind '
             'running.' )
          elif state == 'OfflineNoBlkFiles':
             return tr( \
             'You are currently in offline mode because '
             'Armory could not find the blockchain files produced '
-            'by Bitcoin-Core.  Do you run Bitcoin-Core (or bitcoind) '
+            'by Bitcoin Core.  Do you run Bitcoin Core (or bitcoind) '
             'from a non-standard directory?   Armory expects to '
             'find the blkXXXX.dat files in <br><br>%s<br><br> '
             'If you know where they are located, please restart '
@@ -5400,13 +5400,13 @@ class ArmoryMainWindow(QMainWindow):
             'to notify Armory where to find them.') % BLKFILE_DIR
          elif state == 'Disconnected':
             return tr( \
-            'Armory was previously online, but the connection to Bitcoin-Core/'
+            'Armory was previously online, but the connection to Bitcoin Core/'
             'bitcoind was interrupted.  You will not be able to send bitcoins '
             'or confirm receipt of bitcoins until the connection is '
-            'reestablished.  <br><br>Please check that Bitcoin-Core is open '
+            'reestablished.  <br><br>Please check that Bitcoin Core is open '
             'and synchronized with the network.  Armory will <i>try to '
             'reconnect</i> automatically when the connection is available '
-            'again.  If Bitcoin-Core is available again, and reconnection does '
+            'again.  If Bitcoin Core is available again, and reconnection does '
             'not happen, please restart Armory.<br><br>')
          elif state == 'ScanNoWallets':
             return tr( \
@@ -5427,7 +5427,7 @@ class ArmoryMainWindow(QMainWindow):
          if state == 'OfflineBitcoindRunning':
             return tr( \
             'It appears you are already running Bitcoin software '
-            '(Bitcoin-Core or bitcoind). '
+            '(Bitcoin Core or bitcoind). '
             'Unlike previous versions of Armory, you should <u>not</u> run '
             'this software yourself --  Armory '
             'will run it in the background for you.  Either close the '
@@ -5527,7 +5527,7 @@ class ArmoryMainWindow(QMainWindow):
             return tr( \
             'The Bitcoin software indicates there '
             'is a problem with its databases.  This can occur when '
-            'Bitcoin-Core/bitcoind is upgraded or downgraded, or sometimes '
+            'Bitcoin Core/bitcoind is upgraded or downgraded, or sometimes '
             'just by chance after an unclean shutdown.'
             '<br><br>'
             'You can either revert your installed Bitcoin software to the '
@@ -5551,8 +5551,8 @@ class ArmoryMainWindow(QMainWindow):
                return  (tr("""
                There was an error starting the underlying Bitcoin engine.
                This should not normally happen.  Usually it occurs when you
-               have been using Bitcoin-Core prior to using Armory, especially
-               if you have upgraded or downgraded Bitcoin-Core recently.
+               have been using Bitcoin Core prior to using Armory, especially
+               if you have upgraded or downgraded Bitcoin Core recently.
                Output from bitcoind:<br>""") + \
                (soutDisp if len(sout)>0 else '') + \
                (serrDisp if len(serr)>0 else '') )
@@ -5560,8 +5560,8 @@ class ArmoryMainWindow(QMainWindow):
                return ( tr("""
                   There was an error starting the underlying Bitcoin engine.
                   This should not normally happen.  Usually it occurs when you
-                  have been using Bitcoin-Core prior to using Armory, especially
-                  if you have upgraded or downgraded Bitcoin-Core recently.
+                  have been using Bitcoin Core prior to using Armory, especially
+                  if you have upgraded or downgraded Bitcoin Core recently.
                   <br><br>
                   Unfortunately, this error is so strange, Armory does not
                   recognize it.  Please go to "Export Log File" from the "File"
@@ -5701,7 +5701,7 @@ class ArmoryMainWindow(QMainWindow):
                if satoshiIsAvailable() or sdmState=='BitcoindAlreadyRunning':
                   # But bitcoind/-qt is already running
                   LOGINFO('Dashboard switched to auto-butSatoshiRunning')
-                  self.lblDashModeSync.setText(tr(' Please close Bitcoin-Core'), \
+                  self.lblDashModeSync.setText(tr(' Please close Bitcoin Core'), \
                                                          size=4, bold=True)
                   setBtnFrameVisible(True, '')
                   setBtnRowVisible(DASHBTNS.Close, True)
@@ -5898,7 +5898,7 @@ class ArmoryMainWindow(QMainWindow):
                   setBtnRowVisible(DASHBTNS.Settings, True)
                   setBtnFrameVisible(True, \
                      tr('If you would like Armory to manage the Bitcoin software '
-                     'for you (Bitcoin-Core or bitcoind), then adjust your '
+                     'for you (Bitcoin Core or bitcoind), then adjust your '
                      'Armory settings, then restart Armory.'))
                   descr = self.GetDashStateText('User','OfflineNoSatoshiNoInternet')
                else:

--- a/qtdialogs.py
+++ b/qtdialogs.py
@@ -2861,7 +2861,7 @@ class DlgImportAddress(ArmoryDialog):
                      'has access to it.  Otherwise, sweep it to get '
                      'the funds out of it.  All standard private-key formats '
                      'are supported <i>except for private keys created by '
-                     'Bitcoin-Core version 0.6.0 and later (compressed)</i>.')
+                     'Bitcoin Core version 0.6.0 and later (compressed)</i>.')
 
       lblPrivOne = QRichLabel('Private Key')
       self.edtPrivData = QLineEdit()
@@ -3081,7 +3081,7 @@ class DlgImportAddress(ArmoryDialog):
       except CompressedKeyError, e:
          QMessageBox.critical(self, 'Unsupported key type', 'You entered a key '
             'for an address that uses a compressed public key, usually produced '
-            'in Bitcoin-Core/bitcoind wallets created after version 0.6.0.  Armory '
+            'in Bitcoin Core/bitcoind wallets created after version 0.6.0.  Armory '
             'does not yet support this key type.')
          LOGERROR('Compressed key data recognized but not supported')
          return
@@ -7525,13 +7525,13 @@ class DlgBadConnection(ArmoryDialog):
             'restart Armory.<br><br>Would you like to continue in "Offline" mode? ')
       elif haveInternet and not haveSatoshi:
          lblDescr = QRichLabel(\
-            'Armory was not able to detect the presence of Bitcoin-Core or bitcoind '
+            'Armory was not able to detect the presence of Bitcoin Core or bitcoind '
             'client software (available at https://bitcoin.org).  Please make sure that '
             'the one of those programs is... <br>'
             '<br><b>(1)</b> ...open and connected to the network '
             '<br><b>(2)</b> ...on the same network as Armory (main-network or test-network)'
             '<br><b>(3)</b> ...synchronized with the blockchain before '
-            'starting Armory<br><br>Without the Bitcoin-Core or bitcoind open, you will only '
+            'starting Armory<br><br>Without the Bitcoin Core or bitcoind open, you will only '
             'be able to run Armory in "Offline" mode, which will not have access '
             'to new blockchain data, and you will not be able to send outgoing '
             'transactions<br><br>If you do not want to be in "Offline" mode, please '
@@ -8673,7 +8673,7 @@ class DlgSettings(ArmoryDialog):
       ##########################################################################
       # bitcoind-management settings
       self.chkManageSatoshi = QCheckBox(tr("""
-         Let Armory run Bitcoin-Core/bitcoind in the background"""))
+         Let Armory run Bitcoin Core/bitcoind in the background"""))
       self.edtSatoshiExePath = QLineEdit()
       self.edtSatoshiHomePath = QLineEdit()
       self.edtSatoshiExePath.setMinimumWidth(tightSizeNChar(GETFONT('Fixed', 10), 40)[0])
@@ -8684,7 +8684,7 @@ class DlgSettings(ArmoryDialog):
       if OS_MACOSX:
          self.chkManageSatoshi.setEnabled(False)
          lblManageSatoshi = QRichLabel(\
-            'Bitcoin-Core/bitcoind management is not available on Mac/OSX')
+            'Bitcoin Core/bitcoind management is not available on Mac/OSX')
       else:
          if self.main.settings.hasSetting('SatoshiExe'):
             satexe = self.main.settings.get('SatoshiExe')
@@ -8928,8 +8928,8 @@ class DlgSettings(ArmoryDialog):
       lblNotify = QRichLabel('<b>Enable notifications from the system-tray:</b>')
       self.chkBtcIn = QCheckBox('Bitcoins Received')
       self.chkBtcOut = QCheckBox('Bitcoins Sent')
-      self.chkDiscon = QCheckBox('Bitcoin-Core/bitcoind disconnected')
-      self.chkReconn = QCheckBox('Bitcoin-Core/bitcoind reconnected')
+      self.chkDiscon = QCheckBox('Bitcoin Core/bitcoind disconnected')
+      self.chkReconn = QCheckBox('Bitcoin Core/bitcoind reconnected')
 
       # FYI:If we're not on OS X, the if condition will never be hit.
       if (OS_MACOSX) and (int(osxMinorVer) < 7):
@@ -9259,7 +9259,7 @@ class DlgSettings(ArmoryDialog):
                QMessageBox.warning(self, 'Invalid Path', \
                   'The path you specified for the Bitcoin software home directory '
                   'does not exist.  Only specify this directory if you use a '
-                  'non-standard "-datadir=" option when running Bitcoin-Core or '
+                  'non-standard "-datadir=" option when running Bitcoin Core or '
                   'bitcoind.  If you leave this field blank, the following '
                   'path will be used: <br><br> %s' % BTC_HOME_DIR, QMessageBox.Ok)
                return
@@ -10660,7 +10660,7 @@ class DlgInstallLinux(ArmoryDialog):
 
 
       lblOptions = QRichLabel(\
-         'If you have manually installed Bitcoin-Core or bitcoind on this system '
+         'If you have manually installed Bitcoin Core or bitcoind on this system '
          'before, it is recommended you use the method here you previously used.  '
          'If you get errors using this option, try using the manual instructions '
          'below.')
@@ -10836,7 +10836,7 @@ class DlgInstallLinux(ArmoryDialog):
       if len(fileData) == 0 or dlg.dlVerifyFailed:
          QMessageBox.critical(self, 'Download Failed', \
             'The download failed.  Please visit https://bitcoin.org '
-            'to download and install Bitcoin-Core manually.', QMessageBox.Ok)
+            'to download and install Bitcoin Core manually.', QMessageBox.Ok)
          import webbrowser
          webbrowser.open('https://bitcoin.org/en/download')
          return
@@ -11576,7 +11576,7 @@ class DlgWODataPrintBackup(ArmoryDialog):
          <b><font size=4><font color="#aa0000">WARNING:</font>  <u>This is not 
          a wallet backup!</u></font></b>  
          <br><br>Please make a regular digital or paper backup of your wallet 
-         of your wallet to keep it protected!  This data simply lets you 
+         to keep it protected!  This data simply lets you 
          monitor the funds in this wallet but gives you no ability to move any 
          funds.""")
       self.scene.drawText(warnMsg, GETFONT('Var', 9), wrapWidth=wrap)
@@ -12404,7 +12404,7 @@ class DlgRestoreSingle(ArmoryDialog):
             return
       if self.chkEncrypt.isChecked() and self.advancedOptionsTab.getKdfBytes() == -1:
             QMessageBox.critical(self, tr('Invalid Max Memory Usage'), \
-               tr('You entered Max Memory Usage incorrectly.\n\nnter: <Number> (kb, mb)'), QMessageBox.Ok)
+               tr('You entered Max Memory Usage incorrectly.\n\nEnter: <Number> (kB, MB)'), QMessageBox.Ok)
             return
       if nError > 0:
          pluralStr = 'error' if nError == 1 else 'errors'
@@ -14626,7 +14626,7 @@ class DlgFactoryReset(ArmoryDialog):
          It is <i>strongly</i> recommended that you make backups of your
          wallets before continuing, though <b>wallet files will never be
          intentionally deleted!</b>  All Armory
-         wallet files, and the wallet.dat file used by Bitcoin-Core/bitcoind
+         wallet files, and the wallet.dat file used by Bitcoin Core/bitcoind
          should remain untouched in their current locations.  All Armory
          wallets will automatically be detected and loaded after the reset.
          <br><br>
@@ -14655,7 +14655,7 @@ class DlgFactoryReset(ArmoryDialog):
          <b>Also re-download the blockchain (most extreme)</b>"""))
       self.lblBitcoinDB = QRichLabel(tr("""
          This will delete settings, network data, Armory's databases,
-         <b>and</b> the Bitcoin software databases.  Bitcoin-Core/bitcoind will
+         <b>and</b> the Bitcoin software databases.  Bitcoin Core/bitcoind will
          have to download the blockchain again.  Only use this if you
          suspect blockchain corruption, such as receiving StdOut/StdErr errors
          on the dashboard (8-72 hours depending on your connection)"""))
@@ -14780,11 +14780,11 @@ class DlgFactoryReset(ArmoryDialog):
          if not self.main.settings.get('ManageSatoshi'):
             # Must have user shutdown Bitcoin sw now, and delete DBs now
             reply = MsgBoxCustom(MSGBOX.Warning, tr('Restart Armory'), tr("""
-               <b>Bitcoin-Core (or bitcoind) must be closed to do the reset!</b>
+               <b>Bitcoin Core (or bitcoind) must be closed to do the reset!</b>
                Please close all Bitcoin software, <u><b>right now</b></u>,
                before clicking "Continue".
                <br><br>
-               Armory will now close.  Please restart Bitcoin-Core/bitcoind
+               Armory will now close.  Please restart Bitcoin Core/bitcoind
                first and wait for it to finish synchronizing before restarting
                Armory."""), wCancel=True, yesStr="Continue")
 


### PR DESCRIPTION
Most corrections are "Bitcoin-Core" -> "Bitcoin Core", but a handful of others hide among these.