### PR TITLE
Fix bug in ui when sending from single source addr

### DIFF
--- a/ui/WalletFrames.py
+++ b/ui/WalletFrames.py
@@ -250,7 +250,7 @@ class SelectWalletFrame(ArmoryFrame):
             self.lblCoinCtrl.setText('Source: None selected')
          elif nUtxo == 1:
             utxo = self.customUtxoList[0]
-            aStr = hash160_to_addrStr(utxo.getRecipientHash160)
+            aStr = hash160_to_addrStr(utxo.getRecipientHash160())
             self.lblCoinCtrl.setText('Source: %s...' % aStr[:12])
          elif nUtxo > 1:
             self.lblCoinCtrl.setText('Source: %d Outputs' % nUtxo)


### PR DESCRIPTION
While sending coins, if the user selects exactly one address as the source address, the ui did not correctly update the max amount because utxo.getRecipientHash160() was not called correctly. This patch, referenced by me in issue #105, fixes it.