### PR TITLE
Fix OS X runtime errors.

### DIFF
--- a/ArmoryQt.py
+++ b/ArmoryQt.py
@@ -2959,9 +2959,9 @@ class ArmoryMainWindow(QMainWindow):
       if bdmState == BDM_BLOCKCHAIN_READY:
          for wltID in self.wltIDList:
             wlt = self.walletMap[wltID]
-            totalFunds += wlt.getBalance('Total')
-            spendFunds += wlt.getBalance('Spendable')
-            unconfFunds += wlt.getBalance('Unconfirmed')
+            totalFunds += int(wlt.getBalance('Total'))
+            spendFunds += int(wlt.getBalance('Spendable'))
+            unconfFunds += int(wlt.getBalance('Unconfirmed'))
 
 
       self.ledgerSize = len(self.combinedLedger)

--- a/armorymodels.py
+++ b/armorymodels.py
@@ -74,7 +74,7 @@ class AllWalletsDispModel(QAbstractTableModel):
             if not bdmState==BDM_BLOCKCHAIN_READY:
                return QVariant('(...)')
             if wlt.isEnabled == True:
-               bal = wlt.getBalance('Total')
+               bal = int(wlt.getBalance('Total'))
                if bal==-1:
                   return QVariant('(...)') 
                else:


### PR DESCRIPTION
The OS X version was complaining about SwigPyObject instances not being ints or longs. Cast the objects that Armory complains about.