### PR TITLE
Build improvements

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -74,24 +74,20 @@ case $host in
         [compile using the SDK in DIR])])
     if test "${with_macosx_sdk}" != "" ; then
         test ! -d "${with_macosx_sdk}" && AC_MSG_ERROR([SDK "${with_macosx_sdk}" not found])
-        CPP="${CPP} -isysroot ${with_macosx_sdk}"
-        CC="${CC} -isysroot ${with_macosx_sdk}"
-        CXX="${CXX} -isysroot ${with_macosx_sdk}"
+        CFLAGS="${CFLAGS} -isysroot ${with_macosx_sdk}"
+        CXXFLAGS="${CXXFLAGS} -isysroot ${with_macosx_sdk}"
         OBJC="${OBJC} -isysroot ${with_macosx_sdk}"
-        LD="${LD} -syslibroot ${with_macosx_sdk}"
     fi
     AC_ARG_WITH(macosx-version-min,
       [AS_HELP_STRING([--with-macosx-version-min=VERSION],
         [compile for Mac OS X VERSION and above])])
     if test "${with_macosx_version_min}" != "" ; then
-        CPP="${CPP} -mmacosx-version-min=${with_macosx_version_min}"
-        CC="${CC} -mmacosx-version-min=${with_macosx_version_min}"
-        CXX="${CXX} -mmacosx-version-min=${with_macosx_version_min}"
+        CFLAGS="${CFLAGS} -mmacosx-version-min=${with_macosx_version_min}"
+        CXXFLAGS="${CXXFLAGS} -mmacosx-version-min=${with_macosx_version_min}"
         OBJC="${OBJC} -mmacosx-version-min=${with_macosx_version_min}"
-        LD="${LD} -mmacosx_version_min=${with_macosx_version_min}"
     fi
-    CPP="${CPP} -stdlib=libc++ -std=c++11"
-    CXX="${CXX} -stdlib=libc++ -std=c++11"
+
+    CXXFLAGS="${CXXFLAGS} -stdlib=libc++ -fPIC -pipe"
     LD="${LD} -stdlib=libc++ -std=c++11 -lc++ -undefined dynamic_lookup -headerpad_max_install_names"
 
     # There really ought to be some sort of Qt check here. M4 files don't work
@@ -121,6 +117,18 @@ AC_LANG_POP([C++])
 AC_MSG_RESULT([is compiler clang: $CLANG])
 AC_SUBST([CLANG])
 
+# Declare CFLAGS "unprecious" so that it can be passed directly to subdirs.
+AC_DEFUN([AX_UNPRECIOUS], [
+    m4_define([_AC_PRECIOUS_VARS], m4_bpatsubst(_AC_PRECIOUS_VARS, [$1
+], []))
+])
+AX_UNPRECIOUS([CFLAGS])
+
+export BUILD_OS
+export CFLAGS
+export CXXFLAGS
+export LDFLAGS
+
 AM_CONDITIONAL([HAVE_CLANG], [test x$CLANG = xyes])
 AM_CONDITIONAL([BUILD_DARWIN], [test x$BUILD_OS = xdarwin])
 
@@ -131,3 +139,12 @@ AC_CONFIG_FILES(Makefile
 		cppForSwig/gtest/Makefile)
 
 AC_OUTPUT
+
+echo "  CC            = $CC"
+echo "  CFLAGS        = $CFLAGS"
+echo "  CPP           = $CPP"
+echo "  CPPFLAGS      = $CPPFLAGS"
+echo "  CXX           = $CXX"
+echo "  CXXFLAGS      = $CXXFLAGS"
+echo "  LDFLAGS       = $LDFLAGS"
+echo "  LD            = $LD"

--- a/cppForSwig/Makefile.am
+++ b/cppForSwig/Makefile.am
@@ -1,6 +1,7 @@
 SUBDIRS = lmdb fcgi cryptopp gtest
 
 SWIG_FLAGS = -c++ -python -threads
+AM_CXXFLAGS = $(CXXFLAGS) -std=c++11
 
 if HAVE_GCC
 SWIG_FLAGS += -D__GNUC__
@@ -50,34 +51,36 @@ lib_LTLIBRARIES = libCppBlockUtils.la
 ArmoryDB_SOURCES = $(INCLUDE_FILES) \
 		   $(DB_SOURCE_FILES)
 
-ArmoryDB_CXXFLAGS = -Ilmdb \
+ArmoryDB_CXXFLAGS = $(AM_CXXFLAGS) -Ilmdb \
 		    -Icryptopp \
 		    -Ifcgi -Ifcgi/include \
-		    -D__STDC_LIMIT_MACROS -fPIC -pipe
+		    -D__STDC_LIMIT_MACROS
 
 ArmoryDB_LDADD = -Llmdb -llmdb \
 		 -Lcryptopp -lcryptopp \
 		 -Lfcgi/libfcgi/ -lfcgi \
 		 -lpthread
 
-ArmoryDB_LDFLAGS = -static
+ArmoryDB_LDFLAGS = -static $(LDFLAGS)
 
 #libCppBlockUtils
-libCppBlockUtils_la_SOURCES = 	$(INCLUDE_FILES) \
+libCppBlockUtils_la_SOURCES = $(INCLUDE_FILES) \
 				$(CPPBLOCKUTILS_SOURCE_FILES) \
 				CppBlockUtils_wrap.cxx
-libCppBlockUtils_la_CXXFLAGS = 	-Ilmdb \
+libCppBlockUtils_la_CXXFLAGS = $(AM_CXXFLAGS) -Ilmdb \
 		    		-Icryptopp \
 				$(AX_SWIG_PYTHON_CPPFLAGS) \
 				$(EXTRA_PYTHON_INCLUDES) \
-				-D__STDC_LIMIT_MACROS -fPIC -pipe
+				-D__STDC_LIMIT_MACROS
 
 libCppBlockUtils_la_LIBADD = 	-Llmdb -llmdb \
 		 	 	./cryptopp/libcryptopp.la \
 		 	 	-lpthread
 
+libCppBlockUtils_la_LDFLAGS = $(LDFLAGS)
+
 if BUILD_DARWIN
-libCppBlockUtils_la_LDFLAGS = -Wl,-rpath,@executable_path/ -Wl,-rpath,@loader_path/
+libCppBlockUtils_la_LDFLAGS += -Wl,-rpath,@executable_path/ -Wl,-rpath,@loader_path/
 endif
 
 #custom rules

--- a/cppForSwig/cryptopp/Makefile.am
+++ b/cppForSwig/cryptopp/Makefile.am
@@ -1,30 +1,29 @@
 noinst_LTLIBRARIES = libcryptopp.la
 
 libcryptopp_la_LIBADD =
-AM_LDFLAGS =
-AM_CXXFLAGS = -fPIC -pipe
+AM_LDFLAGS = $(LDFLAGS)
+AM_CXXFLAGS = $(CXXFLAGS) -std=c++11
 
 #compilation flags
 if CRYPTOPP_HAVE_CLANG
 AM_CXXFLAGS += -DCRYPTOPP_DISABLE_ASM
 endif
 
+# On OSX, g++ = clang and comes up as both.
 if IS_X86
-
 if CRYPTOPP_HAVE_GCC
-AM_CXXFLAGS += -march=native -mtune=generic
-endif
-
-AM_CXXFLAGS += -mpclmul -maes $(X86_FEATURE_CFLAGS)
+if ! BUILD_DARWIN
+AM_CXXFLAGS += -march=native -mtune=generic -mpclmul -maes $(X86_FEATURE_CFLAGS)
+endif	# ! BUILD_DARWIN
+endif	# CRYPTOPP_HAVE_GCC
 endif	# IS_X86
 
 if UNAME_LINUX
-AM_CXXFLAGS += -std=c++11
 AM_LDFLAGS += -pthread
 endif
 
 if BUILD_DARWIN
-AM_CXXFLAGS += -arch x86_64
+AM_CXXFLAGS += -DNDEBUG -march=native
 libcryptopp_la_LDFLAGS = -Wl,-rpath,@executable_path/ -Wl,-rpath,@loader_path/
 endif
 

--- a/cppForSwig/gtest/Makefile.am
+++ b/cppForSwig/gtest/Makefile.am
@@ -1,5 +1,12 @@
 SUBDIRS = ../lmdb ../fcgi ../cryptopp
 
+AM_CXXFLAGS =
+
+# "#include <tr1/tuple>" causes a build error on OSX without this flag.
+if BUILD_DARWIN
+AM_CXXFLAGS += -DGTEST_USE_OWN_TR1_TUPLE=1
+endif
+
 INCLUDE_FILES = ../UniversalTimer.h ../BinaryData.h ../lmdb_wrapper.h \
 	../BtcUtils.h ../DBUtils.h ../BlockObj.h ../BlockUtils.h ../EncryptionUtils.h \
 	../BtcWallet.h ../LedgerEntry.h ../ScrAddrObj.h ../Blockchain.h \
@@ -30,12 +37,12 @@ SOURCE_FILES = ../UniversalTimer.cpp ../BinaryData.cpp ../lmdb_wrapper.cpp \
 	../CoinSelection.cpp \
 	gtest-all.cc
 
-AM_CXXFLAGS = -I../lmdb \
+AM_CXXFLAGS += -I../lmdb \
 	-I../cryptopp \
 	-I../fcgi -I../fcgi/include \
-	-D__STDC_LIMIT_MACROS -fPIC
+	-D__STDC_LIMIT_MACROS
 
-AM_LDFLAGS = -static
+AM_LDFLAGS = -static $(LDFLAGS)
 
 bin_PROGRAMS = CppBlockUtilsTests ContainerTests DB1kIterTest
 
@@ -43,19 +50,18 @@ CppBlockUtilsTests_SOURCES = $(INCLUDE_FILES) $(SOURCE_FILES) CppBlockUtilsTests
 DB1kIterTest_SOURCES = $(INCLUDE_FILES) $(SOURCE_FILES) DB1kIterTest.cpp
 ContainerTests_SOURCES = ContainerTests.cpp gtest.h gtest-all.cc
 
+CppBlockUtilsTests_CXXFLAGS = $(AM_CXXFLAGS) $(CXXFLAGS) -std=c++11
+DB1kIterTest_CXXFLAGS = $(AM_CXXFLAGS) $(CXXFLAGS) -std=c++11
+ContainerTests_CXXFLAGS = $(AM_CXXFLAGS) $(CXXFLAGS) -std=c++11
+
 CppBlockUtilsTests_LDADD = -L../lmdb -llmdb \
 	-L../cryptopp -lcryptopp \
 	-L../fcgi/libfcgi/ -lfcgi \
-	-lpthread
+	-lpthread $(LDFLAGS)
 
-ContainerTests_LDADD = -lpthread
+ContainerTests_LDADD = -lpthread $(LDFLAGS)
 
 DB1kIterTest_LDADD = -L../lmdb -llmdb \
 	-L../cryptopp -lcryptopp \
 	-L../fcgi/libfcgi/ -lfcgi \
-	-lpthread
-
-# "#include <tr1/tuple>" causes a build error on OSX without this flag.
-if BUILD_DARWIN
-AM_CXXFLAGS += -DGTEST_USE_OWN_TR1_TUPLE=1
-endif
+	-lpthread $(LDFLAGS)


### PR DESCRIPTION
- Remove Autotools warnings under OS X.
- Allow the root configure file to pass CFLAGS up to configure in subdirectories.
- Miscellaneous flag cleanup.

Tested on OSX and Ubuntu 16.10. Works in conjunction with a libfcgi PR.