### PR TITLE
Better timestamps in logs

### DIFF
--- a/armoryengine/ArmoryUtils.py
+++ b/armoryengine/ArmoryUtils.py
@@ -899,7 +899,7 @@ if CLI_OPTIONS.logDisable:
    DEFAULT_FILE_LOGTHRESH     += 100
 
 
-DateFormat = '%Y-%m-%d %H:%M'
+DateFormat = '%Y-%m-%d %H:%M:%S'
 logging.getLogger('').setLevel(logging.DEBUG)
 fileFormatter  = logging.Formatter('%(asctime)s (%(levelname)s) -- %(message)s', \
                                      datefmt=DateFormat)

--- a/cppForSwig/log.h
+++ b/cppForSwig/log.h
@@ -91,7 +91,6 @@
 using namespace std;
 
 inline string NowTime();
-inline unsigned long long int NowTimeInt();
 
 typedef enum 
 {
@@ -154,7 +153,7 @@ public:
       fname_ = logfile;
       truncateFile(fname_, maxSz);
       fout_.open(OS_TranslatePath(fname_.c_str()), ios::app); 
-      fout_ << "\n\nLog file opened at " << NowTimeInt() << ": " << fname_.c_str() << endl;
+      fout_ << "\n\nLog file opened at " << NowTime() << ": " << fname_.c_str() << endl;
    }
 
    
@@ -342,7 +341,7 @@ public:
    { 
       LogStream & lg = Log::GetInstance().Get(logLevel_);
       lg << "-" << Log::ToString(logLevel_);
-      lg << "- " << NowTimeInt() << ": ";
+      lg << "- " << NowTime() << ": ";
       return lg;
    }
 
@@ -395,13 +394,6 @@ inline string NowTime()
     return result;
 }
 
-inline unsigned long long int NowTimeInt(void)
-{
-   time_t t;
-   time(&t);
-   return (unsigned long long int)t;
-}
-
 #else
 
 #include <sys/time.h>
@@ -418,13 +410,6 @@ inline string NowTime()
     char result[100] = {0};
     sprintf(result, "%s", buffer);
     return result;
-}
-
-inline unsigned long long int NowTimeInt(void)
-{
-   time_t t;
-   time(&t);
-   return (unsigned long long int)t;
 }
 
 #endif //WIN32


### PR DESCRIPTION
Changed c++ logger to use human readable time instead of unix timestamps.

Added seconds to python logger time format