### PR TITLE
Fix broadcast timeout

### DIFF
--- a/cppForSwig/BDM_supportClasses.cpp
+++ b/cppForSwig/BDM_supportClasses.cpp
@@ -2056,42 +2056,65 @@ void ZeroConfContainer::broadcastZC(const BinaryData& rawzc,
       return;
    }
 
-   auto watchTxFuture = gds->getFuture();
+   // Wait for a reject message. If one is sent, it will go to gds
+   auto watchForRejectFut = gds->getFuture();
+   watchForRejectFut.wait_for(chrono::seconds(timeout_sec));
 
-   //try to fetch tx by hash from node
-   if(PEER_USES_WITNESS)
-      entry.invtype_ = Inv_Msg_Witness_Tx;
+   // Do a ping-pong to make sure that the connection is live
+   // If the ping-pong is successful and no reject was received, then the transaction
+   // can be considered successfully sent.
+   
+   // Get a random nonce
+   srand(time(0));
+   uint64_t nonce = rand();
+   
+   // Construct pong payload and promise
+   auto pongProm = make_shared<promise<bool>>();
+   auto pongFut = pongProm->get_future();
 
-   auto grabtxlambda = [this](InvEntry inventry)->void
-   {
-      processInvTxThread(move(inventry));
-   };
+   BitcoinP2P::pongPayload pongPayload;
+   auto&& pong_payload = make_unique<Payload_Pong>();
+   pong_payload->nonce_ = nonce;
+   pongPayload.payload_ = move(pong_payload);
+   pongPayload.promise_ = pongProm;
+   
+   pair<uint64_t, BitcoinP2P::pongPayload> pongPair;
+   pongPair.first = nonce;
+   pongPair.second = move(pongPayload);
 
-   thread grabtxthread(grabtxlambda, move(entry));
-   if (grabtxthread.joinable())
-      grabtxthread.detach();
+   //register getData payload
+   networkNode_->pongPayloadMap_.insert(move(pongPair));
 
-
+   // Construct ping payload and send
+   Payload_Ping payload_ping;
+   payload_ping.nonce_ = nonce;
+   networkNode_->sendMessage(move(payload_ping));
+   
+   //wait on pong future
    if (timeout_sec == 0)
    {
-      watchTxFuture.wait();
+      pongFut.wait();
    }
    else
    {
-      auto status = watchTxFuture.wait_for(chrono::seconds(timeout_sec));
-      if (status != future_status::ready)
+      auto pongFutStatus = pongFut.wait_for(chrono::seconds(timeout_sec));
+      if (pongFutStatus != future_status::ready)
       {
          gds->setStatus(false);
-         gds->setMessage("tx broadcast timed out (get)");
+         gds->setMessage("tx broadcast failed. Disconnected from node.");
       }
    }
-   
+      
    networkNode_->unregisterGetTxCallback(txHash);
 
    if (!gds->status())
    {
       auto&& errorMsg = gds->getMessage();
       bdv_cb.zcErrorCallback_(errorMsg, txHashStr);
+   }
+   else
+   {
+      // TODO: add tx to wallet
    }
 }
 

--- a/cppForSwig/BDM_supportClasses.h
+++ b/cppForSwig/BDM_supportClasses.h
@@ -447,6 +447,7 @@ private:
 
    void processInvTxThread(void);
    bool processInvTxThread(InvEntry);
+   void ProcessZCPayloadTx(shared_ptr<Payload_Tx>&);
 
 public:
    //stacks new zc Tx objects from node

--- a/cppForSwig/BitcoinP2p.h
+++ b/cppForSwig/BitcoinP2p.h
@@ -535,8 +535,15 @@ public:
       shared_ptr<Payload> payload_;
       shared_ptr<promise<bool>> promise_;
    };
+   
+   struct pongPayload
+   {
+      shared_ptr<Payload> payload_;
+      shared_ptr<promise<bool>> promise_;
+   };
 
    TransactionalMap<BinaryData, getDataPayload> getDataPayloadMap_;
+   TransactionalMap<uint64_t, pongPayload> pongPayloadMap_;
 
 public:
    static const map<string, PayloadType> strToPayload_;
@@ -563,6 +570,7 @@ private:
    void processGetData(unique_ptr<Payload>);
    void processGetTx(unique_ptr<Payload>);
    void processReject(unique_ptr<Payload>);
+   void processPong(unique_ptr<Payload>);
 
    int64_t getTimeStamp() const;
 


### PR DESCRIPTION
This fixes the problem where users would receive a "tx broadcast timed out (get)" error.

Asking the transaction back from the node is unreliable since the node will not relay a transaction back to the node that sent it. In order for the transaction to be received back, it must have relayed it to the other nodes it is connected to. 

This PR replaces that mechanism entirely. Instead of asking for the transaction back, we send a ping and wait for a pong. If a reject is received before a pong, the transaction is bad and was not broadcast. If we receive a pong, then the transaction was good and was successfully sent to the node.

Users who run nodes with a large amount of connections (like myself) were unlikely to experience the original error since there is a higher probability that the transaction would be relayed to other nodes by the time it was requested for again by Armory.