### PR TITLE
Carry over message headers without payloads

### DIFF
--- a/cppForSwig/BitcoinP2p.h
+++ b/cppForSwig/BitcoinP2p.h
@@ -122,6 +122,12 @@ struct BitcoinMessageDeserError : public BitcoinP2P_Exception
    {}
 };
 
+struct BitcoinMessageNoPayloadError : public BitcoinP2P_Exception
+{
+   BitcoinMessageNoPayloadError(const string& e) : BitcoinP2P_Exception(e)
+   {}
+};
+
 struct BitcoinMessageUnknown : public BitcoinP2P_Exception
 {
    BitcoinMessageUnknown(const string& e) : BitcoinP2P_Exception(e)


### PR DESCRIPTION
Recently (may have been happening for a while though) I have noticed that many (but not all) message headers are being deserialized separately from the payload where they should be deser'ed together as one message.

To fix this issue, this PR will check to see if the data being processed is just the header and then prepend that data chunk onto the next data chunk which is always (as far as I have observed) the payload.