### PR TITLE
Update OS X build process

### DIFF
--- a/osxbuild/build-app.py
+++ b/osxbuild/build-app.py
@@ -12,32 +12,33 @@ import datetime
 import optparse
 import tarfile
 import subprocess
+import zipfile
 
 from subprocess import Popen, PIPE
 from tempfile import mkstemp
 
 # Set some constants up front
 minOSXVer     = '10.7'
-pythonVer     = '2.7.12' # NB: ArmoryMac.pro must also be kept up to date!!!
+pythonVer     = '2.7.13' # NB: ArmoryMac.pro must also be kept up to date!!!
 pyMajorVer    = '2.7'
-setToolVer    = '25.1.3'
-setToolSubdir = '46/db/baa571da945ff731f3739a119574e89b12add9b05c03842103bd641d0990'
-pipVer        = '8.1.2'
-pipSubdir     = 'e7/a8/7556133689add8d1a54c0b14aeff0acb03c64707ce100ecd53934da1aa13'
-psutilVer     = '4.3.0'
-psutilSubdir  = '22/a8/6ab3f0b3b74a36104785808ec874d24203c6a511ffd2732dd215cf32d689'
-zopeVer       = '4.2.0'
-zopeSubdir    = 'ea/a3/38bdc8e8bd068ea5b4d21a2d80eca1547cd8509318e8d7c875f7247abe43'
-pyasn1Ver     = '0.1.9'
-pyasn1Subdir  = 'f7/83/377e3dd2e95f9020dbd0dfd3c47aaa7deebe3c68d3857a4e51917146ae8b'
+setToolVer    = '33.1.1' # 34.1.1 has a circular dependency w/ pyparsing. Downgrade.
+setToolSubdir = 'dc/8c/7c9869454bdc53e72fb87ace63eac39336879eef6f2bf96e946edbf03e90'
+pipVer        = '9.0.1'
+pipSubdir     = '11/b6/abcb525026a4be042b486df43905d6893fb04f05aac21c32c638e939e447'
+psutilVer     = '5.1.3'
+psutilSubdir  = '78/0a/aa90434c6337dd50d182a81fe4ae4822c953e166a163d1bf5f06abb1ac0b'
+zopeVer       = '4.3.3'
+zopeSubdir    = '44/af/cea1e18bc0d3be0e0824762d3236f0e61088eeed75287e7b854d65ec9916'
+pyasn1Ver     = '0.2.2'
+pyasn1Subdir  = '57/f7/c18a86169bb9995a69195177b23e736776b347fd92592da0c3cac9f1a724'
 siVer         = '16.0.0'
 siSubdir      = 'f3/2a/7c04e7ab74f9f2be026745a9ffa81fd9d56139fa6f5f4b4c8a8c07b2bfba'
-twistedVer    = '16.3.0'
-libpngVer     = '1.6.25'
+twistedVer    = '16.6.0'
+libpngVer     = '1.6.28'
 qtVer         = '4.8.7'  # NB: ArmoryMac.pro must also be kept up to date!!!
                          # Possibly "sipFlags" below too.
-sipVer        = '4.18.1' # NB: ArmoryMac.pro must also be kept up to date!!!
-pyQtVer       = '4.11.4' # NB: When I'm upgraded, SIP usually has to be upgraded too.
+sipVer        = '4.19'   # NB: ArmoryMac.pro must also be kept up to date!!!
+pyQtVer       = '4.12'   # NB: When I'm upgraded, SIP usually has to be upgraded too.
 
 LOGFILE       = 'build-app.log.txt'
 LOGPATH       = path.abspath( path.join(os.getcwd(), LOGFILE))
@@ -237,15 +238,19 @@ def getTarUnpackPath(tarName, inDir=None):
    if inDir is not None:
       tarPath = path.join(inDir, tarName)
 
-   # HACK: XZ support was added to tarfile.open() in Python 3.3. Can't use for
+   # HACK 1: XZ support was added to tarfile.open() in Python 3.3. Can't use for
    # now, so we'll have to apply a hack to get around this. In addition, the
    # builder must have the xz binary on their build machine, otherwise the
    # following error will appear: "tar: Error opening archive: Child process
    # exited with status 254Child process exited with status 254"
+   # HACK 2: AFAIK, it's not possible to peek inside ZIP files and get the
+   # resultant directory. Just be lazy and hard-code it.
    if tarName == "Python-%s.tar.xz" % pythonVer:
       theDir = "Python-%s" % pythonVer
    elif tarName == "libpng-%s.tar.xz" % libpngVer:
       theDir = "libpng-%s" % libpngVer
+   elif tarName == "setuptools-%s.zip" % setToolVer:
+      theDir = "setuptools-%s" % setToolVer
    else:
       tar = tarfile.open(tarPath,'r')
       theDir = tar.next().name.split('/')[0]
@@ -255,9 +260,9 @@ def getTarUnpackPath(tarName, inDir=None):
 ################################################################################
 def unpack(tarName, fromDir=DLDIR, toDir=UNPACKDIR, overwrite=False):
    """
-   This is not a versatile function. It expects tar files with a single
+   This is not a versatile function. It expects tar or zip files with a single
    unpack directory. I will expand this function as necessary if we
-   need tar files that aren't a single bundled dir.
+   need tar/zip files that aren't a single bundled dir.
    """
    if fromDir is not None:
       tardl = path.join(fromDir, tarName)
@@ -279,8 +284,12 @@ def unpack(tarName, fromDir=DLDIR, toDir=UNPACKDIR, overwrite=False):
       execAndWait('tar -zxf %s -C %s' % (tardl, toDir))
    elif tarName.endswith('tar.bz2') or tarName.endswith('tbz'):
       execAndWait('tar -jxf %s -C %s' % (tardl, toDir))
-   elif tarName.endswith('tar.xz') or tarName.endswith('xz'):
+   elif tarName.endswith('tar.xz'):
       execAndWait('tar -Jxf %s -C %s' % (tardl, toDir))
+   elif tarName.endswith('zip'):
+      zip_ref = zipfile.ZipFile(tardl, 'r')
+      zip_ref.extractall(toDir)
+      zip_ref.close()
    else:
       raise RuntimeError('Not a recognized tar name')
    newStuff = []
@@ -321,32 +330,32 @@ distfiles = []
 distfiles.append( [ 'Python', \
                     "Python-%s.tar.xz" % pythonVer, \
                     "http://python.org/ftp/python/%s/Python-%s.tar.xz" % (pythonVer, pythonVer), \
-                    "05360b8ade117b35e266b2004a7f1f11250c6dcd" ] )
+                    "18a8f30a0356c751b8d0ea6f76e764cab13ee046" ] )
 
 distfiles.append( [ 'setuptools', \
-                    "setuptools-%s.tar.gz" % setToolVer, \
-                    "https://pypi.python.org/packages/%s/setuptools-%s.tar.gz" % (setToolSubdir, setToolVer), \
-                    "7b5dc4d1b1cbe42bc6c5bcaca7221148822d20c6" ] )
+                    "setuptools-%s.zip" % setToolVer, \
+                    "https://pypi.python.org/packages/%s/setuptools-%s.zip" % (setToolSubdir, setToolVer), \
+                    "baaa2d1e4a76f968df14cb2defd9044244f25b3f" ] )
 
 distfiles.append( [ 'Pip', \
                     "pip-%s.tar.gz" % pipVer, \
                     "https://pypi.python.org/packages/%s/pip-%s.tar.gz" % (pipSubdir, pipVer), \
-                    "1c13c247967ec5bee6de5fd104c5d78ba30951c7" ] )
+                    "57ff41e99cb01b6a1c2b0999161589b726f0ec8b" ] )
 
 distfiles.append( [ "psutil", \
                     "psutil-%s.tar.gz" % psutilVer, \
                     "https://pypi.python.org/packages/%s/psutil-%s.tar.gz" % (psutilSubdir, psutilVer), \
-                    "062fc6745a16f91aed159bb81381bd1cb84acb81" ] )
+                    "6c48c1ac06fb4d2796dc0157a95d85689466a60f" ] )
 
 distfiles.append( [ 'Twisted', \
                     "Twisted-%s.tar.bz2" % twistedVer, \
                     "https://files.pythonhosted.org/packages/source/T/Twisted/Twisted-%s.tar.bz2" % twistedVer, \
-                    "b9f183ae63a49c99619f7d37d1ae3a368d6cf886" ] )
+                    "57ea06c54e59c314f904870946c4a3586d7b86ea" ] )
 
 distfiles.append( [ 'libpng', \
                     "libpng-%s.tar.xz" % libpngVer, \
-                    "https://dl.bintray.com/homebrew/mirror/libpng-%s.tar.xz" % libpngVer, \
-                    "fb471b7732d886b5adf10b4d689a90c88f005aa5" ] )
+                    "https://sourceforge.net/projects/libpng/files/libpng16/%s/libpng-%s.tar.xz" % (libpngVer, libpngVer), \
+                    "ff4dceadb15e2c929ad26283118d56f66f4a6cff" ] )
 
 distfiles.append( [ 'service_identity', \
                     "service_identity-%s.tar.gz" % siVer, \
@@ -356,7 +365,7 @@ distfiles.append( [ 'service_identity', \
 distfiles.append( [ 'pyasn1', \
                     "pyasn1-%s.tar.gz" % pyasn1Ver, \
                     "https://pypi.python.org/packages/%s/pyasn1-%s.tar.gz" % (pyasn1Subdir, pyasn1Ver), \
-                    "d19599c5d9d039ead21ffcd1a2392c29a838ae03" ] )
+                    "ada7ee490ffcc06c6247b28c2b4d12411ebdfdfd" ] )
 
 # When we upgrade to Qt5....
 #distfiles.append( [ "Qt", \
@@ -371,13 +380,13 @@ distfiles.append( [ "Qt", \
 
 distfiles.append( [ "sip", \
                     "sip-%s.tar.gz" % sipVer, \
-                    "http://sourceforge.net/projects/pyqt/files/sip/sip-%s/sip-%s.tar.gz" % (sipVer, sipVer), \
-                    'a4040e9fbb0e4c764e637c36fa8504722f0bfdf4' ] )
+                    "https://sourceforge.net/projects/pyqt/files/sip/sip-%s/sip-%s.tar.gz" % (sipVer, sipVer), \
+                    'ac654bacb07dac8e86c138a9f30bf6a04e26845b' ] )
 
 distfiles.append( [ "zope", \
                     "zope.interface-%s.tar.gz" % zopeVer, \
                     "https://pypi.python.org/packages/%s/zope.interface-%s.tar.gz" % (zopeSubdir, zopeVer), \
-                    '8b5f345d257d9d03cd782b9e332fc1c0928928f4' ] )
+                    '66bd8e4af0f16468914fefc90ba9cca23e66cd9d' ] )
 
 # When we upgrade to Qt5....
 #distfiles.append( [ "pyqt", \
@@ -386,9 +395,9 @@ distfiles.append( [ "zope", \
 #                    'a1c232d34ab268587c127ad3097c725ee1a70cf0' ] )
 
 distfiles.append( [ "pyqt", \
-                    "PyQt-mac-gpl-%s.tar.gz" % pyQtVer, \
-                    "http://downloads.sf.net/project/pyqt/PyQt4/PyQt-%s/PyQt-mac-gpl-%s.tar.gz" % (pyQtVer, pyQtVer), \
-                    'c319f273e40afe68a2e65ff2b9c01e0d43e980f7' ] )
+                    "PyQt4_gpl_mac-%s.tar.gz" % pyQtVer, \
+                    "http://downloads.sf.net/project/pyqt/PyQt4/PyQt-%s/PyQt4_gpl_mac-%s.tar.gz" % (pyQtVer, pyQtVer), \
+                    '625c80addf7ac2429c3e1af3db81793628452f81' ] )
 
 # Now repack the information in distfiles
 tarfilesToDL = {}
@@ -413,10 +422,26 @@ def compile_python():
 
    # ./configure - Force Python to link against a brew-ed version of OpenSSL
    # due to Python not liking the ancient (0.9.8) version of OpenSSL Apple
-   # includes with OS X. (For whatever reasons, Python can't follow HTTPS links
-   # when attempting to DL files unless you use an updated version.)
+   # includes with OS X.
+   # Note that there's something weird going on with the linker flags, even when
+   # adding custom OpenSSL paths the official way (modding Modules/Setup.dist).
+   # To get around this, manually specify the linker flags (both -L *and* -l)
+   # under LDFLAGS. (CFLAGS and CPPFLAGS probably not needed but it works, so
+   # leave it alone for now....)
+   logprint('Modify Python modules setup files.')
+   logprint('OpenSSL path = %s' % opensslPath)
+   modSetupFile = path.join(bldPath, 'Modules/Setup.dist')
+   with open(modSetupFile) as origFile:
+      setupText = origFile.read()
+   setupText = setupText.replace("#SSL=/usr/local/ssl", "SSL=%s" % opensslPath, 1)
+   setupText = setupText.replace("#_ssl _ssl.c \\", "_ssl _ssl.c \\", 1)
+   setupText = setupText.replace("#	-DUSE_SSL -I$(SSL)/include -I$(SSL)/include/openssl \\", "	-DUSE_SSL -I$(SSL)/include -I$(SSL)/include/openssl \\", 1)
+   setupText = setupText.replace("#	-L$(SSL)/lib -lssl -lcrypto", "	-L$(SSL)/lib -lssl -lcrypto", 1)
+   with open(modSetupFile, "w") as origFile:
+      origFile.write(setupText)
+
    frameDir = path.join(APPDIR, 'Contents/Frameworks')
-   execAndWait('env CFLAGS=\'-I%s/include\' CPPFLAGS=\'-I%s/include\' LDFLAGS=\'-L%s/lib\' ./configure --enable-ipv6 --prefix=%s --enable-framework="%s"' % \
+   execAndWait('./configure CFLAGS=-I%s/include CPPFLAGS=-I%s/include LDFLAGS=\"-L%s/lib -lssl -lcrypto\" --enable-ipv6 --prefix=%s --enable-framework="%s"' % \
                                              (opensslPath, opensslPath, opensslPath, INSTALLDIR, frameDir), cwd=bldPath)
 
    # make
@@ -430,19 +455,20 @@ def compile_python():
 
 ########################################################
 def compile_pip():
-   logprint('Installing setuptools.')
+   logprint('Installing pip and setuptools.')
    pipexe = path.join(PYPREFIX, 'bin/pip')
    if path.exists(pipexe):
       logprint('Pip already installed')
    else:
-      logprint('Installing pip.')
       command = 'python -s setup.py --no-user-cfg install --force --verbose'
 
       # Unpack and build setuptools
+      logprint('Installing setuptools.')
       setupDir = unpack(tarfilesToDL['setuptools'])
       execAndWait(command, cwd=setupDir)
 
       # Unpack and build pip
+      logprint('Installing pip.')
       pipDir   = unpack(tarfilesToDL['Pip'])
       execAndWait(command, cwd=pipDir)
 
@@ -567,7 +593,7 @@ def compile_pyqt():
    #logprint('Install PyQt5')
    #if path.exists(path.join(PYSITEPKGS, 'PyQt5')):
    if path.exists(path.join(PYSITEPKGS, 'PyQt4')):
-      logprint('Pyqt is already installed.')
+      logprint('PyQt4 is already installed.')
    else:
       pyqtPath = unpack(tarfilesToDL['pyqt'])
       incDir = path.join(PYPREFIX, 'include')
@@ -576,7 +602,7 @@ def compile_pyqt():
 
    # Need to add pyrcc4 to the PATH
    execAndWait('make install', cwd=pyqtPath)
-   pyrccPath = path.join(UNPACKDIR, 'PyQt-mac-gpl-%s/pyrcc' % pyQtVer)
+   pyrccPath = path.join(UNPACKDIR, 'PyQt_mac_gpl-%s/pyrcc' % pyQtVer)
    os.environ['PATH'] = '%s:%s' % (pyrccPath, os.environ['PATH'])
 
 ########################################################
@@ -667,7 +693,7 @@ def compile_objc_library():
    # Makefile, and make the shared library. Be sure to keep the SIP flags in
    # sync with generate_sip_module_code() from PyQt's configure-ng.py.
    sipFlags = '-w -x VendorID -t WS_MACX -t Qt_4_8_7 -x Py_v3 -B Qt_5_0_0 -o ' \
-              '-P -g -c . -I ../workspace/unpackandbuild/PyQt-mac-gpl-%s/sip' % pyQtVer
+              '-P -g -c . -I ../workspace/unpackandbuild/PyQt4_gpl_mac-%s/sip' % pyQtVer
    execAndWait('../workspace/unpackandbuild/sip-%s/sipgen/sip %s ./ArmoryMac.sip' % (sipVer, sipFlags), cwd=OBJCDIR)
    execAndWait('../workspace/unpackandbuild/qt-everywhere-opensource-src-%s/bin/qmake ArmoryMac.pro' % qtVer, cwd=OBJCDIR)
 

--- a/osxbuild/objc_armory/ArmoryMac.pro
+++ b/osxbuild/objc_armory/ArmoryMac.pro
@@ -20,8 +20,8 @@
 # macx-clang-libc++ option like Qt. (macx-g++ is all it can muster for now.)
 # NB: The "version" values must be updated alongside build-app.py!!!
 QTVER = 4.8.7
-SIPVER = 4.18.1
-PYVER = 2.7.12
+SIPVER = 4.19
+PYVER = 2.7.13
 QT_UNPACK_BASE = ../workspace/unpackandbuild/qt-everywhere-opensource-src-$${QTVER}
 SIP_UNPACK_BASE = ../workspace/unpackandbuild/sip-$${SIPVER}
 PYTHON_UNPACK_BASE = ../workspace/unpackandbuild/Python-$${PYVER}


### PR DESCRIPTION
- Various package updates.
- Fix up Python build issues related to HTTPS. (Long story short, Python’s official method for baking in HTTPS support is garbage.)

Note that the Mac build still won't compile or run. A separate PR will be created later to cover fixes for those problems. This merely gets the build process off the ground again. (In particular, there were HTTPS-related issues.)