### PR TITLE
Bump required OS X version to 10.8

### DIFF
--- a/osxbuild/Info.plist
+++ b/osxbuild/Info.plist
@@ -9,7 +9,7 @@
   <key>CFBundleInfoDictionaryVersion</key> <string>0.89.99.3</string>
   <key>CFBundleName</key> <string>Armory Bitcoin Client</string>
   <key>NSPrincipalClass</key> <string>NSApplication</string>
-  <key>LSMinimumSystemVersion</key> <string>10.7.0</string>
+  <key>LSMinimumSystemVersion</key> <string>10.8.0</string>
   <key>LSAppNapIsDisabled</key> <true/>
 </dict>
 </plist>

--- a/osxbuild/OSX_build_notes.md
+++ b/osxbuild/OSX_build_notes.md
@@ -1,13 +1,11 @@
 # macOS (OS X) BUILD NOTES
-These notes describe what had to be done on fresh installs of OS X 10.7 - 10.12 in order to compile Armory.
+These notes describe what had to be done on fresh installs of OS X 10.8 - 10.12 in order to compile Armory.
 
 ## Requirements / Caveats
-At the present time, **it is highly recommended that Armory be compiled on OS X 10.11 with Xcode 7.3.1**. This is due to issues with C++11 support under OS X 10.7, which Armory still supports (although this will change eventually). When compiling using Xcode 8, Xcode forces the minimum supported version to be 10.8. When compiling using Xcode 7 and OS X 10.12, other issues come up. Xcode 7 and OS X 10.11 is the only combo known to produce binaries that run without issues.
-
-Because C++11 support is shaky on OS X 10.7, *Armory developers may not fix bugs found under 10.7*. If a bug is found, please consult the [Bitcoin Forum](https://bitcointalk.org/index.php?board=97.0) or *bitcoin-armory* IRC channel on Freenode for further instructions.
+At the present time, **it is highly recommended that Armory be compiled on OS X 10.11+ with Xcode 8+**. The minimum OS X version supported is 10.8 due to issues with C++11 support under OS X 10.7.
 
 ## Instructions
- 1. Install the latest version of [Xcode](https://itunes.apple.com/us/app/xcode/id497799835). Due to the XCode 8 issue, you may need to get an [Apple developer account](https://developer.apple.com/) and download the latest XCode 7 version via developer-specific downloads.
+ 1. Install the latest version of [Xcode](https://itunes.apple.com/us/app/xcode/id497799835).
 
  2. Open a terminal and install the Xcode commandline tools. Follow any prompts that appear.
 

--- a/osxbuild/build-app.py
+++ b/osxbuild/build-app.py
@@ -18,7 +18,7 @@ from subprocess import Popen, PIPE
 from tempfile import mkstemp
 
 # Set some constants up front
-minOSXVer     = '10.7'
+minOSXVer     = '10.8'
 pythonVer     = '2.7.13' # NB: ArmoryMac.pro must also be kept up to date!!!
 pyMajorVer    = '2.7'
 setToolVer    = '33.1.1' # 34.1.1 has a circular dependency w/ pyparsing. Downgrade.

--- a/osxbuild/objc_armory/ArmoryMac.pro
+++ b/osxbuild/objc_armory/ArmoryMac.pro
@@ -51,12 +51,12 @@ QMAKE_LFLAGS += "-undefined dynamic_lookup"
 # Handle the Objective-C++ files. This will include executing moc on the
 # ArmoryMac.h file, creating a resultant CPP file, and compiling the CPP file.
 # (Such a step is critical for getting the shared library to work properly.)
-# Because we support 10.7+, it's safe to assume we can use SSSE3 instructions.
+# Because we support 10.8+, it's safe to assume we can use SSSE3 instructions.
 # NB: -std=c++11 -stdlib=libc++ will be required for Qt 4.8.7+.
 # Source: http://stackoverflow.com/questions/2355056/how-to-mix-qt-c-and-obj-c-cocoa
 # Source: http://el-tramo.be/blog/mixing-cocoa-and-qt
 # Source: http://stackoverflow.com/questions/18768219/sdl-framework-include-on-macos-qt
-QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.7
+QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.8
 # 4.8.7 upgrade
 #QMAKE_OBJECTIVE_CFLAGS += -std=c++11 -stdlib=libc++
 QMAKE_OBJECTIVE_CFLAGS += -Xarch_x86_64 -mmacosx-version-min=$${QMAKE_MACOSX_DEPLOYMENT_TARGET} -O2 -arch x86_64 -mssse3 -Wall -W -fPIC

--- a/release_scripts/README.txt
+++ b/release_scripts/README.txt
@@ -197,10 +197,10 @@ def getMasterPackageList():
    m[pkg]['FetchFrom']  = ['scp', 'joeschmoe', '192.168.1.22', 22, '~/BitcoinArmory/osxbuild/armory_%s_osx.tar.gz']
    m[pkg]['FileSuffix'] = 'osx.tar.gz'
    m[pkg]['OSNameDisp'] = 'MacOSX'
-   m[pkg]['OSVarDisp']  = '10.7+'
+   m[pkg]['OSVarDisp']  = '10.8+'
    m[pkg]['OSArchDisp'] = '64bit'
    m[pkg]['OSNameLink'] = 'MacOSX'
-   m[pkg]['OSVarLink']  = '10.7,10.8,10.9,10.9.1,10.9.2'
+   m[pkg]['OSVarLink']  = '10.8,10.9,10.9.1,10.9.2'
    m[pkg]['OSArchLink'] = '64''
    m[pkg]['HasBundle']  = False
    


### PR DESCRIPTION
ArmoryDB doesn't build unless the minimum OS X version is 10.8 due to missing C++ features. The latest Bitcoin Core also requires OS X 10.8 so we should drop 10.7 support.