### PR TITLE
Enable GCC/clang -Wshadow compiler flag

### DIFF
--- a/cppForSwig/BDM_mainthread.cpp
+++ b/cppForSwig/BDM_mainthread.cpp
@@ -112,8 +112,8 @@ class OnFinish
 {
    const function<void()> fn;
 public:
-   OnFinish(const function<void()> &fn)
-      : fn(fn) { }
+   OnFinish(const function<void()> &_fn)
+      : fn(_fn) { }
    ~OnFinish()
    {
       fn();

--- a/cppForSwig/BitcoinP2P.cpp
+++ b/cppForSwig/BitcoinP2P.cpp
@@ -1047,8 +1047,8 @@ void BitcoinP2P::processGetData(unique_ptr<Payload> payload)
       if (payloadIter == getdatamap->end())
          continue;
 
-      auto&& payload = *payloadIter->second.payload_.get();
-      sendMessage(move(payload));
+      auto&& _payload = *payloadIter->second.payload_.get();
+      sendMessage(move(_payload));
       
       try
       {

--- a/cppForSwig/BlockDataMap.cpp
+++ b/cppForSwig/BlockDataMap.cpp
@@ -287,11 +287,11 @@ shared_future<shared_ptr<BlockDataFileMap>>
 {
    string filename = move(intIDToName(fileid));
 
-   auto blockdataasync = [](string filename, bool preload)->
+   auto blockdataasync = [](string _filename, bool preload)->
       shared_ptr<BlockDataFileMap>
    {
       shared_ptr<BlockDataFileMap> blockptr = make_shared<BlockDataFileMap>(
-         filename, preload);
+         _filename, preload);
 
       return blockptr;
    };

--- a/cppForSwig/BlockUtils.cpp
+++ b/cppForSwig/BlockUtils.cpp
@@ -271,7 +271,7 @@ public:
             }
          };
 
-         bool foundTopBlock = false;
+         bool _foundTopBlock = false;
          int32_t fnum = blkFiles_.size();
          if (fnum > 0)
             fnum--;
@@ -283,11 +283,11 @@ public:
          }
          catch (StopReading&)
          {
-            foundTopBlock = true;
+            _foundTopBlock = true;
             // we're fine
          }
 
-         if (!foundTopBlock)
+         if (!_foundTopBlock)
          {
             //can't find the top header, let's just rescan all headers
             LOGERR << "Failed to find last known top block hash in "
@@ -930,12 +930,12 @@ void BlockDataManagerConfig::parseArgs(int argc, char* argv[])
                string argstr;
                getline(ss, argstr, '=');
 
-               auto&& str = stripQuotes(argstr);
-               if (str == "DB_BARE")
+               auto&& _str = stripQuotes(argstr);
+               if (_str == "DB_BARE")
                   armoryDbType_ = ARMORY_DB_BARE;
-               else if (str == "DB_FULL")
+               else if (_str == "DB_FULL")
                   armoryDbType_ = ARMORY_DB_FULL;
-               else if (str == "DB_SUPER")
+               else if (_str == "DB_SUPER")
                   armoryDbType_ = ARMORY_DB_SUPER;
                else
                {

--- a/cppForSwig/DatabaseBuilder.cpp
+++ b/cppForSwig/DatabaseBuilder.cpp
@@ -253,14 +253,14 @@ Blockchain::ReorganizationState DatabaseBuilder::updateBlocksInDB(
 
 
    auto addblocks = [&](uint16_t fileID, size_t startOffset, 
-      shared_ptr<BlockOffset> bo, bool verbose)->void
+      shared_ptr<BlockOffset> bo, bool _verbose)->void
    {
       while (1)
       {
          if (!addBlocksToDB(bdl, fileID, startOffset, bo, fullHints))
             return;
 
-         if (verbose)
+         if (_verbose)
          {
             unique_lock<mutex> lock(progressMutex, defer_lock);
             if (lock.try_lock() && fileID >= baseID)
@@ -942,18 +942,18 @@ void DatabaseBuilder::verifyTransactions()
                   continue;
 
                //check hash
-               auto txn = txns[txid];
-               txn->getHash();
-               if (hashref != txn->txHash_)
+               auto _txn = txns[txid];
+               _txn->getHash();
+               if (hashref != _txn->txHash_)
                   continue;
 
                //grab output
-               auto txoutcount = txn->txouts_.size();
+               auto txoutcount = _txn->txouts_.size();
                if (*outputID > txoutcount)
                   break;
 
-               BinaryDataRef output(txn->data_ + txn->txouts_[*outputID].first,
-                  txn->txouts_[*outputID].second);
+               BinaryDataRef output(_txn->data_ + _txn->txouts_[*outputID].first,
+                  _txn->txouts_[*outputID].second);
 
                UTXO utxo;
                utxo.unserializeRaw(output);

--- a/cppForSwig/EncryptionUtils.cpp
+++ b/cppForSwig/EncryptionUtils.cpp
@@ -163,8 +163,8 @@ void KdfRomix::computeKdfParams(double targetComputeSec, uint32_t maxMemReqts)
       TIMER_RESTART("KDF_Time_Search");
       for(uint32_t i=0; i<numTest; i++)
       {
-         SecureBinaryData testKey("This is an example key to test KDF iteration speed");
-         testKey = DeriveKey_OneIter(testKey);
+         SecureBinaryData _testKey("This is an example key to test KDF iteration speed");
+         _testKey = DeriveKey_OneIter(_testKey);
       }
       TIMER_STOP("KDF_Time_Search");
       allItersSec = TIMER_READ_SEC("KDF_Time_Search");

--- a/cppForSwig/LedgerEntry.cpp
+++ b/cppForSwig/LedgerEntry.cpp
@@ -190,8 +190,8 @@ void LedgerEntry::computeLedgerMap(map<BinaryData, LedgerEntry> &leMap,
       {
          auto txInDBKey = txio.second.getDBKeyOfInput().getSliceCopy(0, 6);
 
-         auto& txioVec = TxnTxIOMap[txInDBKey];
-         txioVec.push_back(&txio.second);
+         auto& _txioVec = TxnTxIOMap[txInDBKey];
+         _txioVec.push_back(&txio.second);
       }
    }
 

--- a/cppForSwig/Makefile
+++ b/cppForSwig/Makefile
@@ -2,11 +2,11 @@ CXX = g++
 CC = gcc
 
 ifdef DEBUG
-CFLAGS=-g3 -Wall -pipe -fPIC
-CXXFLAGS=-g3 -Wall -pipe -fPIC
+CFLAGS=-g3 -Wall -pipe -fPIC -Wshadow
+CXXFLAGS=-g3 -Wall -pipe -fPIC -Wshadow
 else
-CFLAGS = -O2 -pipe -fPIC
-CXXFLAGS = -O2 -pipe -fPIC
+CFLAGS = -O2 -pipe -fPIC -Wshadow
+CXXFLAGS = -O2 -pipe -fPIC -Wshadow
 endif
 
 ifdef STATIC_LINK

--- a/cppForSwig/ScrAddrObj.cpp
+++ b/cppForSwig/ScrAddrObj.cpp
@@ -180,13 +180,13 @@ void ScrAddrObj::scanZC(const ScanAddressStruct& scanInfo,
    for (auto& txiopair : zcTxIOMap)
    {
       auto& newtxio = txiopair.second;
-      auto keyIter = relevantTxIO_.find(txiopair.first);
-      if (keyIter != relevantTxIO_.end())
+      auto _keyIter = relevantTxIO_.find(txiopair.first);
+      if (_keyIter != relevantTxIO_.end())
       {
          
          //dont replace a zc that is spent with a zc that is unspent. zc revocation
          //is handled in the purge segment         
-         auto& txio = keyIter->second;
+         auto& txio = _keyIter->second;
          if (txio.hasTxIn())
          {
             if (txio.getDBKeyOfInput() == newtxio.getDBKeyOfInput())

--- a/cppForSwig/Script.cpp
+++ b/cppForSwig/Script.cpp
@@ -1153,15 +1153,15 @@ void StackResolver::resolveStack()
    {
       if (static_count == 2 && stack_.size() == 2)
       {
-         auto stackIter = stack_.begin();
-         auto firstStackItem = *stackIter;
+         auto _stackIter = stack_.begin();
+         auto firstStackItem = *_stackIter;
 
          auto header = rawBinaryToInt(firstStackItem->staticData_);
 
          if (header == 0)
          {
-            ++stackIter;
-            auto secondStackItem = *stackIter;
+            ++_stackIter;
+            auto secondStackItem = *_stackIter;
 
             BinaryData swScript;
 

--- a/cppForSwig/StoredBlockObj.cpp
+++ b/cppForSwig/StoredBlockObj.cpp
@@ -1231,10 +1231,10 @@ StoredTx & StoredTx::createFromTx(Tx & tx, bool doFrag, bool withTxOuts)
       BinaryRefReader brr(tx.getPtr(), tx.getSize());
       uint32_t firstOut  = tx.getTxOutOffset(0);
       uint32_t afterLast = tx.getTxOutOffset(numTxOut_);
-      uint32_t span = afterLast - firstOut;
-      dataCopy_.resize(tx.getSize() - span);
+      uint32_t _span = afterLast - firstOut;
+      dataCopy_.resize(tx.getSize() - _span);
       brr.get_BinaryData(dataCopy_.getPtr(), firstOut);
-      brr.advance(span);
+      brr.advance(_span);
       brr.get_BinaryData(dataCopy_.getPtr()+firstOut, 4);
    }
 
@@ -1895,14 +1895,14 @@ void StoredSubHistory::pprintFullSubSSH(uint32_t indent)
          cout << " ";
 
       TxIOPair & txio = iter->second;
-      uint32_t hgt;
-      uint8_t  dup;
+      uint32_t _hgt;
+      uint8_t  _dup;
       uint16_t txi;
       uint16_t txo = txio.getIndexOfOutput();
       BinaryData txoKey = txio.getDBKeyOfOutput();
       BinaryRefReader brrTxOut(txoKey);
-      DBUtils::readBlkDataKeyNoPrefix(brrTxOut, hgt, dup, txi);
-      cout << "TXIO: (" << hgt << "," << (uint32_t)dup 
+      DBUtils::readBlkDataKeyNoPrefix(brrTxOut, _hgt, _dup, txi);
+      cout << "TXIO: (" << _hgt << "," << (uint32_t)_dup 
                           << "," << txi << "," << txo << ")";
 
       
@@ -1914,12 +1914,12 @@ void StoredSubHistory::pprintFullSubSSH(uint32_t indent)
 
       if(txio.hasTxIn())
       {
-         uint16_t txo = txio.getIndexOfInput();
+         uint16_t _txo = txio.getIndexOfInput();
          BinaryData txiKey = txio.getDBKeyOfInput();
          BinaryRefReader brrTxIn(txiKey);
-         DBUtils::readBlkDataKeyNoPrefix(brrTxIn, hgt, dup, txi);
-         cout << "  SPENT: (" << hgt << "," << (uint32_t)dup 
-                       << "," << txi << "," << txo << ")";
+         DBUtils::readBlkDataKeyNoPrefix(brrTxIn, _hgt, _dup, txi);
+         cout << "  SPENT: (" << _hgt << "," << (uint32_t)_dup 
+                       << "," << txi << "," << _txo << ")";
       }
       cout << endl;
    }

--- a/cppForSwig/SwigClient.cpp
+++ b/cppForSwig/SwigClient.cpp
@@ -401,7 +401,6 @@ map<BinaryData, uint32_t> SwigClient::BtcWallet::getAddrTxnCountsFromDB()
    for (unsigned i = 0; i < count; i++)
    {
       auto&& addr = arg.get<BinaryDataObject>();
-      auto&& count = arg.get<IntType>().getVal();
 
       countMap[addr.get()] = count;
    }
@@ -568,9 +567,9 @@ vector<UTXO> ScrAddrObj::getSpendableTxOutList(bool ignoreZC)
    vector<UTXO> utxovec;
    for (unsigned i = 0; i < count; i++)
    {
-      auto&& bdo = arg.get<BinaryDataObject>();
+      auto&& _bdo = arg.get<BinaryDataObject>();
       UTXO utxo;
-      utxo.unserialize(bdo.get());
+      utxo.unserialize(_bdo.get());
 
       utxovec.push_back(move(utxo));
    }

--- a/cppForSwig/lmdb_wrapper.cpp
+++ b/cppForSwig/lmdb_wrapper.cpp
@@ -889,13 +889,13 @@ bool LMDBBlockDatabase::readStoredScriptHistoryAtIter(LDBIter & ldbIter,
    size_t numTxioRead = 0;
    do
    {
-      size_t sz = subsshIter.getKeyRef().getSize();
-      BinaryDataRef keyNoPrefix= subsshIter.getKeyRef().getSliceRef(1,sz-1);
+      size_t _sz = subsshIter.getKeyRef().getSize();
+      BinaryDataRef keyNoPrefix= subsshIter.getKeyRef().getSliceRef(1,_sz-1);
       if(!keyNoPrefix.startsWith(ssh.uniqueKey_))
          break;
 
       pair<BinaryData, StoredSubHistory> keyValPair;
-      keyValPair.first = keyNoPrefix.getSliceCopy(sz-5, 4);
+      keyValPair.first = keyNoPrefix.getSliceCopy(_sz-5, 4);
       keyValPair.second.unserializeDBKey(subsshIter.getKeyRef());
 
       //iter is at the right ssh, make sure hgtX <= endBlock

--- a/cppForSwig/lmdbpp.h
+++ b/cppForSwig/lmdbpp.h
@@ -45,17 +45,17 @@ public:
    const size_t len;
    const char *data;
    
-   CharacterArrayRef(const size_t len, const char *data)
-      : len(len), data(data)
+   CharacterArrayRef(const size_t _len, const char *_data)
+      : len(_len), data(_data)
    { }
-   CharacterArrayRef(const size_t len, const unsigned char *data)
-      : len(len), data(reinterpret_cast<const char*>(data))
+   CharacterArrayRef(const size_t _len, const unsigned char *_data)
+      : len(_len), data(reinterpret_cast<const char*>(_data))
    { }
-   CharacterArrayRef(const std::string &data)
-      : len(data.size()), data(&data[0])
+   CharacterArrayRef(const std::string &_data)
+      : len(_data.size()), data(&_data[0])
    { }
-   CharacterArrayRef(const std::vector<char> &data)
-      : len(data.size()), data(&data.front())
+   CharacterArrayRef(const std::vector<char> &_data)
+      : len(_data.size()), data(&_data.front())
    { }
 };
 
@@ -172,9 +172,9 @@ public:
    };
    
    LMDB() { }
-   LMDB(LMDBEnv *env, const std::string &name=std::string())
+   LMDB(LMDBEnv *_env, const std::string &name=std::string())
    {
-      open(env, name);
+      open(_env, name);
    }
    
    ~LMDB();

--- a/cppForSwig/log.h
+++ b/cppForSwig/log.h
@@ -179,7 +179,6 @@ public:
       else
       {
          // Otherwise, seek to <maxSize> before end of log file
-         ifstream is(OS_TranslatePath(logfile.c_str()), ios::in|ios::binary);
          is.seekg(fsize - maxSizeInBytes);
 
          // Allocate buffer to hold the rest of the file (about maxSizeInBytes)

--- a/cppForSwig/util.h
+++ b/cppForSwig/util.h
@@ -25,7 +25,7 @@ class IterateSecond
 public:
    typedef typename Container::value_type::second_type value_type;
 
-   IterateSecond(Container &c) : c(c) { }
+   IterateSecond(Container &_c) : c(_c) { }
 
    class Iterator
    {


### PR DESCRIPTION
GCC/clang will now throw warnings whenever variables shadow other variables. Armory code was cleaned up to remove these warnings. (Third party code - LMDB and Crypto++ - and code generated by SWIG was not cleaned up.)