### PR TITLE
OS X build fixes / enhancements

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -43,9 +43,11 @@ install-exec-hook: uninstall-old
 	cp -r armoryengine/* $(DESTDIR)$(PREFIX)/lib/armory/armoryengine
 	sed "s: /usr: $(PREFIX):g" < dpkgfiles/armory > $(DESTDIR)$(PREFIX)/bin/armory 
 	chmod +x $(DESTDIR)$(PREFIX)/bin/armory
+if BUILD_DARWIN
 	sed "s:python /usr:python $(PREFIX):g" < dpkgfiles/armory.desktop > $(DESTDIR)$(PREFIX)/share/applications/armory.desktop
 	sed "s:python /usr:python $(PREFIX):g" < dpkgfiles/armoryoffline.desktop > $(DESTDIR)$(PREFIX)/share/applications/armoryoffline.desktop
 	sed "s:python /usr:python $(PREFIX):g" < dpkgfiles/armorytestnet.desktop > $(DESTDIR)$(PREFIX)/share/applications/armorytestnet.desktop
+endif
 
 uninstall-hook: uninstall-old
 	rm -rf $(DESTDIR)$(PREFIX)/lib/armory

--- a/configure.ac
+++ b/configure.ac
@@ -68,10 +68,38 @@ AS_IF([test $HAVE_PYRCC4 == yes], [],
 
 AC_SUBST([CXX_STANDARD], $CXX_STANDARD)
 
-dnl Determine build OS.
+dnl Determine build OS and do other OS-specific things.
 case $host in
   *darwin*)
     BUILD_OS=darwin
+
+    dnl
+    dnl  Handle Mac OS X SDK flags
+    dnl
+    AC_ARG_WITH(macosx-sdk,
+      [AS_HELP_STRING([--with-macosx-sdk=DIR],
+        [compile using the SDK in DIR])])
+    if test "${with_macosx_sdk}" != "" ; then
+        test ! -d "${with_macosx_sdk}" && AC_MSG_ERROR([SDK "${with_macosx_sdk}" not found])
+        CPP="${CPP} -isysroot ${with_macosx_sdk}"
+        CC="${CC} -isysroot ${with_macosx_sdk}"
+        CXX="${CXX} -isysroot ${with_macosx_sdk}"
+        OBJC="${OBJC} -isysroot ${with_macosx_sdk}"
+        LD="${LD} -syslibroot ${with_macosx_sdk}"
+    fi
+    AC_ARG_WITH(macosx-version-min,
+      [AS_HELP_STRING([--with-macosx-version-min=VERSION],
+        [compile for Mac OS X VERSION and above])])
+    if test "${with_macosx_version_min}" != "" ; then
+        CPP="${CPP} -mmacosx-version-min=${with_macosx_version_min}"
+        CC="${CC} -mmacosx-version-min=${with_macosx_version_min}"
+        CXX="${CXX} -mmacosx-version-min=${with_macosx_version_min}"
+        OBJC="${OBJC} -mmacosx-version-min=${with_macosx_version_min}"
+        LD="${LD} -mmacosx_version_min=${with_macosx_version_min}"
+    fi
+    CPP="${CPP} -stdlib=libc++ -std=c++11"
+    CXX="${CXX} -stdlib=libc++ -std=c++11"
+    LD="${LD} -stdlib=libc++ -std=c++11 -lc++ -undefined dynamic_lookup -headerpad_max_install_names"
     ;;
   *linux*)
     BUILD_OS=linux

--- a/cppForSwig/Makefile.am
+++ b/cppForSwig/Makefile.am
@@ -76,6 +76,10 @@ libCppBlockUtils_la_LIBADD = 	-Llmdb -llmdb \
 		 	 	./cryptopp/libcryptopp.la \
 		 	 	-lpthread
 
+if BUILD_DARWIN
+libCppBlockUtils_la_LDFLAGS = -Wl,-rpath,@executable_path/ -Wl,-rpath,@loader_path/
+endif
+
 #custom rules
 CppBlockUtils_wrap.cxx: CppBlockUtils.i
 	swig $(SWIG_FLAGS) CppBlockUtils.i 
@@ -86,5 +90,3 @@ clean-local:
 	rm -f CppBlockUtils.py
 	rm -f CppBlockUtils_wrap.cxx
 	rm -f CppBlockUtils_wrap.h
-
-

--- a/cppForSwig/cryptopp/Makefile.am
+++ b/cppForSwig/cryptopp/Makefile.am
@@ -12,13 +12,7 @@ endif
 if IS_X86
 
 if CRYPTOPP_HAVE_GCC
-if BUILD_DARWIN
-AM_CXXFLAGS += -arch x86_64 -std=c++11 -stdlib=libc++
-AM_LDFLAGS += -lc++
-else
-AM_CXXFLAGS += -march=native
-endif
-AM_CXXFLAGS += -mtune=generic
+AM_CXXFLAGS += -march=native -mtune=generic
 endif
 
 AM_CXXFLAGS += -mpclmul -maes $(X86_FEATURE_CFLAGS)
@@ -27,6 +21,11 @@ endif	# IS_X86
 if UNAME_LINUX
 AM_CXXFLAGS += -std=c++11
 AM_LDFLAGS += -pthread
+endif
+
+if BUILD_DARWIN
+AM_CXXFLAGS += -arch x86_64
+libcryptopp_la_LDFLAGS = -Wl,-rpath,@executable_path/ -Wl,-rpath,@loader_path/
 endif
 
 INCLUDE_FILES = 3way.h	    crc.h	gcm.h	    modexppc.h	ripemd.h     tea.h \

--- a/osxbuild/build-app.py
+++ b/osxbuild/build-app.py
@@ -49,14 +49,16 @@ APPDIR        = path.join(WORKDIR, 'Armory.app') # actually make it local
 DLDIR         = path.join(WORKDIR, 'downloads')
 UNPACKDIR     = path.join(WORKDIR, 'unpackandbuild')
 INSTALLDIR    = path.join(WORKDIR, 'install')
+PREFIXBASEDIR = path.join(APPDIR, 'Contents/MacOS/py')
 PYPREFIX      = path.join(APPDIR, 'Contents/Frameworks/Python.framework/Versions/%s' % pyMajorVer)
+PREFIXDIR     = path.join(PREFIXBASEDIR, 'usr')
 PYLIBPREFIX   = path.join(PYPREFIX, 'lib')
 PYINCPREFIX   = path.join(PYPREFIX, 'include/python%s' % pyMajorVer)
 PYSITEPKGS    = path.join(PYLIBPREFIX, 'python%s/site-packages' % pyMajorVer)
 MAKEFLAGS     = '-j4'
 
 # Autotools needs some TLC to make Python happy.
-CONFIGFLAGS   = 'LIBS=\"-L%s\" PYTHON_LDFLAGS=\"-L%s\" PYTHON_CPPFLAGS=\"-I%s\" PYTHON_EXTRA_LIBS=\"-u _PyMac_Error %s/Python\"' % (PYLIBPREFIX, PYLIBPREFIX, PYINCPREFIX, PYPREFIX)
+CONFIGFLAGS   = '--with-macosx-version-min=%s LIBS=\"-L%s\" PYTHON_LDFLAGS=\"-L%s\" PYTHON_CPPFLAGS=\"-I%s\" PYTHON_EXTRA_LIBS=\"-u _PyMac_Error %s/Python\"' % (minOSXVer, PYLIBPREFIX, PYLIBPREFIX, PYINCPREFIX, PYPREFIX)
 
 QTBUILTFLAG   = path.join(UNPACKDIR, 'qt/qt_install_success.txt')
 
@@ -678,15 +680,13 @@ def compile_armory():
    armoryAppScript = path.join(APPDIR, 'Contents/MacOS/Armory')
    armorydAppScript = path.join(APPDIR, 'Contents/MacOS/armoryd')
    armoryDB = path.join(APPDIR, 'Contents/MacOS/ArmoryDB')
-   pydir = path.join(APPDIR, 'Contents/MacOS/py')
    currentDir = os.getcwd()
    os.chdir("..")
    execAndWait('python update_version.py')
    os.chdir(currentDir)
    execAndWait('./autogen.sh', cwd='..')
    execAndWait('./configure %s' % CONFIGFLAGS, cwd='..')
-   execAndWait('make all %s' % MAKEFLAGS, cwd='..')
-   execAndWait('make DESTDIR="%s" install %s' % (pydir, MAKEFLAGS), cwd='..')
+   execAndWait('make DESTDIR="%s" install %s' % (PREFIXBASEDIR, MAKEFLAGS), cwd='..')
    copyfile('Armory-script.sh', armoryAppScript)
    copyfile('armoryd-script.sh', armorydAppScript)
    execAndWait('chmod +x "%s"' % armoryAppScript)
@@ -735,7 +735,7 @@ def cleanup_app():
       remove_python_files(PYPREFIX, False)
    else:
       remove_python_files(PYPREFIX)
-   remove_python_files(path.join(APPDIR, 'Contents/MacOS/py'), False)
+   remove_python_files(PREFIXBASEDIR, False)
    show_app_size()
 
 ########################################################


### PR DESCRIPTION
- Make OS X compile/linker flags a bit more consistent.
- Allow OS X to set a minimum target version when compiling.
- Remove unneeded flags.