### PR TITLE
[Website] 0.96 Release stuff

### DIFF
--- a/_includes/contributors_list.html
+++ b/_includes/contributors_list.html
@@ -1,77 +1,77 @@
 <div class="contributors">
   <div>
-    <div><img src="https://avatars.githubusercontent.com/u/384526?v=3"alt="icon" /></div>
+    <div><img src="https://avatars1.githubusercontent.com/u/384526?v=3"alt="icon" /></div>
     <div><a href="https://github.com/etotheipi">etotheipi</a></div>
     <div>1069</div>
   </div>
   <div>
-    <div><img src="https://avatars.githubusercontent.com/u/5758209?v=3"alt="icon" /></div>
+    <div><img src="https://avatars1.githubusercontent.com/u/5758209?v=3"alt="icon" /></div>
     <div><a href="https://github.com/goatpig">goatpig</a></div>
-    <div>755</div>
+    <div>956</div>
   </div>
   <div>
-    <div><img src="https://avatars.githubusercontent.com/u/5141752?v=3"alt="icon" /></div>
+    <div><img src="https://avatars3.githubusercontent.com/u/5141752?v=3"alt="icon" /></div>
     <div><a href="https://github.com/AndyOfiesh">AndyOfiesh</a></div>
     <div>475</div>
   </div>
   <div>
-    <div><img src="https://avatars.githubusercontent.com/u/5783811?v=3"alt="icon" /></div>
+    <div><img src="https://avatars2.githubusercontent.com/u/5783811?v=3"alt="icon" /></div>
     <div><a href="https://github.com/njaard">njaard</a></div>
     <div>291</div>
   </div>
   <div>
-    <div><img src="https://avatars.githubusercontent.com/u/5931802?v=3"alt="icon" /></div>
+    <div><img src="https://avatars0.githubusercontent.com/u/5931802?v=3"alt="icon" /></div>
     <div><a href="https://github.com/droark">droark</a></div>
-    <div>270</div>
+    <div>290</div>
   </div>
   <div>
-    <div><img src="https://avatars.githubusercontent.com/u/524761?v=3"alt="icon" /></div>
+    <div><img src="https://avatars0.githubusercontent.com/u/3782274?v=3"alt="icon" /></div>
+    <div><a href="https://github.com/achow101">achow101</a></div>
+    <div>59</div>
+  </div>
+  <div>
+    <div><img src="https://avatars3.githubusercontent.com/u/524761?v=3"alt="icon" /></div>
     <div><a href="https://github.com/jimmysong">jimmysong</a></div>
     <div>57</div>
   </div>
   <div>
-    <div><img src="https://avatars.githubusercontent.com/u/3782274?v=3"alt="icon" /></div>
-    <div><a href="https://github.com/achow101">achow101</a></div>
-    <div>44</div>
-  </div>
-  <div>
-    <div><img src="https://avatars.githubusercontent.com/u/863730?v=3"alt="icon" /></div>
+    <div><img src="https://avatars1.githubusercontent.com/u/863730?v=3"alt="icon" /></div>
     <div><a href="https://github.com/fanquake">fanquake</a></div>
     <div>21</div>
   </div>
   <div>
-    <div><img src="https://avatars.githubusercontent.com/u/346306?v=3"alt="icon" /></div>
+    <div><img src="https://avatars1.githubusercontent.com/u/346306?v=3"alt="icon" /></div>
     <div><a href="https://github.com/Rudd-O">Rudd-O</a></div>
     <div>5</div>
   </div>
   <div>
-    <div><img src="https://avatars.githubusercontent.com/u/3298484?v=3"alt="icon" /></div>
+    <div><img src="https://avatars1.githubusercontent.com/u/1197375?v=3"alt="icon" /></div>
+    <div><a href="https://github.com/STRML">STRML</a></div>
+    <div>5</div>
+  </div>
+  <div>
+    <div><img src="https://avatars0.githubusercontent.com/u/3298484?v=3"alt="icon" /></div>
     <div><a href="https://github.com/jameshilliard">jameshilliard</a></div>
     <div>3</div>
   </div>
   <div>
-    <div><img src="https://avatars.githubusercontent.com/u/1197375?v=3"alt="icon" /></div>
-    <div><a href="https://github.com/STRML">STRML</a></div>
-    <div>3</div>
-  </div>
-  <div>
-    <div><img src="https://avatars.githubusercontent.com/u/148100?v=3"alt="icon" /></div>
+    <div><img src="https://avatars3.githubusercontent.com/u/148100?v=3"alt="icon" /></div>
     <div><a href="https://github.com/invalid-email-address">invalid-email-address</a></div>
     <div>2</div>
   </div>
   <div>
-    <div><img src="https://avatars.githubusercontent.com/u/3573821?v=3"alt="icon" /></div>
+    <div><img src="https://avatars2.githubusercontent.com/u/4958549?v=3"alt="icon" /></div>
+    <div><a href="https://github.com/AnAverageHuman">AnAverageHuman</a></div>
+    <div>1</div>
+  </div>
+  <div>
+    <div><img src="https://avatars3.githubusercontent.com/u/3573821?v=3"alt="icon" /></div>
     <div><a href="https://github.com/Ation">Ation</a></div>
     <div>1</div>
   </div>
   <div>
-    <div><img src="https://avatars.githubusercontent.com/u/458997?v=3"alt="icon" /></div>
+    <div><img src="https://avatars3.githubusercontent.com/u/458997?v=3"alt="icon" /></div>
     <div><a href="https://github.com/gwillen">gwillen</a></div>
-    <div>1</div>
-  </div>
-  <div>
-    <div><img src="https://avatars.githubusercontent.com/u/4958549?v=3"alt="icon" /></div>
-    <div><a href="https://github.com/AnAverageHuman">AnAverageHuman</a></div>
     <div>1</div>
   </div>
 </div>

--- a/_posts/2017-05-01-0.96.0-release.md
+++ b/_posts/2017-05-01-0.96.0-release.md
@@ -23,7 +23,7 @@ In preparation for Segwit's activation, two new output script types have been ad
 
 ### Migrating to A New Wallet Format
 
-Armory 0.96.0 marks the beginning to a new wallet format written in C++ and uses LMDB. Currently this wallet format is only a mirrored version of the current Python wallet format. It only contains public data and metadata in order to allow the C++ signing code to function, including support for P2SH-P2PK and P2SH-P2WPKH outputs which are not supported by the current Python wallet format. In the future, this new format will support BIP 32 and compressed public keys.
+Armory 0.96.0 marks the beginning to a new wallet format written in C++ and uses LMDB. Currently this wallet format is only a mirrored version of the current Python wallet format. It only contains public data and metadata in order to allow the C++ signing code to function, including support for P2SH-P2PK and P2SH-P2WPKH outputs which are not supported by the current Python wallet format. In the future, this new format will support BIP 32 and the importing of compressed keys.
 
 ### Dynamic Transaction Fees
 
@@ -31,12 +31,15 @@ In Armory 0.95.0, we added the option to use a fee per byte given by the bitcoin
 
 ### Replace-By-Fee Support
 
-When sending a transaction, the user can now choose to mark a transaction as RBF enabled so that its fee can be increased while it is unconfirmed. While a transaction is unconfirmed, it's fee can be increased with the Fee Bump option. This will create a RBF transaction for transactions sent by your wallet. The fee bump will never be greater than 10% of the original fee value.
+When sending a transaction, the user can now choose to mark a transaction as RBF enabled so that its fee can be increased while it is unconfirmed. While a transaction is unconfirmed, it's fee can be increased with the Fee Bump option. Users will be able to create a replacement transaction where they can change any aspect of the original transaction for the replacement, including increasing the transaction fee.
 
-# Configuration files
+### Configuration files
 
 Config files can now be created for ArmoryQt (armoryqt.conf) and ArmoryDB (armorydb.conf). These files can take any valid command line argument, one per line. Arguments can be commented out using a `#` (pound) symbol. The command line arguments used will always override the arguments set in the config file.
 
+### Translations
+
+Armory now supports multiple languages. Current languages with translations are Danish, German, Greek, Spanish, French, Hebrew, Croatian, Indonesian, Russian, and Swedish. Please note that these all have varying degrees of completness. If a string does not have a translation in the language selected, it will default to English. Translations can be enabled in the Settings dialog or via the `--language=<lang>` command line argument. If you would like to help us translate Armory, please join the [Armory team on Transifex](https://www.transifex.com/bitcoin-armory/bitcoin-armory-software/)
 
 ## Full changelog
 
@@ -178,7 +181,12 @@ and the testers/bug reporters:
 
 ## Downloads
 
- - [Armory 0.96.0 for Windows 64-bit](https://github.com/goatpig/BitcoinArmory/releases/download/v0.96.0/armory_0.96.0_win64.exe)
- - [Armory 0.96.0 for Mac OSX 64-bit](https://github.com/goatpig/BitcoinArmory/releases/download/v0.96.0/armory_0.96.0_osx.tar.gz)
- - [Armory 0.96.0 for Ubuntu/Debian 64-bit](https://github.com/goatpig/BitcoinArmory/releases/download/v0.96.0/armory_0.96.0_amd64.deb)
- - [Armory 0.96.0 Signed Hash File](https://github.com/goatpig/BitcoinArmory/releases/download/v0.96.0/sha256sum.asc)
+Due to some build system and dependency issues, MacOS, Raspberry Pi, and Offline binaries will not be available for this release. These will be released shortly with 0.96.1 which will fix those issues on those platforms as well as a few other bug fixes that were recently reported.
+
+The GCC 4.7 version of the Ubuntu/Debian package is for older systems. If you are unsure which to use, use the GCC 5.3 version first and switch to the GCC 4.7 if the GCC 5.3 version does not work.
+
+ - [Armory 0.96.0 Installer for Windows 64-bit](https://github.com/goatpig/BitcoinArmory/releases/download/v0.96/armory_0.96_win64.exe)
+ - [Armory 0.96.0 Zip package for Windows 64-bit](https://github.com/goatpig/BitcoinArmory/releases/download/v0.96/armory_0.96_win64.zip)
+ - [Armory 0.96.0 for Ubuntu/Debian 64-bit with GCC 4.7](https://github.com/goatpig/BitcoinArmory/releases/download/v0.96/armory_0.96-gcc4.7_amd64.deb)
+ - [Armory 0.96.0 for Ubuntu/Debian 64-bit with GCC 5.3](https://github.com/goatpig/BitcoinArmory/releases/download/v0.96/armory_0.96-gcc5.4_amd64.deb)
+ - [Armory 0.96.0 Signed Hash File](https://github.com/goatpig/BitcoinArmory/releases/download/v0.96/sha256sum.txt.asc)

--- a/_posts/2017-05-01-0.96.0-release.md
+++ b/_posts/2017-05-01-0.96.0-release.md
@@ -1,0 +1,184 @@
+---
+layout: post
+category: releases
+title: Armory 0.96.0 Released
+date: 2017-05-01 00:00:00 -0000
+---
+
+This release is a major release introducing many new features, bug fixes, and optimizations.
+
+## Compatibility
+
+Armory 0.96.0 introduces new output script types, P2SH-P2PK and P2SH-P2WPKH. Spending from these output types requires Armory 0.96.0+. The standard P2PKH output types are still created and can be signed for by previous versions dating back to Armory 0.92.x.
+
+This version is also compatible with Bitcoin Core 0.14.0+.
+
+## Notable Changes
+
+### Segregated Witness Support
+
+Armory 0.96.0 contains all of the code necessary in order for it to use Segregated Witness. This functionality is currently hard-coded to be disabled on mainnet, but is enabled on testnet for users to experiment with this feature if they wish.
+
+In preparation for Segwit's activation, two new output script types have been added. Users can now choose between P2PKH, P2SH-P2PK, and P2SH-P2WPKH addresses. While Segwit is still not activated, the P2SH-P2WPKH address type will not be available. P2PKH are the standard addresses that are currently in use. Those addresses are backwards compatible and can be used in older versions of Armory. P2SH-P2PK is a Pay-to-Pubkey script as the redeemscript of a P2SH address. P2SH-P2WPKH is a Pay-to-Witness-Pubkey-Hash output nested within a P2SH output as specified by [BIP 141](https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#P2WPKH_nested_in_BIP16_P2SH). In order to spend from P2SH-P2PK and P2SH-P2WPKH outputs, you must use Armory 0.96+.
+
+### Migrating to A New Wallet Format
+
+Armory 0.96.0 marks the beginning to a new wallet format written in C++ and uses LMDB. Currently this wallet format is only a mirrored version of the current Python wallet format. It only contains public data and metadata in order to allow the C++ signing code to function, including support for P2SH-P2PK and P2SH-P2WPKH outputs which are not supported by the current Python wallet format. In the future, this new format will support BIP 32 and compressed public keys.
+
+### Dynamic Transaction Fees
+
+In Armory 0.95.0, we added the option to use a fee per byte given by the bitcoind running behind the scenes. This transaction fee option has been expanded to allow users to set their own confirmation target, set a different fee rate, or set a fixed transaction fee. The automatic fee per byte option is selected by default and will adjust the transaction fee based upon the inputs selected for your transaction.
+
+### Replace-By-Fee Support
+
+When sending a transaction, the user can now choose to mark a transaction as RBF enabled so that its fee can be increased while it is unconfirmed. While a transaction is unconfirmed, it's fee can be increased with the Fee Bump option. This will create a RBF transaction for transactions sent by your wallet. The fee bump will never be greater than 10% of the original fee value.
+
+# Configuration files
+
+Config files can now be created for ArmoryQt (armoryqt.conf) and ArmoryDB (armorydb.conf). These files can take any valid command line argument, one per line. Arguments can be commented out using a `#` (pound) symbol. The command line arguments used will always override the arguments set in the config file.
+
+
+## Full changelog
+
+### Added
+   - 2 new script types have been introduced on top of legacy P2PKH:
+      - P2SH-P2PK: nested P2PK script. Uses compressed public keys.
+      - P2SH-P2WPKH: nested P2WPKH SegWit single sig output script.
+
+   - Added new signer code to handle the new script types. The code is only used when redeeming outputs using 
+     the new scripts. All legacy outputs (P2PKH) are still handled by the original code and can be signed for 
+     by previous versions dating back to 0.92.x. New address selection GUI let's the user pick the output script 
+     of their choice.
+
+   - The modified offline signing serialization format is backwards compatible. Older version can sign for legacy outputs.
+     Older versions can also fund the new types (as they are P2SH scripts). You will need Armory 0.96+ to spend from these
+     new scripts
+
+   - Introducing brand new wallet code in C++, using LMDB for system I/O. The new code is compatible with Armory's 
+     own chain derivation and can reproduce any existing Armory wallet. Starting 0.96, all existing wallets
+     are mirrored to this new format.
+
+   - Wallet mirrors are exclusively watching only (they only contain public data). The new wallet code interfaces with 
+     the new address types and signer code. It is used to bridge the wallet data from client to database and distinguish 
+     between output scripts.
+
+   - Single address use patterns are preserved. While any wallet can return any of the new output scripts, the new 
+     wallet code guarantees requested new addresses originate from fresh public keys and locks public keys to their
+     chosen address type.
+
+   - Coin selection logic has been reproduced on the C++ side, with some improvements. It allows for proper interaction
+     with satoshi/byte fee options and provides predictive tx size thanks to the new wallet framework.
+
+   - New options have been introduced for fee management:
+      - Manual fee/byte.
+      - Auto fee/byte.
+
+      Auto fee/byte queries fee/byte from your local node over the RPC. It defaults to the default manual fee/byte on
+      failure. UI has been added to the Settings dialog to change the defaults. UI has been added to the Send dialog
+      to select fee options on the fly.
+
+   - Added optional auto adjust fee/byte feature. This feature ties back to the new coin selection logic. When using 
+     fee/byte options, it attempts to increase your fee in order to lign up the precision of your change output with
+     the precision of your spend values. The goal is to obfuscate your change output in conjunction with the existing
+     output order randomization, by bluring the difference in value between change and payement outputs. This feature
+     improves privacy when applicable.
+     
+     The fee bump is never more than 10% the original fee value and the coin selection code will prioritize outputs
+     that fit this strategy if enabled. This behavior can be turned on and off in the new fee dialogs.
+
+   - Added new change address options, configurable in a new settings tab. The options allow the user to pick the 
+     script type of the change address, or automate it.
+
+     When automated, the change output will attempt to match the output script type of the payement address. This
+     feature improves privacy by unifying output script types, which obfuscates the change output. 
+
+     If the recipient address types do not match, auto change will create a P2SH-P2PK output (as it uses compressed 
+     public keys). Keep in mind that all versions prior to 0.96 cannot redeem these type of P2SH outputs.
+
+     If the transaction is SegWit and the change output is automated, the output script type will be P2SH-P2WPKH.
+
+   - The coin selection code will attempt to consolidate unspent outputs in order to redeem more outputs than it creates. 
+     This behavior only takes place if there are available outputs sharing the same address as the already selected ones. 
+     This behavior will not inflate the transaction fee by more than 20%.
+
+   - When choosing fee/byte options, the coin selection code will not create a change output if the change is considered
+     dust. Dust change refers to a change output with a value lower than the fee it will cost to redeem it. 
+
+     In such case, the change value will be added to the transaction fee instead. This will increase tx priority and 
+     improve privacy (as there will be no change output).
+
+   - Reworked the coin control dialog. It now distinguishes between address types. It also allows the selection of CPFP 
+     outputs when applicable.
+
+   - Added RBF support. You can create RBF transactions from the Send dialogue. Checking the RBF box will set all input
+     sequences to (UINT32_MAX - 2).
+
+   - Modified zero confirmation coloring in legders. Own RBFs are displayed in a teal line. Incoming RBFs are red, child
+     ZC (a zero confirmation transaction spending at least one zero confirmation output) are displayed as orange.
+
+   - Your own RBFs have an extra right click menu option, to bump the fee. This will spawn the send dialogue with
+     prefilled fields.
+
+   - A coin control like RBF dialog has been added. It can be accessed from the send dialogue, under the Coin Control
+     button. It allows you to pick any eligible RBF output to double spend. RBF coin control and regular coin control
+     are mutually exclusive. The UX is still experimental, and subject to improvements/redesign.
+
+   - Transactions are now time locked to the current top block. This means miners cannot mine this transaction in a 
+     block with a lower height than specified in the nLockTime field. This limits selfish mining attack scenarios, and
+     is in line with Bitcoin Core's own wallet practices. 
+
+     Due to a mismanagement of the nLockTime field in previous versions, older signers cannot sign transactions 
+     with a nLockTime other than 0. This means that when signing for a legacy P2PKH output with an a pre 0.96 signer, 
+     the transaction will default back to a 0 nLockTime.
+
+   - Added the option to force the full redemption of coin control selection. Previously, the coin selection code would 
+     pick outputs from within a custom coin control set. This option instructs the code to use the set as is, regardless
+     of total spent amount.
+
+   - Added a Tx preview button to the send dialog, to review transactions before clicking "Send".
+
+   - Reworked address ledger in wallet properties dialog. Now distinguishes between address categories (Used, Change and 
+     Unused) and address types (P2PKH, P2SH-P2PK, P2SH-P2WPKH)
+
+   - The SegWit address type (P2SH-P2WPKH) can only be used if your local node operates on a chain that has activated SegWit.
+     SegWit is disabled on the Bitcoin mainnet through the use of a hardcoded flag.
+
+   - Moved node RPC socketing to ArmoryDB. ArmoryDB now waits on node initiliazation and synchronization processes if it can 
+     establish a RPC connection.
+
+   - Migrated build system from raw Makefiles to autotools. This will eventually lead to deterministic builds through Gitian.
+
+   - Added config files for ArmoryQt (armoryqt.conf) and ArmoryDB (armorydb.conf). The config files can take any valid command
+     line arguments for their respective binaries (one arg per line). Config file arguments do not override command line 
+     arguments
+
+### Fixed
+
+   - Fixed transaction count display in wallet properties dialog
+   - Fixed wallet group selector in online lobby
+   - Fixed lockbox spending
+   - Will now properly display updated comments in global ledger
+   - Fixed wallet restore features
+   - Fixed P2P socketing with refactor Bitcoin Core networking layer (0.14+)
+   - Fixed clear mempool feature
+   - The bottom right block count indicator in the client now reports node connectivity properly, with tray notifications and
+     color coding
+   - Fixed interfacing between DB running on a Linux server and clients running on Windows.
+
+## Contributors
+
+Thank you to all the contributors: 
+
+- [https://github.com/goatpig/BitcoinArmory/graphs/contributors](https://github.com/goatpig/BitcoinArmory/graphs/contributors)
+
+and the testers/bug reporters: 
+
+- [Preliminary testing](https://bitcointalk.org/index.php?topic=1784442.0)
+- [Testing builds](https://bitcointalk.org/index.php?topic=1849994.0)
+
+## Downloads
+
+ - [Armory 0.96.0 for Windows 64-bit](https://github.com/goatpig/BitcoinArmory/releases/download/v0.96.0/armory_0.96.0_win64.exe)
+ - [Armory 0.96.0 for Mac OSX 64-bit](https://github.com/goatpig/BitcoinArmory/releases/download/v0.96.0/armory_0.96.0_osx.tar.gz)
+ - [Armory 0.96.0 for Ubuntu/Debian 64-bit](https://github.com/goatpig/BitcoinArmory/releases/download/v0.96.0/armory_0.96.0_amd64.deb)
+ - [Armory 0.96.0 Signed Hash File](https://github.com/goatpig/BitcoinArmory/releases/download/v0.96.0/sha256sum.asc)

--- a/contribute/armory-todo.md
+++ b/contribute/armory-todo.md
@@ -7,6 +7,7 @@ permalink: /contribute/armory-todo/
 
 Things that need to be done for Armory are listed here. Feel free to choose one and begin working on it, just check that no one else is working on the same thing.
 
- - Segwit wallets (wait for goatpig to finish the new wallets)
- - Enable the import of compressed keys
- - Complete translations
+ - BIP 32 support (New C++ wallet format)
+ - Compressed key support (New C++ wallet format)
+ - Hardware wallet support (New C++ wallet format)
+ - BIP 9 Deployments checking


### PR DESCRIPTION
This contains the release post for 0.96, the contributors page update, and todo list update.

The release post is not finished yet. It needs to have the correct download links which are only available once the binaries are posted. Let me know when that happens and I will update it.

To those of you who see this PR and want to post it to reddit, bitcointalk, etc., please don't. Wait for the binaries to be posted and for goatpig to make the announcement on bitcointalk before posting elsewhere about this release. Also, only the developers of this project should really be posting release announcements, so if you aren't one, I ask that you don't.