### PR TITLE
OS X note changes

### DIFF
--- a/README_OSX.md
+++ b/README_OSX.md
@@ -1,6 +1,8 @@
 # macOS (OS X) README
 ## Requirements
-As of Armory 0.95.1, due to Python requirements that can't be met by macOS 10.12 (Sierra), users must use `brew` to install an updated version of OpenSSL in order for Armory to run. Please follow these instructions.
+Armory will run on OS X 10.7 and beyond. However, due to code changes that aren't supported under 10.7, it is highly recommended that users, if possible, upgrade to OS X 10.8 or higher. Armory will run on 10.7 for now. However, *Armory developers may not fix bugs found under 10.7*. Users who are completely unable to upgrade beyond 10.7 should make mitigation plans; Armory will eventually require OS X 10.8.
+
+Due to [Twisted](http://twistedmatrix.com/trac/) and [Python](https://python.org/) requirements that can't be met by macOS 10.12 (Sierra), users must use `brew` to install an updated version of OpenSSL in order for Armory 0.95.1 to run. Please follow these instructions.
 
 1. Open a terminal and run the `brew` command. If `brew` is not found, please execute the following commands from the command line. If the final command returns any errors, consult Google, the *bitcoin-armory* IRC channel on Freenode, or the [Bitcoin Forum](https://bitcointalk.org/index.php?board=97.0) for further instructions.
 
@@ -19,5 +21,7 @@ As of Armory 0.95.1, due to Python requirements that can't be met by macOS 10.12
 You may now run Armory.
 
 ## macOS-specific Bugs
-- If any bugs are found, report them on the *bitcoin-armory* IRC channel on Freenode, or the [Bitcoin Forum](https://bitcointalk.org/index.php?board=97.0).
-- Due to unknown issues with multithreading on Qt 4 (a library Armory uses), there are rare instances where Armory may crash suddenly. The Armory team has done its best to mitigate the crashes, with some users not reporting any crashes at all.
+Armory developers make a best effort to ensure that all Armory features are available on all versions of Armory. Unfortunately, there are rare cases where the OS X version is missing features or has bugs not found elsewhere. The following is a list of known bugs/issues. Please report any other bugs on the [Bitcoin Forum](https://bitcointalk.org/index.php?board=97.0) or on the *bitcoin-armory* IRC channel on Freenode.
+
+- Due to unknown issues with multithreading on Qt 4 (a library Armory uses), there are rare instances where Armory may crash suddenly. The Armory team has done its best to mitigate the crashes, with very few users reporting any crashes at all. Armory developers themselves haven't experienced any such crashes since approximately June 2015.
+- The "File Open" dialog under OS X Armory is very "dumb." (This is due to an unknown Qt 4 bug that causes Armory to crash whenever a much nicer dialog is opened.) Opening files in certain locations (e.g., thumb drives) is very difficult. The only consistent solutions are to copy files over to a location that can be opened, or to generate a [symbolic link](http://askubuntu.com/questions/600714/creating-a-symlink-from-one-folder-to-another-with-different-names) to the desired directory.

--- a/osxbuild/OSX_build_notes.md
+++ b/osxbuild/OSX_build_notes.md
@@ -1,5 +1,12 @@
+# macOS (OS X) BUILD NOTES
 These notes describe what had to be done on fresh installs of OS X 10.7 - 10.12 in order to compile Armory.
 
+## Requirements / Caveats
+At the present time, **Armory cannot be compiled using XCode 8 or later versions**. This is due to issues with C++11 support under OS X 10.7, which Armory still supports (although this will change eventually). If compiling Armory, it is highly recommended that the user runs the latest versions of XCode 7 (7.3.1 as of Oct. 2016). Armory may be compiled under OS X 10.12.
+
+Because C++11 support is shaky on OS X 10.7, *Armory developers may not fix bugs found under 10.7*. If a bug is found, please consult the [Bitcoin Forum](https://bitcointalk.org/index.php?board=97.0) or *bitcoin-armory* IRC channel on Freenode for further instructions.
+
+## Instructions
  1. Install the latest version of [Xcode](https://itunes.apple.com/us/app/xcode/id497799835).
 
  2. Open a terminal and install the Xcode commandline tools.


### PR DESCRIPTION
Clarified some notes regarding support for OS X 10.7 and how, for now, Armory can't be built using XCode 8.