### PR TITLE
Finish getting OS X build running again

### DIFF
--- a/ArmoryQt.py
+++ b/ArmoryQt.py
@@ -129,7 +129,6 @@ class ArmoryMainWindow(QMainWindow):
       if not OS_MACOSX:
          self.setWindowIcon(QIcon(self.iconfile))
       else:
-         self.notifCtr = ArmoryMac.MacNotificationHandler.None
          if USE_TESTNET or USE_REGTEST:
             self.iconfile = ':/armory_icon_green_fullres.png'
             ArmoryMac.MacDockIconHandler.instance().setMainWindow(self)
@@ -720,17 +719,6 @@ class ArmoryMainWindow(QMainWindow):
 
       if OS_MACOSX:
          self.macNotifHdlr = ArmoryMac.MacNotificationHandler()
-         if self.macNotifHdlr.hasUserNotificationCenterSupport():
-            self.notifCtr = ArmoryMac.MacNotificationHandler.BuiltIn
-         else:
-            # In theory, Qt can support notifications via Growl on pre-10.8
-            # machines. It's shaky as hell, though, so we'll rely on alternate
-            # code for now. In the future, according to
-            # https://bugreports.qt-project.org/browse/QTBUG-33733 (which may not
-            # be accurate, as the official documentation is contradictory),
-            # showMessage() may have direct support for the OS X notification
-            # center in Qt5.1. Something to experiment with later....
-            self.notifCtr = self.macNotifHdlr.hasGrowl()
 
       # Now that construction of the UI is done
       # Check for warnings to be displayed

--- a/cppForSwig/ScriptRecipient.h
+++ b/cppForSwig/ScriptRecipient.h
@@ -95,7 +95,7 @@ public:
    }
 
    //return size is static
-   uint64_t getSize(void) const { return 34; }
+   size_t getSize(void) const { return 34; }
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -124,7 +124,7 @@ public:
       script_ = move(bw.getData());
    }
 
-   uint64_t getSize(void) const { return 31; }
+   size_t getSize(void) const { return 31; }
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -154,7 +154,7 @@ public:
       script_ = move(bw.getData());
    }
 
-   uint64_t getSize(void) const { return 32; }
+   size_t getSize(void) const { return 32; }
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -183,7 +183,7 @@ public:
       script_ = move(bw.getData());
    }
 
-   uint64_t getSize(void) const { return 43; }
+   size_t getSize(void) const { return 43; }
 };
 
 #endif


### PR DESCRIPTION
- Remove some notification code not removed when the Growl code was removed.
- Fix a uint64_t/size_t function prototype issue.

The Mac build still doesn’t quite run but this seems to be due to deeper issues. This PR just gets the splash screen to (sort of) properly load again.