### PR TITLE
Enable rpc calls to bitcoind even when not managing it

### DIFF
--- a/ArmoryQt.py
+++ b/ArmoryQt.py
@@ -2212,6 +2212,8 @@ class ArmoryMainWindow(QMainWindow):
    def startBitcoindIfNecessary(self):
       LOGINFO('startBitcoindIfNecessary')
 
+      TheSDM.checkClientIsLocal()
+
       if self.internetStatus == INTERNET_STATUS.Unavailable or \
          CLI_OPTIONS.offline:
          LOGWARN('Not online, will not start bitcoind')

--- a/ArmoryQt.py
+++ b/ArmoryQt.py
@@ -2218,6 +2218,8 @@ class ArmoryMainWindow(QMainWindow):
          return False
 
       if TheBDM.hasRemoteDB() or not self.doAutoBitcoind:
+         self.setSatoshiPaths()
+         TheSDM.setupManualSDM()
          self.notifyBitcoindIsReady()
          return False
 

--- a/SDM.py
+++ b/SDM.py
@@ -152,6 +152,10 @@ class SatoshiDaemonManager(object):
    def setupSDM(self, pathToBitcoindExe=None, satoshiHome=None, \
                       extraExeSearch=[], createHomeIfDNE=True):
       LOGDEBUG('Exec setupSDM')
+      # If the client is remote, don't do anything.
+      if not self.localClient:
+         LOGWARN("No SDM since the client is remote")
+         return
 
       self.failedFindExe = False
       self.failedFindHome = False
@@ -205,6 +209,10 @@ class SatoshiDaemonManager(object):
    #############################################################################
    def setupManualSDM(self):
       LOGDEBUG('Exec setupManualSDM')
+      # If the client is remote, don't do anything.
+      if not self.localClient:
+         LOGWARN("No SDM since the client is remote")
+         return
 
       # Setup bitcoind stuff
       self.bitcoind = False
@@ -219,6 +227,13 @@ class SatoshiDaemonManager(object):
          LOGDEBUG("bitcoind rpc is not actually availalbe")
          self.bitcoind = None
          self.proxy = None
+
+   #############################################################################
+   def checkClientIsLocal(self):
+      if ARMORYDB_IP != ARMORYDB_DEFAULT_IP or ARMORYDB_PORT != ARMORYDB_DEFAULT_PORT:
+         self.localClient = False
+      else:
+         self.localClient = True
 
    #############################################################################
    def setDisabled(self, newBool=True):

--- a/SDM.py
+++ b/SDM.py
@@ -201,6 +201,21 @@ class SatoshiDaemonManager(object):
       self.readBitcoinConf(makeIfDNE=True)
 
    #############################################################################
+   def setupManualSDM(self):
+      LOGDEBUG('Exec setupManualSDM')
+      self.bitcoind = False
+      self.readBitcoinConf()
+
+      # Check bitcoind is actually up. If it is not, remove self.bitcoind
+      self.createProxy()
+      try:
+         self.proxy.getinfo()
+      except:
+         LOGDEBUG("bitcoind rpc is not actually availalbe")
+         self.bitcoind = None
+         self.proxy = None
+
+   #############################################################################
    def setDisabled(self, newBool=True):
       s = self.getSDMState()
 
@@ -543,6 +558,9 @@ class SatoshiDaemonManager(object):
    #############################################################################
    def stopBitcoind(self):
       LOGINFO('Called stopBitcoind')
+      if self.bitcoind == False:
+         self.bitcoind = None
+         return
       try:
          if not self.isRunningBitcoind():
                LOGINFO('...but bitcoind is not running, to be able to stop')
@@ -580,6 +598,9 @@ class SatoshiDaemonManager(object):
       """
       if self.bitcoind==None:
          return False
+      # Assume Bitcoind is running if manually started
+      if self.bitcoind==False:
+         return True
       else:
          if not self.bitcoind.poll()==None:
             LOGDEBUG('Bitcoind is no more')

--- a/bitcoinrpc_jsonrpc/authproxy.py
+++ b/bitcoinrpc_jsonrpc/authproxy.py
@@ -41,6 +41,7 @@ except ImportError:
 import base64
 import json
 import decimal
+import urllib
 try:
     import urllib.parse as urlparse
 except ImportError:
@@ -65,7 +66,7 @@ class AuthServiceProxy(object):
         else:
             port = self.__url.port
         self.__idcnt = 0
-        authpair = "%s:%s" % (self.__url.username, self.__url.password)
+        authpair = "%s:%s" % (self.__url.username, urllib.unquote(self.__url.password))
         authpair = unicode(authpair, 'utf-8').encode('utf-8')
         self.__authhdr = "Basic ".encode('utf8') + base64.b64encode(authpair)
         if self.__url.scheme == 'https':

--- a/ui/TxFrames.py
+++ b/ui/TxFrames.py
@@ -14,7 +14,7 @@ from qtdefines import * #@UnusedWildImport
 from armoryengine.Transaction import UnsignedTransaction, getTxOutScriptType
 from armoryengine.Script import convertScriptToOpStrings
 from armoryengine.CoinSelection import PySelectCoins, calcMinSuggestedFees,\
-   calcMinSuggestedFeesHackMS, PyUnspentTxOut, estimateTxSize
+   calcMinSuggestedFeesHackMS, PyUnspentTxOut, estimateTxSize, estimateFee
 from ui.WalletFrames import SelectWalletFrame, LockboxSelectFrame
 from armoryengine.MultiSigUtils import \
       calcLockboxID, readLockboxEntryStr, createLockboxEntryStr, isBareLockbox,\
@@ -330,7 +330,7 @@ class SendBitcoinsFrame(ArmoryFrame):
    def perSatFChecked(self):
       self.radioFlatFee.setChecked(False)
       self.radioPerSatF.setChecked(True)
-      self.edtFeeAmt.setText(QString('0'))      
+      self.edtFeeAmt.setText(QString(str(estimateFee() / 1000.0)))
 
    #############################################################################
    def unsignedCheckBoxUpdate(self):


### PR DESCRIPTION
This enables Armory to send rpc calls to bitcoin even when it is not managing the bitcoind. This enables more functionality like estimateFee when Armory is not managing bitcoind.

This also changes Armory to use bitcoind's cookie auth by default instead of rpcuser and rpcpassword. rpcuser and rpcpassword will still work if they are set. This authentication mode has been deprecated by Bitcoin Core.