### PR TITLE
Fix ArmoryDB path

### DIFF
--- a/SDM.py
+++ b/SDM.py
@@ -147,7 +147,7 @@ class SatoshiDaemonManager(object):
       path = os.path.dirname(os.path.abspath(__file__))
       if OS_MACOSX:
          # OSX separates binaries/start scripts from the Python code. Back up!
-         path = os.path.join(path, '../../../../')
+         path = os.path.join(path, '../../bin/')
       self.dbExecutable = os.path.join(path, 'ArmoryDB')  
          
       if OS_WINDOWS:


### PR DESCRIPTION
The path somehow got changed before the latest merge was added. Fix the path. (It might be more pertinent to just fix the build scripts to avoid this in the future, but for now, this will suffice.)