### PR TITLE
fix typos in Welcome to Armory! popup (3rd attempt) 

### DIFF
--- a/lang/armory_en.ts
+++ b/lang/armory_en.ts
@@ -23,7 +23,7 @@
         <translation>Synchronizing wallet %1</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3862"/>
+        <location filename="qtdialogs.py" line="3867"/>
         <source>Add comment</source>
         <translation>Add comment</translation>
     </message>
@@ -195,17 +195,17 @@
 <context>
     <name>ArmoryDialog</name>
     <message>
-        <location filename="qtdefines.py" line="725"/>
+        <location filename="qtdefines.py" line="729"/>
         <source>Armory - Bitcoin Wallet Management [TESTNET] </source>
         <translation>Armory - Bitcoin Wallet Management [TESTNET] </translation>
     </message>
     <message>
-        <location filename="qtdefines.py" line="728"/>
+        <location filename="qtdefines.py" line="732"/>
         <source>Armory - Bitcoin Wallet Management [REGTEST] </source>
         <translation>Armory - Bitcoin Wallet Management [REGTEST] </translation>
     </message>
     <message>
-        <location filename="qtdefines.py" line="731"/>
+        <location filename="qtdefines.py" line="735"/>
         <source>Armory - Bitcoin Wallet Management</source>
         <translation>Armory - Bitcoin Wallet Management</translation>
     </message>
@@ -213,337 +213,337 @@
 <context>
     <name>ArmoryMainWindow</name>
     <message>
-        <location filename="ArmoryQt.py" line="297"/>
+        <location filename="ArmoryQt.py" line="295"/>
         <source>&lt;font color=%1&gt;Offline&lt;/font&gt; </source>
         <translation>&lt;font color=%1&gt;Offline&lt;/font&gt; </translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="348"/>
+        <location filename="ArmoryQt.py" line="346"/>
         <source>Create Wallet</source>
         <translation>Create Wallet</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="349"/>
+        <location filename="ArmoryQt.py" line="347"/>
         <source>Import or Restore Wallet</source>
         <translation>Import or Restore Wallet</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="354"/>
+        <location filename="ArmoryQt.py" line="352"/>
         <source>&lt;b&gt;Available Wallets:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Available Wallets:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="384"/>
+        <location filename="ArmoryQt.py" line="382"/>
         <source>&lt;b&gt;Maximum Funds:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Maximum Funds:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="385"/>
+        <location filename="ArmoryQt.py" line="383"/>
         <source>&lt;b&gt;Spendable Funds:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Spendable Funds:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="386"/>
+        <location filename="ArmoryQt.py" line="384"/>
         <source>&lt;b&gt;Unconfirmed:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Unconfirmed:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="405"/>
+        <location filename="ArmoryQt.py" line="403"/>
         <source>Funds that can be spent &lt;i&gt;right now&lt;/i&gt;</source>
         <translation>Funds that can be spent &lt;i&gt;right now&lt;/i&gt;</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="434"/>
+        <location filename="ArmoryQt.py" line="432"/>
         <source>Dashboard</source>
         <translation>Dashboard</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="1302"/>
+        <location filename="ArmoryQt.py" line="1300"/>
         <source>Send Bitcoins</source>
         <translation>Send Bitcoins</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="1303"/>
+        <location filename="ArmoryQt.py" line="1301"/>
         <source>Receive Bitcoins</source>
         <translation>Receive Bitcoins</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="450"/>
+        <location filename="ArmoryQt.py" line="448"/>
         <source>Wallet Properties</source>
         <translation>Wallet Properties</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="451"/>
+        <location filename="ArmoryQt.py" line="449"/>
         <source>Offline Transactions</source>
         <translation>Offline Transactions</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="452"/>
+        <location filename="ArmoryQt.py" line="450"/>
         <source>Lockboxes (Multi-Sig)</source>
         <translation>Lockboxes (Multi-Sig)</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="509"/>
+        <location filename="ArmoryQt.py" line="507"/>
         <source>&amp;File</source>
         <translation>&amp;File</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="510"/>
+        <location filename="ArmoryQt.py" line="508"/>
         <source>&amp;User</source>
         <translation>&amp;User</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="511"/>
+        <location filename="ArmoryQt.py" line="509"/>
         <source>&amp;Tools</source>
         <translation>&amp;Tools</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="512"/>
+        <location filename="ArmoryQt.py" line="510"/>
         <source>&amp;Addresses</source>
         <translation>&amp;Addresses</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="513"/>
+        <location filename="ArmoryQt.py" line="511"/>
         <source>&amp;Wallets</source>
         <translation>&amp;Wallets</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="514"/>
+        <location filename="ArmoryQt.py" line="512"/>
         <source>&amp;MultiSig</source>
         <translation>&amp;MultiSig</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="515"/>
+        <location filename="ArmoryQt.py" line="513"/>
         <source>&amp;Help</source>
         <translation>&amp;Help</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="521"/>
+        <location filename="ArmoryQt.py" line="519"/>
         <source>Transactions Unavailable</source>
         <translation>Transactions Unavailable</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="589"/>
+        <location filename="ArmoryQt.py" line="587"/>
         <source>&amp;Message Signing/Verification...</source>
         <translation>&amp;Message Signing/Verification...</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="591"/>
+        <location filename="ArmoryQt.py" line="589"/>
         <source>&amp;EC Calculator...</source>
         <translation>&amp;EC Calculator...</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="592"/>
+        <location filename="ArmoryQt.py" line="590"/>
         <source>&amp;Broadcast Raw Transaction...</source>
         <translation>&amp;Broadcast Raw Transaction...</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="2024"/>
+        <location filename="ArmoryQt.py" line="2022"/>
         <source>Offline</source>
         <translation>Offline</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="610"/>
+        <location filename="ArmoryQt.py" line="608"/>
         <source>Import Multi-Spend Transaction</source>
         <translation>Import Multi-Spend Transaction</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="624"/>
+        <location filename="ArmoryQt.py" line="622"/>
         <source>Simulfund &amp;Promissory Note</source>
         <translation>Simulfund &amp;Promissory Note</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="625"/>
+        <location filename="ArmoryQt.py" line="623"/>
         <source>Simulfund &amp;Collect &amp;&amp; Merge</source>
         <translation>Simulfund &amp;Collect &amp;&amp; Merge</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="626"/>
+        <location filename="ArmoryQt.py" line="624"/>
         <source>Simulfund &amp;Review &amp;&amp; Sign</source>
         <translation>Simulfund &amp;Review &amp;&amp; Sign</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="633"/>
+        <location filename="ArmoryQt.py" line="631"/>
         <source>View &amp;Address Book...</source>
         <translation>View &amp;Address Book...</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="634"/>
+        <location filename="ArmoryQt.py" line="632"/>
         <source>&amp;Sweep Private Key/Address...</source>
         <translation>&amp;Sweep Private Key/Address...</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="635"/>
+        <location filename="ArmoryQt.py" line="633"/>
         <source>&amp;Import Private Key/Address...</source>
         <translation>&amp;Import Private Key/Address...</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="642"/>
+        <location filename="ArmoryQt.py" line="640"/>
         <source>&amp;Create New Wallet</source>
         <translation>&amp;Create New Wallet</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="643"/>
+        <location filename="ArmoryQt.py" line="641"/>
         <source>&amp;Import or Restore Wallet</source>
         <translation>&amp;Import or Restore Wallet</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="644"/>
+        <location filename="ArmoryQt.py" line="642"/>
         <source>View &amp;Address Book</source>
         <translation>View &amp;Address Book</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="645"/>
+        <location filename="ArmoryQt.py" line="643"/>
         <source>&amp;Fix Damaged Wallet</source>
         <translation>&amp;Fix Damaged Wallet</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="654"/>
+        <location filename="ArmoryQt.py" line="652"/>
         <source>&amp;About Armory...</source>
         <translation>&amp;About Armory...</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="655"/>
+        <location filename="ArmoryQt.py" line="653"/>
         <source>Clear All Unconfirmed</source>
         <translation>Clear All Unconfirmed</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="656"/>
+        <location filename="ArmoryQt.py" line="654"/>
         <source>Rescan Databases</source>
         <translation>Rescan Databases</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="657"/>
+        <location filename="ArmoryQt.py" line="655"/>
         <source>Rebuild and Rescan Databases</source>
         <translation>Rebuild and Rescan Databases</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="658"/>
+        <location filename="ArmoryQt.py" line="656"/>
         <source>Rescan Balance</source>
         <translation>Rescan Balance</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="659"/>
+        <location filename="ArmoryQt.py" line="657"/>
         <source>Factory Reset</source>
         <translation>Factory Reset</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="674"/>
+        <location filename="ArmoryQt.py" line="672"/>
         <source>Multi-Sig Lockboxes</source>
         <translation>Multi-Sig Lockboxes</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="675"/>
+        <location filename="ArmoryQt.py" line="673"/>
         <source>Lockbox &amp;Manager...</source>
         <translation>Lockbox &amp;Manager...</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="722"/>
+        <location filename="ArmoryQt.py" line="720"/>
         <source>Default Data Directory</source>
         <translation>Default Data Directory</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="729"/>
+        <location filename="ArmoryQt.py" line="727"/>
         <source>Default Database Directory</source>
         <translation>Default Database Directory</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="736"/>
+        <location filename="ArmoryQt.py" line="734"/>
         <source>Bitcoin Directory</source>
         <translation>Bitcoin Directory</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="743"/>
+        <location filename="ArmoryQt.py" line="741"/>
         <source>Delete Old DB Directory</source>
         <translation>Delete Old DB Directory</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="1492"/>
+        <location filename="ArmoryQt.py" line="1490"/>
         <source>Do not ask this question again</source>
         <translation>Do not ask this question again</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="941"/>
+        <location filename="ArmoryQt.py" line="939"/>
         <source>Bad Module</source>
         <translation>Bad Module</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="950"/>
+        <location filename="ArmoryQt.py" line="948"/>
         <source>Outdated Module</source>
         <translation>Outdated Module</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="912"/>
+        <location filename="ArmoryQt.py" line="910"/>
         <source>Invalid Module</source>
         <translation>Invalid Module</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="922"/>
+        <location filename="ArmoryQt.py" line="920"/>
         <source>UNSIGNED Module</source>
         <translation>UNSIGNED Module</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="1023"/>
+        <location filename="ArmoryQt.py" line="1021"/>
         <source>Memory Pool</source>
         <translation>Memory Pool</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="1153"/>
+        <location filename="ArmoryQt.py" line="1151"/>
         <source>Queue Rescan?</source>
         <translation>Queue Rescan?</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="1165"/>
+        <location filename="ArmoryQt.py" line="1163"/>
         <source>Queue Rebuild?</source>
         <translation>Queue Rebuild?</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="1177"/>
+        <location filename="ArmoryQt.py" line="1175"/>
         <source>Queue Balance Rescan?</source>
         <translation>Queue Balance Rescan?</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="1217"/>
+        <location filename="ArmoryQt.py" line="1215"/>
         <source>Select Wallet</source>
         <translation>Select Wallet</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="1203"/>
+        <location filename="ArmoryQt.py" line="1201"/>
         <source>You must import an address into a specific wallet.  If you do not want to import the key into any available wallet, it is recommeneded you make a new wallet for this purpose.&lt;br&gt;&lt;br&gt;Double-click on the desired wallet from the main window, then click on &quot;Import/Sweep Private Keys&quot; on the bottom-right of the properties window.&lt;br&gt;&lt;br&gt;Keys cannot be imported into watching-only wallets, only full wallets.</source>
         <translation>You must import an address into a specific wallet.  If you do not want to import the key into any available wallet, it is recommeneded you make a new wallet for this purpose.&lt;br&gt;&lt;br&gt;Double-click on the desired wallet from the main window, then click on &quot;Import/Sweep Private Keys&quot; on the bottom-right of the properties window.&lt;br&gt;&lt;br&gt;Keys cannot be imported into watching-only wallets, only full wallets.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="1217"/>
+        <location filename="ArmoryQt.py" line="1215"/>
         <source>You must select a wallet into which funds will be swept. Double-click on the desired wallet from the main window, then click on &quot;Import/Sweep Private Keys&quot; on the bottom-right of the properties window to sweep to that wallet.&lt;br&gt;&lt;br&gt;Keys cannot be swept into watching-only wallets, only full wallets.</source>
         <translation>You must select a wallet into which funds will be swept. Double-click on the desired wallet from the main window, then click on &quot;Import/Sweep Private Keys&quot; on the bottom-right of the properties window to sweep to that wallet.&lt;br&gt;&lt;br&gt;Keys cannot be swept into watching-only wallets, only full wallets.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="1301"/>
+        <location filename="ArmoryQt.py" line="1299"/>
         <source>Show Armory</source>
         <translation>Show Armory</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="1304"/>
+        <location filename="ArmoryQt.py" line="1302"/>
         <source>Quit Armory</source>
         <translation>Quit Armory</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="1492"/>
+        <location filename="ArmoryQt.py" line="1490"/>
         <source>Default URL Handler</source>
         <translation>Default URL Handler</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="1545"/>
+        <location filename="ArmoryQt.py" line="1543"/>
         <source>Version Warning</source>
         <translation>Version Warning</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="1545"/>
+        <location filename="ArmoryQt.py" line="1543"/>
         <source>Do not show this warning again</source>
         <translation>Do not show this warning again</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="1579"/>
+        <location filename="ArmoryQt.py" line="1577"/>
         <source>No Tools Yet!</source>
         <translation>No Tools Yet!</translation>
     </message>
@@ -553,52 +553,52 @@
         <translation type="obsolete">Root Pubkey Text Files (*.rootpubkey)</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="1639"/>
+        <location filename="ArmoryQt.py" line="1637"/>
         <source>Aborted</source>
         <translation>Aborted</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="1651"/>
+        <location filename="ArmoryQt.py" line="1649"/>
         <source>Backup Complete</source>
         <translation>Backup Complete</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="1714"/>
+        <location filename="ArmoryQt.py" line="1712"/>
         <source>Restart Armory</source>
         <translation>Restart Armory</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="1714"/>
+        <location filename="ArmoryQt.py" line="1712"/>
         <source>You will have to restart Armory for the new language to go into effect</source>
         <translation>You will have to restart Armory for the new language to go into effect</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="1735"/>
+        <location filename="ArmoryQt.py" line="1733"/>
         <source>Invalid Date Format</source>
         <translation>Invalid Date Format</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="1767"/>
+        <location filename="ArmoryQt.py" line="1765"/>
         <source>Already Open</source>
         <translation>Already Open</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="1920"/>
+        <location filename="ArmoryQt.py" line="1918"/>
         <source>No URL String</source>
         <translation>No URL String</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="2040"/>
+        <location filename="ArmoryQt.py" line="2038"/>
         <source>clicked</source>
         <translation>clicked</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3372"/>
+        <location filename="ArmoryQt.py" line="3403"/>
         <source>Offline Mode</source>
         <translation>Offline Mode</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="1959"/>
+        <location filename="ArmoryQt.py" line="1957"/>
         <source>The raw URI string is:
 
 </source>
@@ -607,722 +607,722 @@
 </translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="1960"/>
+        <location filename="ArmoryQt.py" line="1958"/>
         <source>Invalid URI</source>
         <translation>Invalid URI</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="1989"/>
+        <location filename="ArmoryQt.py" line="1987"/>
         <source>Wrong Network!</source>
         <translation>Wrong Network!</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="2008"/>
+        <location filename="ArmoryQt.py" line="2006"/>
         <source>Unsupported URI</source>
         <translation>Unsupported URI</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="2410"/>
+        <location filename="ArmoryQt.py" line="2408"/>
         <source>Contributor &quot;%1&quot; (%2)</source>
         <translation>Contributor &quot;%1&quot; (%2)</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="2412"/>
+        <location filename="ArmoryQt.py" line="2410"/>
         <source>Contributor %1</source>
         <translation>Contributor %1</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="2415"/>
+        <location filename="ArmoryQt.py" line="2413"/>
         <source>Contributor &quot;%1&quot;</source>
         <translation>Contributor &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="2417"/>
+        <location filename="ArmoryQt.py" line="2415"/>
         <source>Unknown Contributor</source>
         <translation>Unknown Contributor</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="2482"/>
+        <location filename="ArmoryQt.py" line="2480"/>
         <source>Blockchain loaded, wallets sync&apos;d!</source>
         <translation>Blockchain loaded, wallets sync&apos;d!</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="2488"/>
+        <location filename="ArmoryQt.py" line="2486"/>
         <source>Blockchain Loaded!</source>
         <translation>Blockchain Loaded!</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="2488"/>
+        <location filename="ArmoryQt.py" line="2486"/>
         <source>Do not show me this notification again </source>
         <translation>Do not show me this notification again </translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="2574"/>
+        <location filename="ArmoryQt.py" line="2572"/>
         <source>&lt;b&gt;&lt;font color=&quot;%1&quot;&gt;Maximum Funds:&lt;/font&gt;&lt;/b&gt;</source>
         <translation>&lt;b&gt;&lt;font color=&quot;%1&quot;&gt;Maximum Funds:&lt;/font&gt;&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="2715"/>
+        <location filename="ArmoryQt.py" line="2720"/>
         <source>My Wallets</source>
         <translation>My Wallets</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="2716"/>
+        <location filename="ArmoryQt.py" line="2721"/>
         <source>Offline Wallets</source>
         <translation>Offline Wallets</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="2717"/>
+        <location filename="ArmoryQt.py" line="2722"/>
         <source>Other&apos;s wallets</source>
         <translation>Other&apos;s wallets</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="2718"/>
+        <location filename="ArmoryQt.py" line="2723"/>
         <source>All Wallets</source>
         <translation>All Wallets</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="2719"/>
+        <location filename="ArmoryQt.py" line="2724"/>
         <source>Custom Filter</source>
         <translation>Custom Filter</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3477"/>
+        <location filename="ArmoryQt.py" line="3508"/>
         <source>No Wallets!</source>
         <translation>No Wallets!</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="2743"/>
+        <location filename="ArmoryQt.py" line="2747"/>
         <source>Select a Wallet</source>
         <translation>Select a Wallet</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="2743"/>
+        <location filename="ArmoryQt.py" line="2747"/>
         <source>Please select a wallet on the right, to see its properties.</source>
         <translation>Please select a wallet on the right, to see its properties.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="2961"/>
+        <location filename="ArmoryQt.py" line="2965"/>
         <source>Already Sweeping</source>
         <translation>Already Sweeping</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3042"/>
+        <location filename="ArmoryQt.py" line="3046"/>
         <source>addresses</source>
         <translation>addresses</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3042"/>
+        <location filename="ArmoryQt.py" line="3046"/>
         <source>address</source>
         <translation>address</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="2983"/>
+        <location filename="ArmoryQt.py" line="2987"/>
         <source>Armory is Offline</source>
         <translation>Armory is Offline</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3004"/>
+        <location filename="ArmoryQt.py" line="3008"/>
         <source>&lt;b&gt;Would you like to start the scan operation right now?&lt;/b&gt;</source>
         <translation>&lt;b&gt;Would you like to start the scan operation right now?&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3007"/>
+        <location filename="ArmoryQt.py" line="3011"/>
         <source>&lt;br&gt;&lt;br&gt;Clicking &quot;No&quot; will abort the sweep operation</source>
         <translation>&lt;br&gt;&lt;br&gt;Clicking &quot;No&quot; will abort the sweep operation</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3009"/>
+        <location filename="ArmoryQt.py" line="3013"/>
         <source>Confirm Rescan</source>
         <translation>Confirm Rescan</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3036"/>
+        <location filename="ArmoryQt.py" line="3040"/>
         <source>Nothing to do</source>
         <translation>Nothing to do</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3043"/>
+        <location filename="ArmoryQt.py" line="3047"/>
         <source>Cannot sweep</source>
         <translation>Cannot sweep</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3058"/>
+        <location filename="ArmoryQt.py" line="3062"/>
         <source>multiple addresses</source>
         <translation>multiple addresses</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3062"/>
+        <location filename="ArmoryQt.py" line="3066"/>
         <source>address &lt;b&gt;%1&lt;/b&gt;</source>
         <translation>address &lt;b&gt;%1&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3064"/>
+        <location filename="ArmoryQt.py" line="3068"/>
         <source>wallet &lt;b&gt;&quot;%1&quot;&lt;/b&gt; (%2) </source>
         <translation>wallet &lt;b&gt;&quot;%1&quot;&lt;/b&gt; (%2) </translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3108"/>
+        <location filename="ArmoryQt.py" line="3112"/>
         <source>Broadcast failed</source>
         <translation>Broadcast failed</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3134"/>
+        <location filename="ArmoryQt.py" line="3182"/>
         <source>Transaction Not Accepted</source>
         <translation>Transaction Not Accepted</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3166"/>
+        <location filename="ArmoryQt.py" line="3197"/>
         <source>In the future, you may avoid scanning twice by starting Armory in offline mode (--offline), and perform the import before switching to online mode.</source>
         <translation>In the future, you may avoid scanning twice by starting Armory in offline mode (--offline), and perform the import before switching to online mode.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3170"/>
+        <location filename="ArmoryQt.py" line="3201"/>
         <source>Armory is Busy</source>
         <translation>Armory is Busy</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3170"/>
+        <location filename="ArmoryQt.py" line="3201"/>
         <source>Wallets and addresses cannot be imported while Armory is in the middle of an existing blockchain scan.  Please wait for the scan to finish.  </source>
         <translation>Wallets and addresses cannot be imported while Armory is in the middle of an existing blockchain scan.  Please wait for the scan to finish.  </translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3184"/>
+        <location filename="ArmoryQt.py" line="3215"/>
         <source>Scanning</source>
         <translation>Scanning</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3204"/>
+        <location filename="ArmoryQt.py" line="3235"/>
         <source>Duplicate Wallet!</source>
         <translation>Duplicate Wallet!</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3223"/>
+        <location filename="ArmoryQt.py" line="3254"/>
         <source>Be Careful!</source>
         <translation>Be Careful!</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3240"/>
+        <location filename="ArmoryQt.py" line="3271"/>
         <source>Blockchain Not Ready</source>
         <translation>Blockchain Not Ready</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3246"/>
+        <location filename="ArmoryQt.py" line="3277"/>
         <source>No wallets!</source>
         <translation>No wallets!</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3298"/>
+        <location filename="ArmoryQt.py" line="3329"/>
         <source>Invalid Tx</source>
         <translation>Invalid Tx</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3326"/>
+        <location filename="ArmoryQt.py" line="3357"/>
         <source>View Details</source>
         <translation>View Details</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3327"/>
+        <location filename="ArmoryQt.py" line="3358"/>
         <source>View on %1</source>
         <translation>View on %1</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3328"/>
+        <location filename="ArmoryQt.py" line="3359"/>
         <source>Change Comment</source>
         <translation>Change Comment</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3329"/>
+        <location filename="ArmoryQt.py" line="3360"/>
         <source>Copy Transaction ID</source>
         <translation>Copy Transaction ID</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3330"/>
+        <location filename="ArmoryQt.py" line="3361"/>
         <source>Open Relevant Wallet</source>
         <translation>Open Relevant Wallet</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3340"/>
+        <location filename="ArmoryQt.py" line="3371"/>
         <source>Could not open browser</source>
         <translation>Could not open browser</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3382"/>
+        <location filename="ArmoryQt.py" line="3413"/>
         <source>Armory Not Ready</source>
         <translation>Armory Not Ready</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3423"/>
+        <location filename="ArmoryQt.py" line="3454"/>
         <source>&lt;br&gt;--&lt;b&gt;Address&lt;/b&gt;:<byte value="x9"/>%1 </source>
         <translation>&lt;br&gt;--&lt;b&gt;Address&lt;/b&gt;:&lt;byte value=&quot;x9&quot;/&gt;%1 </translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3435"/>
+        <location filename="ArmoryQt.py" line="3466"/>
         <source>&lt;br&gt;--&lt;b&gt;Amount&lt;/b&gt;:<byte value="x9"/>%1 BTC</source>
         <translation>&lt;br&gt;--&lt;b&gt;Amount&lt;/b&gt;:&lt;byte value=&quot;x9&quot;/&gt;%1 BTC</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3440"/>
+        <location filename="ArmoryQt.py" line="3471"/>
         <source>&lt;br&gt;--&lt;b&gt;Message&lt;/b&gt;:<byte value="x9"/>%1...</source>
         <translation>&lt;br&gt;--&lt;b&gt;Message&lt;/b&gt;:&lt;byte value=&quot;x9&quot;/&gt;%1...</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3442"/>
+        <location filename="ArmoryQt.py" line="3473"/>
         <source>&lt;br&gt;--&lt;b&gt;Message&lt;/b&gt;:<byte value="x9"/>%1</source>
         <translation>&lt;br&gt;--&lt;b&gt;Message&lt;/b&gt;:&lt;byte value=&quot;x9&quot;/&gt;%1</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3494"/>
+        <location filename="ArmoryQt.py" line="3525"/>
         <source>Receive coins with wallet...</source>
         <translation>Receive coins with wallet...</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3584"/>
+        <location filename="ArmoryQt.py" line="3615"/>
         <source>Privacy Warning</source>
         <translation>Privacy Warning</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3652"/>
+        <location filename="ArmoryQt.py" line="3683"/>
         <source>Already running!</source>
         <translation>Already running!</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3660"/>
+        <location filename="ArmoryQt.py" line="3691"/>
         <source>Still Missing</source>
         <translation>Still Missing</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3667"/>
+        <location filename="ArmoryQt.py" line="3698"/>
         <source>Still Running</source>
         <translation>Still Running</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3763"/>
+        <location filename="ArmoryQt.py" line="3794"/>
         <source>Close Bitcoin Process</source>
         <translation>Close Bitcoin Process</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3764"/>
+        <location filename="ArmoryQt.py" line="3795"/>
         <source>Open https://bitcoin.org</source>
         <translation>Open https://bitcoin.org</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3765"/>
+        <location filename="ArmoryQt.py" line="3796"/>
         <source>Change Settings</source>
         <translation>Change Settings</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3769"/>
+        <location filename="ArmoryQt.py" line="3800"/>
         <source>Preparing to shut down..</source>
         <translation>Preparing to shut down..</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3797"/>
+        <location filename="ArmoryQt.py" line="3828"/>
         <source>Stop existing Bitcoin processes so that Armory can open its own</source>
         <translation>Stop existing Bitcoin processes so that Armory can open its own</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3799"/>
+        <location filename="ArmoryQt.py" line="3830"/>
         <source>Open browser to Bitcoin webpage to download and install Bitcoin software</source>
         <translation>Open browser to Bitcoin webpage to download and install Bitcoin software</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3801"/>
+        <location filename="ArmoryQt.py" line="3832"/>
         <source>Open Armory settings window to change Bitcoin software management</source>
         <translation>Open Armory settings window to change Bitcoin software management</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3864"/>
+        <location filename="ArmoryQt.py" line="3895"/>
         <source>Not Found</source>
         <translation>Not Found</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3917"/>
+        <location filename="ArmoryQt.py" line="3948"/>
         <source>Loading Database Headers</source>
         <translation>Loading Database Headers</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3926"/>
+        <location filename="ArmoryQt.py" line="3957"/>
         <source>Organizing Blockchain</source>
         <translation>Organizing Blockchain</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="4646"/>
+        <location filename="ArmoryQt.py" line="4677"/>
         <source>Scan Transaction History</source>
         <translation>Scan Transaction History</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3937"/>
+        <location filename="ArmoryQt.py" line="3968"/>
         <source>Reading New Block Headers</source>
         <translation>Reading New Block Headers</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3945"/>
+        <location filename="ArmoryQt.py" line="3976"/>
         <source>Building Databases</source>
         <translation>Building Databases</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="4579"/>
+        <location filename="ArmoryQt.py" line="4610"/>
         <source>Build Databases</source>
         <translation>Build Databases</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3955"/>
+        <location filename="ArmoryQt.py" line="3986"/>
         <source>Scanning Transaction History</source>
         <translation>Scanning Transaction History</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3965"/>
+        <location filename="ArmoryQt.py" line="3996"/>
         <source>Computing Balances</source>
         <translation>Computing Balances</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3975"/>
+        <location filename="ArmoryQt.py" line="4006"/>
         <source>Parsing Tx Hashes</source>
         <translation>Parsing Tx Hashes</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3989"/>
+        <location filename="ArmoryQt.py" line="4020"/>
         <source>Resolving Tx Hashes</source>
         <translation>Resolving Tx Hashes</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="4098"/>
+        <location filename="ArmoryQt.py" line="4129"/>
         <source>&lt;ul&gt;&lt;li&gt;Create, import or recover Armory wallets&lt;/li&gt;&lt;li&gt;Generate new addresses to receive coins&lt;/li&gt;&lt;li&gt;Send bitcoins to other people&lt;/li&gt;&lt;li&gt;Create one-time backups of your wallets (in printed or digital form)&lt;/li&gt;&lt;li&gt;Click on &quot;bitcoin:&quot; links in your web browser (not supported on all operating systems)&lt;/li&gt;&lt;li&gt;Import private keys to wallets&lt;/li&gt;&lt;li&gt;Monitor payments to watching-only wallets and create unsigned transactions&lt;/li&gt;&lt;li&gt;Sign messages&lt;/li&gt;&lt;li&gt;&lt;b&gt;Create transactions with watching-only wallets, to be signed by an offline wallets&lt;/b&gt;&lt;/li&gt;&lt;/ul&gt;</source>
         <translation>&lt;ul&gt;&lt;li&gt;Create, import or recover Armory wallets&lt;/li&gt;&lt;li&gt;Generate new addresses to receive coins&lt;/li&gt;&lt;li&gt;Send bitcoins to other people&lt;/li&gt;&lt;li&gt;Create one-time backups of your wallets (in printed or digital form)&lt;/li&gt;&lt;li&gt;Click on &quot;bitcoin:&quot; links in your web browser (not supported on all operating systems)&lt;/li&gt;&lt;li&gt;Import private keys to wallets&lt;/li&gt;&lt;li&gt;Monitor payments to watching-only wallets and create unsigned transactions&lt;/li&gt;&lt;li&gt;Sign messages&lt;/li&gt;&lt;li&gt;&lt;b&gt;Create transactions with watching-only wallets, to be signed by an offline wallets&lt;/b&gt;&lt;/li&gt;&lt;/ul&gt;</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="4140"/>
+        <location filename="ArmoryQt.py" line="4171"/>
         <source>&lt;p&gt;&lt;b&gt;You now have access to all the features Armory has to offer!&lt;/b&gt;&lt;br&gt;To see your balances and transaction history, please click on the &quot;Transactions&quot; tab above this text.  &lt;br&gt;Here&apos;s some things you can do with Armory Bitcoin Client:&lt;br&gt;</source>
         <translation>&lt;p&gt;&lt;b&gt;You now have access to all the features Armory has to offer!&lt;/b&gt;&lt;br&gt;To see your balances and transaction history, please click on the &quot;Transactions&quot; tab above this text.  &lt;br&gt;Here&apos;s some things you can do with Armory Bitcoin Client:&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="4147"/>
+        <location filename="ArmoryQt.py" line="4178"/>
         <source>If you experience any performance issues with Armory, please confirm that Bitcoin Core is running and &lt;i&gt;fully synchronized with the Bitcoin network&lt;/i&gt;.  You will see a green checkmark in the bottom right corner of the Bitcoin Core window if it is synchronized.  If not, it is recommended you close Armory and restart it only when you see that checkmark.&lt;br&gt;&lt;br&gt;</source>
         <translation>If you experience any performance issues with Armory, please confirm that Bitcoin Core is running and &lt;i&gt;fully synchronized with the Bitcoin network&lt;/i&gt;.  You will see a green checkmark in the bottom right corner of the Bitcoin Core window if it is synchronized.  If not, it is recommended you close Armory and restart it only when you see that checkmark.&lt;br&gt;&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="4147"/>
+        <location filename="ArmoryQt.py" line="4178"/>
         <source>&lt;b&gt;Please backup your wallets!&lt;/b&gt;  Armory wallets are &quot;deterministic&quot;, meaning they only need to be backed up one time (unless you have imported external addresses/keys). Make a backup and keep it in a safe place!  All funds from Armory-generated addresses will always be recoverable with a paper backup, any time in the future.  Use the &quot;Backup Individual Keys&quot; option for each wallet to backup imported keys.&lt;/p&gt;</source>
         <translation>&lt;b&gt;Please backup your wallets!&lt;/b&gt;  Armory wallets are &quot;deterministic&quot;, meaning they only need to be backed up one time (unless you have imported external addresses/keys). Make a backup and keep it in a safe place!  All funds from Armory-generated addresses will always be recoverable with a paper backup, any time in the future.  Use the &quot;Backup Individual Keys&quot; option for each wallet to backup imported keys.&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="4175"/>
+        <location filename="ArmoryQt.py" line="4206"/>
         <source>&lt;b&gt;Wallet balances may be incorrect until the rescan operation is performed!&lt;/b&gt;&lt;br&gt;&lt;br&gt;Armory is currently online, but addresses/keys have been added without rescanning the blockchain.  You may continue using Armory in online mode, but any transactions associated with the new addresses will not appear in the ledger. &lt;br&gt;&lt;br&gt;Pressing the button above will put Armory into offline mode for a few minutes until the scan operation is complete.</source>
         <translation>&lt;b&gt;Wallet balances may be incorrect until the rescan operation is performed!&lt;/b&gt;&lt;br&gt;&lt;br&gt;Armory is currently online, but addresses/keys have been added without rescanning the blockchain.  You may continue using Armory in online mode, but any transactions associated with the new addresses will not appear in the ledger. &lt;br&gt;&lt;br&gt;Pressing the button above will put Armory into offline mode for a few minutes until the scan operation is complete.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="4187"/>
+        <location filename="ArmoryQt.py" line="4218"/>
         <source>There is no connection to the internet, and there is no other Bitcoin software running.  Most likely you are here because this is a system dedicated to manage offline wallets! &lt;br&gt;&lt;br&gt;&lt;b&gt;If you expected Armory to be in online mode&lt;/b&gt;, please verify your internet connection is active, then restart Armory.  If you think the lack of internet connection is in error (such as if you are using Tor), then you can restart Armory with the &quot;--skip-online-check&quot; option, or change it in the Armory settings.&lt;br&gt;&lt;br&gt;If you do not have Bitcoin Core installed, you can download it from &lt;a href=&quot;https://bitcoin.org&quot;&gt;https://bitcoin.org&lt;/a&gt;.</source>
         <translation>There is no connection to the internet, and there is no other Bitcoin software running.  Most likely you are here because this is a system dedicated to manage offline wallets! &lt;br&gt;&lt;br&gt;&lt;b&gt;If you expected Armory to be in online mode&lt;/b&gt;, please verify your internet connection is active, then restart Armory.  If you think the lack of internet connection is in error (such as if you are using Tor), then you can restart Armory with the &quot;--skip-online-check&quot; option, or change it in the Armory settings.&lt;br&gt;&lt;br&gt;If you do not have Bitcoin Core installed, you can download it from &lt;a href=&quot;https://bitcoin.org&quot;&gt;https://bitcoin.org&lt;/a&gt;.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="4210"/>
+        <location filename="ArmoryQt.py" line="4241"/>
         <source>You are currently in offline mode, but can switch to online mode by pressing the button above.  However, it is not recommended that you switch until Bitcoin Core/bitcoind is fully synchronized with the bitcoin network.  You will see a green checkmark in the bottom-right corner of the Bitcoin Core window when it is finished.&lt;br&gt;&lt;br&gt;Switching to online mode will give you access to more Armory functionality, including sending and receiving bitcoins and viewing the balances and transaction histories of each of your wallets.&lt;br&gt;&lt;br&gt;</source>
         <translation>You are currently in offline mode, but can switch to online mode by pressing the button above.  However, it is not recommended that you switch until Bitcoin Core/bitcoind is fully synchronized with the bitcoin network.  You will see a green checkmark in the bottom-right corner of the Bitcoin Core window when it is finished.&lt;br&gt;&lt;br&gt;Switching to online mode will give you access to more Armory functionality, including sending and receiving bitcoins and viewing the balances and transaction histories of each of your wallets.&lt;br&gt;&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="4224"/>
+        <location filename="ArmoryQt.py" line="4255"/>
         <source>You are currently in offline mode because Bitcoin Core is not running.  To switch to online mode, start Bitcoin Core and let it synchronize with the network -- you will see a green checkmark in the bottom-right corner when it is complete.  If Bitcoin Core is already running and you believe the lack of connection is an error (especially if using proxies), please see &lt;a href=&quot;https://bitcointalk.org/index.php?topic=155717.msg1719077#msg1719077&quot;&gt;this link&lt;/a&gt; for options.&lt;br&gt;&lt;br&gt;&lt;b&gt;If you prefer to have Armory do this for you&lt;/b&gt;, then please check &quot;Let Armory run Bitcoin Core in the background&quot; under &quot;File&quot;-&gt;&quot;Settings.&quot;&lt;br&gt;&lt;br&gt;If you already know what you&apos;re doing and simply need to fetch the latest version of Bitcoin Core, you can download it from &lt;a href=&quot;https://bitcoin.org&quot;&gt;https://bitcoin.org&lt;/a&gt;.</source>
         <translation>You are currently in offline mode because Bitcoin Core is not running.  To switch to online mode, start Bitcoin Core and let it synchronize with the network -- you will see a green checkmark in the bottom-right corner when it is complete.  If Bitcoin Core is already running and you believe the lack of connection is an error (especially if using proxies), please see &lt;a href=&quot;https://bitcointalk.org/index.php?topic=155717.msg1719077#msg1719077&quot;&gt;this link&lt;/a&gt; for options.&lt;br&gt;&lt;br&gt;&lt;b&gt;If you prefer to have Armory do this for you&lt;/b&gt;, then please check &quot;Let Armory run Bitcoin Core in the background&quot; under &quot;File&quot;-&gt;&quot;Settings.&quot;&lt;br&gt;&lt;br&gt;If you already know what you&apos;re doing and simply need to fetch the latest version of Bitcoin Core, you can download it from &lt;a href=&quot;https://bitcoin.org&quot;&gt;https://bitcoin.org&lt;/a&gt;.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="4243"/>
+        <location filename="ArmoryQt.py" line="4274"/>
         <source>You are currently in offline mode because Armory could not detect an internet connection.  If you think this is in error, then restart Armory using the &quot; --skip-online-check&quot; option, or adjust the Armory settings.  Then restart Armory.&lt;br&gt;&lt;br&gt;If this is intended to be an offline computer, note that it is not necessary to have Bitcoin Core or bitcoind running.</source>
         <translation>You are currently in offline mode because Armory could not detect an internet connection.  If you think this is in error, then restart Armory using the &quot; --skip-online-check&quot; option, or adjust the Armory settings.  Then restart Armory.&lt;br&gt;&lt;br&gt;If this is intended to be an offline computer, note that it is not necessary to have Bitcoin Core or bitcoind running.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="4254"/>
+        <location filename="ArmoryQt.py" line="4285"/>
         <source>You are currently in offline mode because Armory could not find the blockchain files produced by Bitcoin Core.  Do you run Bitcoin Core (or bitcoind) from a non-standard directory?   Armory expects to find the blkXXXX.dat files in &lt;br&gt;&lt;br&gt;%1&lt;br&gt;&lt;br&gt; If you know where they are located, please restart Armory using the &quot; --satoshi-datadir=[path]&quot; to notify Armory where to find them.</source>
         <translation>You are currently in offline mode because Armory could not find the blockchain files produced by Bitcoin Core.  Do you run Bitcoin Core (or bitcoind) from a non-standard directory?   Armory expects to find the blkXXXX.dat files in &lt;br&gt;&lt;br&gt;%1&lt;br&gt;&lt;br&gt; If you know where they are located, please restart Armory using the &quot; --satoshi-datadir=[path]&quot; to notify Armory where to find them.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="4264"/>
+        <location filename="ArmoryQt.py" line="4295"/>
         <source>Armory was previously online, but the connection to Bitcoin Core/bitcoind was interrupted.  You will not be able to send bitcoins or confirm receipt of bitcoins until the connection is reestablished.  &lt;br&gt;&lt;br&gt;Please check that Bitcoin Core is open and synchronized with the network.  Armory will &lt;i&gt;try to reconnect&lt;/i&gt; automatically when the connection is available again.  If Bitcoin Core is available again, and reconnection does not happen, please restart Armory.&lt;br&gt;&lt;br&gt;</source>
         <translation>Armory was previously online, but the connection to Bitcoin Core/bitcoind was interrupted.  You will not be able to send bitcoins or confirm receipt of bitcoins until the connection is reestablished.  &lt;br&gt;&lt;br&gt;Please check that Bitcoin Core is open and synchronized with the network.  Armory will &lt;i&gt;try to reconnect&lt;/i&gt; automatically when the connection is available again.  If Bitcoin Core is available again, and reconnection does not happen, please restart Armory.&lt;br&gt;&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="4274"/>
+        <location filename="ArmoryQt.py" line="4305"/>
         <source>Please wait while the global transaction history is scanned. Armory will go into online mode automatically, as soon as the scan is complete.</source>
         <translation>Please wait while the global transaction history is scanned. Armory will go into online mode automatically, as soon as the scan is complete.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="4279"/>
+        <location filename="ArmoryQt.py" line="4310"/>
         <source>Armory is scanning the global transaction history to retrieve information about your wallets.  The &quot;Transactions&quot; tab will be updated with wallet balance and history as soon as the scan is complete.  You may manage your wallets while you wait.&lt;br&gt;&lt;br&gt;</source>
         <translation>Armory is scanning the global transaction history to retrieve information about your wallets.  The &quot;Transactions&quot; tab will be updated with wallet balance and history as soon as the scan is complete.  You may manage your wallets while you wait.&lt;br&gt;&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="4291"/>
+        <location filename="ArmoryQt.py" line="4322"/>
         <source>It appears you are already running Bitcoin software (Bitcoin Core or bitcoind). Unlike previous versions of Armory, you should &lt;u&gt;not&lt;/u&gt; run this software yourself --  Armory will run it in the background for you.  Either close the Bitcoin application or adjust your settings.  If you change your settings, then please restart Armory.</source>
         <translation>It appears you are already running Bitcoin software (Bitcoin Core or bitcoind). Unlike previous versions of Armory, you should &lt;u&gt;not&lt;/u&gt; run this software yourself --  Armory will run it in the background for you.  Either close the Bitcoin application or adjust your settings.  If you change your settings, then please restart Armory.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="4300"/>
+        <location filename="ArmoryQt.py" line="4331"/>
         <source>&lt;b&gt;Only one more step to getting online with Armory!&lt;/b&gt;   You must install the Bitcoin software from https://bitcoin.org in order for Armory to communicate with the Bitcoin network.  If the Bitcoin software is already installed and/or you would prefer to manage it yourself, please adjust your settings and restart Armory.</source>
         <translation>&lt;b&gt;Only one more step to getting online with Armory!&lt;/b&gt;   You must install the Bitcoin software from https://bitcoin.org in order for Armory to communicate with the Bitcoin network.  If the Bitcoin software is already installed and/or you would prefer to manage it yourself, please adjust your settings and restart Armory.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="4341"/>
+        <location filename="ArmoryQt.py" line="4372"/>
         <source>Armory&apos;s communication with the Bitcoin network was interrupted. This usually does not happen unless you closed the process that Armory was using to communicate with the network. Armory requires %1 to be running in the background, and this error pops up if it disappears.&lt;br&gt;&lt;br&gt;You may continue in offline mode, or you can close all Bitcoin processes and restart Armory.</source>
         <translation>Armory&apos;s communication with the Bitcoin network was interrupted. This usually does not happen unless you closed the process that Armory was using to communicate with the network. Armory requires %1 to be running in the background, and this error pops up if it disappears.&lt;br&gt;&lt;br&gt;You may continue in offline mode, or you can close all Bitcoin processes and restart Armory.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="4350"/>
+        <location filename="ArmoryQt.py" line="4381"/>
         <source>Armory has experienced an issue trying to communicate with the Bitcoin software.  The software is running in the background, but Armory cannot communicate with it through RPC as it expects to be able to.  If you changed any settings in the Bitcoin home directory, please make sure that RPC is enabled and that it is accepting connections from localhost.  &lt;br&gt;&lt;br&gt;If you have not changed anything, please export the log file (from the &quot;File&quot; menu) and open an issue at https://github.com/goatpig/BitcoinArmory/issues</source>
         <translation>Armory has experienced an issue trying to communicate with the Bitcoin software.  The software is running in the background, but Armory cannot communicate with it through RPC as it expects to be able to.  If you changed any settings in the Bitcoin home directory, please make sure that RPC is enabled and that it is accepting connections from localhost.  &lt;br&gt;&lt;br&gt;If you have not changed anything, please export the log file (from the &quot;File&quot; menu) and open an issue at https://github.com/goatpig/BitcoinArmory/issues</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="4361"/>
+        <location filename="ArmoryQt.py" line="4392"/>
         <source>Armory does not detect internet access, but it does detect running Bitcoin software.  Armory is in offline-mode. &lt;br&gt;&lt;br&gt;If you are intending to run an offline system, you will not need to have the Bitcoin software installed on the offline computer.  It is only needed for the online computer. If you expected to be online and the absence of internet is an error, please restart Armory using the &quot;--skip-online-check&quot; option.  </source>
         <translation>Armory does not detect internet access, but it does detect running Bitcoin software.  Armory is in offline-mode. &lt;br&gt;&lt;br&gt;If you are intending to run an offline system, you will not need to have the Bitcoin software installed on the offline computer.  It is only needed for the online computer. If you expected to be online and the absence of internet is an error, please restart Armory using the &quot;--skip-online-check&quot; option.  </translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="4371"/>
+        <location filename="ArmoryQt.py" line="4402"/>
         <source>Armory was started in offline-mode, but detected you are running Bitcoin software.  If you are intending to run an offline system, you will &lt;u&gt;not&lt;/u&gt; need to have the Bitcoin software installed or running on the offline computer.  It is only required for being online. </source>
         <translation>Armory was started in offline-mode, but detected you are running Bitcoin software.  If you are intending to run an offline system, you will &lt;u&gt;not&lt;/u&gt; need to have the Bitcoin software installed or running on the offline computer.  It is only required for being online. </translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="4540"/>
+        <location filename="ArmoryQt.py" line="4571"/>
         <source>Armory is &lt;u&gt;offline&lt;/u&gt;</source>
         <translation>Armory is &lt;u&gt;offline&lt;/u&gt;</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="4525"/>
+        <location filename="ArmoryQt.py" line="4556"/>
         <source>In case you actually do have internet access, you can use the following links to get Armory installed.  Or change your settings.</source>
         <translation>In case you actually do have internet access, you can use the following links to get Armory installed.  Or change your settings.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="4544"/>
+        <location filename="ArmoryQt.py" line="4575"/>
         <source>Cannot find Bitcoin Home Directory</source>
         <translation>Cannot find Bitcoin Home Directory</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="4552"/>
+        <location filename="ArmoryQt.py" line="4583"/>
         <source>Check Again</source>
         <translation>Check Again</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="4574"/>
+        <location filename="ArmoryQt.py" line="4605"/>
         <source>Initializing Bitcoin Engine</source>
         <translation>Initializing Bitcoin Engine</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="4634"/>
+        <location filename="ArmoryQt.py" line="4665"/>
         <source>Synchronizing with Network</source>
         <translation>Synchronizing with Network</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="4588"/>
+        <location filename="ArmoryQt.py" line="4619"/>
         <source>Since version 0.88, Armory runs bitcoind in the background.  You can switch back to the old way in the Settings dialog. </source>
         <translation>Since version 0.88, Armory runs bitcoind in the background.  You can switch back to the old way in the Settings dialog. </translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="4606"/>
+        <location filename="ArmoryQt.py" line="4637"/>
         <source>Armory is disconnected</source>
         <translation>Armory is disconnected</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="4613"/>
+        <location filename="ArmoryQt.py" line="4644"/>
         <source>Armory is online!</source>
         <translation>Armory is online!</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="4642"/>
+        <location filename="ArmoryQt.py" line="4673"/>
         <source>Preparing Databases</source>
         <translation>Preparing Databases</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="4816"/>
+        <location filename="ArmoryQt.py" line="4851"/>
         <source>&lt;font color=%1&gt;Connected (%2 blocks)&lt;/font&gt; </source>
         <translation>&lt;font color=%1&gt;Connected (%2 blocks)&lt;/font&gt; </translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="4822"/>
+        <location filename="ArmoryQt.py" line="4864"/>
         <source>Last block received %1 ago</source>
         <translation>Last block received %1 ago</translation>
     </message>
     <message>
         <location filename="ArmoryQt.py" line="4828"/>
         <source>&lt;font color=%1&gt;Node offline (%2 blocks)&lt;/font&gt; </source>
-        <translation>&lt;font color=%1&gt;Node offline (%2 blocks)&lt;/font&gt; </translation>
+        <translation type="obsolete">&lt;font color=%1&gt;Node offline (%2 blocks)&lt;/font&gt; </translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="4833"/>
+        <location filename="ArmoryQt.py" line="4876"/>
         <source>Disconnected from Bitcoin Node, cannot update history &lt;br&gt;&lt;br&gt;Last known block: %1 &lt;br&gt;Received %2 ago</source>
         <translation>Disconnected from Bitcoin Node, cannot update history &lt;br&gt;&lt;br&gt;Last known block: %1 &lt;br&gt;Received %2 ago</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="4970"/>
+        <location filename="ArmoryQt.py" line="5013"/>
         <source>BDM error!</source>
         <translation>BDM error!</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="4964"/>
+        <location filename="ArmoryQt.py" line="5007"/>
         <source>Rebuild and rescan on next start</source>
         <translation>Rebuild and rescan on next start</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="4970"/>
+        <location filename="ArmoryQt.py" line="5013"/>
         <source>Factory reset on next start</source>
         <translation>Factory reset on next start</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="4976"/>
+        <location filename="ArmoryQt.py" line="5019"/>
         <source>BlockDataManager Warning</source>
         <translation>BlockDataManager Warning</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="5025"/>
+        <location filename="ArmoryQt.py" line="5068"/>
         <source>Disconnected</source>
         <translation>Disconnected</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="5025"/>
+        <location filename="ArmoryQt.py" line="5068"/>
         <source>Connection to Bitcoin Core client lost!  Armory cannot send nor receive bitcoins until connection is re-established.</source>
         <translation>Connection to Bitcoin Core client lost!  Armory cannot send nor receive bitcoins until connection is re-established.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="5031"/>
+        <location filename="ArmoryQt.py" line="5074"/>
         <source>Connected</source>
         <translation>Connected</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="5031"/>
+        <location filename="ArmoryQt.py" line="5074"/>
         <source>Connection to Bitcoin Core re-established</source>
         <translation>Connection to Bitcoin Core re-established</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="5711"/>
+        <location filename="ArmoryQt.py" line="5754"/>
         <source>Database Error</source>
         <translation>Database Error</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="5180"/>
+        <location filename="ArmoryQt.py" line="5223"/>
         <source>Wallet %1 (%2)</source>
         <translation>Wallet %1 (%2)</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="5187"/>
+        <location filename="ArmoryQt.py" line="5230"/>
         <source>Lockbox %1 (%2)</source>
         <translation>Lockbox %1 (%2)</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="5281"/>
+        <location filename="ArmoryQt.py" line="5324"/>
         <source>Bitcoins Received!</source>
         <translation>Bitcoins Received!</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="5300"/>
+        <location filename="ArmoryQt.py" line="5343"/>
         <source>Amount:  %1 BTC</source>
         <translation>Amount:  %1 BTC</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="5197"/>
+        <location filename="ArmoryQt.py" line="5240"/>
         <source>Recipient:  %1</source>
         <translation>Recipient:  %1</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="5299"/>
+        <location filename="ArmoryQt.py" line="5342"/>
         <source>Bitcoins Sent!</source>
         <translation>Bitcoins Sent!</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="5202"/>
+        <location filename="ArmoryQt.py" line="5245"/>
         <source>Sender:  %1</source>
         <translation>Sender:  %1</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="5253"/>
+        <location filename="ArmoryQt.py" line="5296"/>
         <source>Wallet &quot;%1&quot; (%2)</source>
         <translation>Wallet &quot;%1&quot; (%2)</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="5261"/>
+        <location filename="ArmoryQt.py" line="5304"/>
         <source>Lockbox %1-of-%2 &quot;%3&quot; (%4)</source>
         <translation>Lockbox %1-of-%2 &quot;%3&quot; (%4)</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="5272"/>
+        <location filename="ArmoryQt.py" line="5315"/>
         <source>Your bitcoins just did a lap!</source>
         <translation>Your bitcoins just did a lap!</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="5272"/>
+        <location filename="ArmoryQt.py" line="5315"/>
         <source>%1 just sent some BTC to itself!</source>
         <translation>%1 just sent some BTC to itself!</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="5283"/>
+        <location filename="ArmoryQt.py" line="5326"/>
         <source>From:    %2</source>
         <translation>From:    %2</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="5297"/>
+        <location filename="ArmoryQt.py" line="5340"/>
         <source>&lt;Multiple Recipients&gt;</source>
         <translation>&lt;Multiple Recipients&gt;</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="5301"/>
+        <location filename="ArmoryQt.py" line="5344"/>
         <source>From:    %1</source>
         <translation>From:    %1</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="5302"/>
+        <location filename="ArmoryQt.py" line="5345"/>
         <source>To:      %1</source>
         <translation>To:      %1</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="5318"/>
+        <location filename="ArmoryQt.py" line="5361"/>
         <source>Minimize or Close</source>
         <translation>Minimize or Close</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="5318"/>
+        <location filename="ArmoryQt.py" line="5361"/>
         <source>Would you like to minimize Armory to the system tray instead of closing it?</source>
         <translation>Would you like to minimize Armory to the system tray instead of closing it?</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="5318"/>
+        <location filename="ArmoryQt.py" line="5361"/>
         <source>Remember my answer</source>
         <translation>Remember my answer</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="5318"/>
+        <location filename="ArmoryQt.py" line="5361"/>
         <source>Minimize</source>
         <translation>Minimize</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="5318"/>
+        <location filename="ArmoryQt.py" line="5361"/>
         <source>Close</source>
         <translation>Close</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="5520"/>
+        <location filename="ArmoryQt.py" line="5563"/>
         <source>All wallets are consistent</source>
         <translation>All wallets are consistent</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="5524"/>
+        <location filename="ArmoryQt.py" line="5567"/>
         <source>Consistency Check Failed!</source>
         <translation>Consistency Check Failed!</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="5593"/>
+        <location filename="ArmoryQt.py" line="5636"/>
         <source>Wallet Consistency Check: %p%</source>
         <translation>Wallet Consistency Check: %p%</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="5830"/>
+        <location filename="ArmoryQt.py" line="5873"/>
         <source>Filter:</source>
         <translation>Filter:</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="5848"/>
+        <location filename="ArmoryQt.py" line="5891"/>
         <source>Transactions</source>
         <translation>Transactions</translation>
     </message>
     <message numerus="yes">
-        <location filename="ArmoryQt.py" line="4328"/>
+        <location filename="ArmoryQt.py" line="4359"/>
         <source>The software is downloading and processing the latest activity on the network related to your wallet(s).  This should take only a few minutes.  While you wait, you can manage your wallet(s).  &lt;br&gt;&lt;br&gt;Now would be a good time to make paper (or digital) backups of your wallet(s) if you have not done so already!  You are protected &lt;i&gt;forever&lt;/i&gt; from hard-drive loss, or forgetting you password. If you do not have a backup, you could lose all of your Bitcoins forever!</source>
         <translation>
             <numerusform>The software is downloading and processing the latest activity on the network related to your wallet.  This should take only a few minutes.  While you wait, you can manage your wallet.  &lt;br&gt;&lt;br&gt;Now would be a good time to make paper (or digital) backups of your wallet if you have not done so already!  You are protected &lt;i&gt;forever&lt;/i&gt; from hard-drive loss, or forgetting you password. If you do not have a backup, you could lose all of your Bitcoins forever!</numerusform>
@@ -1330,297 +1330,297 @@
         </translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="4065"/>
+        <location filename="ArmoryQt.py" line="4096"/>
         <source>The following functionalities are available while scanning in offline mode:&lt;ul&gt;&lt;li&gt;Create new wallets&lt;/li&gt;&lt;li&gt;Generate receiving addresses for your wallets&lt;/li&gt;&lt;li&gt;Create backups of your wallets (printed or digital)&lt;/li&gt;&lt;li&gt;Change wallet encryption settings&lt;/li&gt;&lt;li&gt;Sign transactions created from an online system&lt;/li&gt;&lt;li&gt;Sign messages&lt;/li&gt;&lt;/ul&gt;&lt;br&gt;&lt;br&gt;&lt;b&gt;NOTE:&lt;/b&gt;  The Bitcoin network &lt;u&gt;will&lt;/u&gt; process transactions to your addresses, even if you are offline.  It is perfectly okay to create and distribute payment addresses while Armory is offline, you just won&apos;t be able to verify those payments until the next time Armory is online.</source>
         <translation>The following functionalities are available while scanning in offline mode:&lt;ul&gt;&lt;li&gt;Create new wallets&lt;/li&gt;&lt;li&gt;Generate receiving addresses for your wallets&lt;/li&gt;&lt;li&gt;Create backups of your wallets (printed or digital)&lt;/li&gt;&lt;li&gt;Change wallet encryption settings&lt;/li&gt;&lt;li&gt;Sign transactions created from an online system&lt;/li&gt;&lt;li&gt;Sign messages&lt;/li&gt;&lt;/ul&gt;&lt;br&gt;&lt;br&gt;&lt;b&gt;NOTE:&lt;/b&gt;  The Bitcoin network &lt;u&gt;will&lt;/u&gt; process transactions to your addresses, even if you are offline.  It is perfectly okay to create and distribute payment addresses while Armory is offline, you just won&apos;t be able to verify those payments until the next time Armory is online.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="4081"/>
+        <location filename="ArmoryQt.py" line="4112"/>
         <source>The following functionalities are available in offline mode:&lt;ul&gt;&lt;li&gt;Create, import or recover wallets&lt;/li&gt;&lt;li&gt;Generate new receiving addresses for your wallets&lt;/li&gt;&lt;li&gt;Create backups of your wallets (printed or digital)&lt;/li&gt;&lt;li&gt;Import private keys to wallets&lt;/li&gt;&lt;li&gt;Change wallet encryption settings&lt;/li&gt;&lt;li&gt;Sign messages&lt;/li&gt;&lt;li&gt;&lt;b&gt;Sign transactions created from an online system&lt;/b&gt;&lt;/li&gt;&lt;/ul&gt;&lt;br&gt;&lt;br&gt;&lt;b&gt;NOTE:&lt;/b&gt;  The Bitcoin network &lt;u&gt;will&lt;/u&gt; process transactions to your addresses, regardless of whether you are online.  It is perfectly okay to create and distribute payment addresses while Armory is offline, you just won&apos;t be able to verify those payments until the next time Armory is online.</source>
         <translation>The following functionalities are available in offline mode:&lt;ul&gt;&lt;li&gt;Create, import or recover wallets&lt;/li&gt;&lt;li&gt;Generate new receiving addresses for your wallets&lt;/li&gt;&lt;li&gt;Create backups of your wallets (printed or digital)&lt;/li&gt;&lt;li&gt;Import private keys to wallets &lt;/li&gt;&lt;li&gt;Change wallet encryption settings&lt;/li&gt;&lt;li&gt;Sign messages&lt;/li&gt;&lt;li&gt;&lt;b&gt;Sign transactions created from an online system&lt;/b&gt;&lt;/li&gt;&lt;/ul&gt;&lt;br&gt;&lt;br&gt;&lt;b&gt;NOTE:&lt;/b&gt;  The Bitcoin network &lt;u&gt;will&lt;/u&gt; process transactions to your addresses, regardlesss of whether you are online.  It is perfectly okay to create and distribute payment addresses while Armory is offline, you just won&apos;t be able to verify those payments until the next time Armory is online.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="4165"/>
+        <location filename="ArmoryQt.py" line="4196"/>
         <source>Armory is currently online, but you have requested a sweep operation on one or more private keys.  This requires searching the global transaction history for the available balance of the keys to be swept. &lt;br&gt;&lt;br&gt;Press the button to start the blockchain scan, which will also put Armory into offline mode for a few minutes until the scan operation is complete.</source>
         <translation>Armory is currently online, but you have requested a sweep operation on one or more private keys.  This requires searching the global transaction history for the available balance of the keys to be swept. &lt;br&gt;&lt;br&gt;Press the button to start the blockchain scan, which will also put Armory into offline mode for a few minutes until the scan operation is complete.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="4378"/>
+        <location filename="ArmoryQt.py" line="4409"/>
         <source>The Bitcoin software indicates there is a problem with its databases.  This can occur when Bitcoin Core/bitcoind is upgraded or downgraded, or sometimes just by chance after an unclean shutdown.&lt;br&gt;&lt;br&gt;You can either revert your installed Bitcoin software to the last known working version (but not earlier than version 0.8.1) or delete everything &lt;b&gt;except&lt;/b&gt; &quot;wallet.dat&quot; from your Bitcoin home directory &lt;font face=&quot;courier&quot;&gt;&lt;b&gt;%1&lt;/b&gt;&lt;/font&gt;&lt;br&gt;&lt;br&gt;If you choose to delete the contents of the Bitcoin home directory, you will have to do a fresh download of the blockchain again, which will require a few hours the first time.</source>
         <translation>The Bitcoin software indicates there is a problem with its databases.  This can occur when Bitcoin Core/bitcoind is upgraded or downgraded, or sometimes just by chance after an unclean shutdown.&lt;br&gt;&lt;br&gt;You can either revert your installed Bitcoin software to the last known working version (but not earlier than version 0.8.1) or delete everything &lt;b&gt;except&lt;/b&gt; &quot;wallet.dat&quot; from your Bitcoin home directory&lt;font face=&quot;courier&quot;&gt;&lt;b&gt;%1&lt;/b&gt;&lt;/font&gt;&lt;br&gt;&lt;br&gt;If you choose to delete the contents of the Bitcoin home directory, you will have to do a fresh download of the blockchain again, which will require a few hours the first time.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="1953"/>
+        <location filename="ArmoryQt.py" line="1951"/>
         <source>It looks like you just clicked a &quot;bitcoin:&quot; link, but that link is malformed.</source>
         <translation>It looks like you just clicked a &quot;bitcoin:&quot; link, but that link is malformed.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="1955"/>
+        <location filename="ArmoryQt.py" line="1953"/>
         <source>It looks like you just entered a &quot;bitcoin:&quot; link, but that link is malformed.</source>
         <translation>It looks like you just entered a &quot;bitcoin:&quot; link, but that link is malformed.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="1957"/>
+        <location filename="ArmoryQt.py" line="1955"/>
         <source>Please check the source of the link and enter the transaction manually.</source>
         <translation>Please check the source of the link and enter the transaction manually.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="2780"/>
+        <location filename="ArmoryQt.py" line="2784"/>
         <source>Add Transaction Comment</source>
         <translation>Add Transaction Comment</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="2782"/>
+        <location filename="ArmoryQt.py" line="2786"/>
         <source>Change Transaction Comment</source>
         <translation>Change Transaction Comment</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="2798"/>
+        <location filename="ArmoryQt.py" line="2802"/>
         <source>Add Address Comment</source>
         <translation>Add Address Comment</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="2800"/>
+        <location filename="ArmoryQt.py" line="2804"/>
         <source>Change Address Comment</source>
         <translation>Change Address Comment</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="530"/>
+        <location filename="ArmoryQt.py" line="528"/>
         <source>&amp;Export Transactions...</source>
         <translation>&amp;Export Transactions...</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="531"/>
+        <location filename="ArmoryQt.py" line="529"/>
         <source>&amp;Settings...</source>
         <translation>&amp;Settings...</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="532"/>
+        <location filename="ArmoryQt.py" line="530"/>
         <source>&amp;Minimize Armory</source>
         <translation>&amp;Minimize Armory</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="533"/>
+        <location filename="ArmoryQt.py" line="531"/>
         <source>Export &amp;Log File...</source>
         <translation>Export &amp;Log File...</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="534"/>
+        <location filename="ArmoryQt.py" line="532"/>
         <source>&amp;Quit Armory</source>
         <translation>&amp;Quit Armory</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="550"/>
+        <location filename="ArmoryQt.py" line="548"/>
         <source>&amp;Standard</source>
         <translation>&amp;Standard</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="551"/>
+        <location filename="ArmoryQt.py" line="549"/>
         <source>&amp;Advanced</source>
         <translation>&amp;Advanced</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="552"/>
+        <location filename="ArmoryQt.py" line="550"/>
         <source>&amp;Expert</source>
         <translation>&amp;Expert</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="402"/>
+        <location filename="ArmoryQt.py" line="400"/>
         <source>Funds if all current transactions are confirmed. Value appears gray when it is the same as your spendable funds.</source>
         <translation>Funds if all current transactions are confirmed. Value appears gray when it is the same as your spendable funds.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="406"/>
+        <location filename="ArmoryQt.py" line="404"/>
         <source>Funds that have less than 6 confirmations, and thus should not be considered &lt;i&gt;yours&lt;/i&gt;, yet.</source>
         <translation>Funds that have less than 6 confirmations, and thus should not be considered &lt;i&gt;yours&lt;/i&gt;, yet.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="521"/>
+        <location filename="ArmoryQt.py" line="519"/>
         <source>Transaction history cannot be collected until Armory is in online mode.  Please try again when Armory is online. </source>
         <translation>Transaction history cannot be collected until Armory is in online mode.  Please try again when Armory is online. </translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="581"/>
+        <location filename="ArmoryQt.py" line="579"/>
         <source>Bitcoin Core is not available, so Armory will not be able to broadcast any transactions for you.</source>
         <translation>Bitcoin Core is not available, so Armory will not be able to broadcast any transactions for you.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="601"/>
+        <location filename="ArmoryQt.py" line="599"/>
         <source>Armory is currently offline, and cannot determine what funds are available for Simulfunding.  Please try again when Armory is in online mode.</source>
         <translation>Armory is currently offline, and cannot determine what funds are available for simulfunding.  Please try again when Armory is in online mode.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="611"/>
+        <location filename="ArmoryQt.py" line="609"/>
         <source>Import a signature-collector text block for review and signing. It is usually a block of text with &quot;TXSIGCOLLECT&quot; in the first line, or a &lt;i&gt;*.sigcollect.tx&lt;/i&gt; file.</source>
         <translation>Import a signature-collector text block for review and signing. It is usually a block of text with &quot;TXSIGCOLLECT&quot; in the first line, or a &lt;i&gt;*.sigcollect.tx&lt;/i&gt; file.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="722"/>
+        <location filename="ArmoryQt.py" line="720"/>
         <source>Armory is using the default data directory because the data directory specified in the command line could not be found nor created.</source>
         <translation>Armory is using the default data directory because the data directory specified in the command line could not be found nor created.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="729"/>
+        <location filename="ArmoryQt.py" line="727"/>
         <source>Armory is using the default database directory because the database directory specified in the command line could not be found nor created.</source>
         <translation>Armory is using the default database directory because the database directory specified in the command line could not be found nor created.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="736"/>
+        <location filename="ArmoryQt.py" line="734"/>
         <source>Armory is using the default Bitcoin directory because the Bitcoin directory specified in the command line could not be found.</source>
         <translation>Armory is using the default Bitcoin directory because the Bitcoin directory specified in the command line could not be found.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="743"/>
+        <location filename="ArmoryQt.py" line="741"/>
         <source>Armory detected an older version Database. Do you want to delete the old database? Choose yes if  do not think that you will revert to an older version of Armory.</source>
         <translation>Armory detected an older version Database. Do you want to delete the old database? Choose yes if  do not think that you will revert to an older version of Armory.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="941"/>
+        <location filename="ArmoryQt.py" line="939"/>
         <source>The module you attempted to load (%1) is malformed.  It is missing attributes that are needed for Armory to load it. It will be skipped.</source>
         <translation>The module you attempted to load (%1) is malformed.  It is missing attributes that are needed for Armory to load it. It will be skipped.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="855"/>
+        <location filename="ArmoryQt.py" line="853"/>
         <source>Module &quot;%1&quot; is only specified to work up to Armory version %2. You are using Armory version %3.  Please remove the module if you experience any problems with it, or contact the maintainer for a new version. &lt;br&gt;&lt;br&gt; Do you want to continue loading the module?</source>
         <translation>Module &quot;%1&quot; is only specified to work up to Armory version %2. You are using Armory version %3.  Please remove the module if you experience any problems with it, or contact the maintainer for a new version. &lt;br&gt;&lt;br&gt; Do you want to continue loading the module?</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="922"/>
+        <location filename="ArmoryQt.py" line="920"/>
         <source>Armory detected the following module which &lt;font color=&quot;%1&quot;&gt;&lt;b&gt;has not been signed by Armory&lt;/b&gt;&lt;/font&gt; and may be dangerous: &lt;br&gt;&lt;br&gt;   &lt;b&gt;Module Name:&lt;/b&gt; %2&lt;br&gt;   &lt;b&gt;Module Path:&lt;/b&gt; %3&lt;br&gt;&lt;br&gt;&lt;br&gt;Armory will not allow you to run this module.</source>
         <translation>Armory detected the following module which &lt;font color=&quot;%1&quot;&gt;&lt;b&gt;has not been signed by Armory&lt;/b&gt;&lt;/font&gt; and may be dangerous: &lt;br&gt;&lt;br&gt;   &lt;b&gt;Module Name:&lt;/b&gt; %2&lt;br&gt;   &lt;b&gt;Module Path:&lt;/b&gt; %3&lt;br&gt;&lt;br&gt;&lt;br&gt;Armory will not allow you to run this module.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="950"/>
+        <location filename="ArmoryQt.py" line="948"/>
         <source>Module %1 is only specified to work up to Armory version %2. You are using Armory version %3.  Please remove the module if you experience any problems with it, or contact the maintainer for a new version.&lt;br&gt;&lt;br&gt;Do you want to continue loading the module?</source>
         <translation>Module %1 is only specified to work up to Armory version %2. You are using Armory version %3.  Please remove the module if you experience any problems with it, or contact the maintainer for a new version.&lt;br&gt;&lt;br&gt;Do you want to continue loading the module?</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="1015"/>
+        <location filename="ArmoryQt.py" line="1013"/>
         <source>The next time you restart Armory, all unconfirmed transactions will be cleared allowing you to retry any stuck transactions.</source>
         <translation>The next time you restart Armory, all unconfirmed transactions will be cleared allowing you to retry any stuck transactions.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="1019"/>
+        <location filename="ArmoryQt.py" line="1017"/>
         <source>&lt;br&gt;&lt;br&gt;Make sure you also restart Bitcoin Core (or bitcoind) and let it synchronize again before you restart Armory.  Doing so will clear its memory pool as well.</source>
         <translation>&lt;br&gt;&lt;br&gt;Make sure you also restart Bitcoin Core (or bitcoind) and let it synchronize again before you restart Armory.  Doing so will clear its memory pool as well.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="1153"/>
+        <location filename="ArmoryQt.py" line="1151"/>
         <source>The next time you restart Armory, it will rescan the blockchain database, and reconstruct your wallet histories from scratch. The rescan will take 10-60 minutes depending on your system. &lt;br&gt;&lt;br&gt; Do you wish to force a rescan on the next Armory restart?</source>
         <translation>The next time you restart Armory, it will rescan the blockchain database, and reconstruct your wallet histories from scratch. The rescan will take 10-60 minutes depending on your system. &lt;br&gt;&lt;br&gt; Do you wish to force a rescan on the next Armory restart?</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="1165"/>
+        <location filename="ArmoryQt.py" line="1163"/>
         <source>The next time you restart Armory, it will rebuild and rescan the entire blockchain database.  This operation can take between 30 minutes and 4 hours depending on your system speed. &lt;br&gt;&lt;br&gt;Do you wish to force a rebuild on the next Armory restart?</source>
         <translation>The next time you restart Armory, it will rebuild and rescan the entire blockchain database.  This operation can take between 30 minutes and 4 hours depending on your system speed. &lt;br&gt;&lt;br&gt;Do you wish to force a rebuild on the next Armory restart?</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="1177"/>
+        <location filename="ArmoryQt.py" line="1175"/>
         <source>The next time you restart Armory, it will rescan the balance of your wallets. This operation typically takes less than a minute. &lt;br&gt;&lt;br&gt;Do you wish to force a balance rescan on the next Armory restart?</source>
         <translation>The next time you restart Armory, it will rescan the balance of your wallets. This operation typically takes less than a minute. &lt;br&gt;&lt;br&gt;Do you wish to force a balance rescan on the next Armory restart?</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="1492"/>
+        <location filename="ArmoryQt.py" line="1490"/>
         <source>Armory is not set as your default application for handling &quot;bitcoin:&quot; links.  Would you like to use Armory as the default?</source>
         <translation>Armory is not set as your default application for handling &quot;bitcoin:&quot; links.  Would you like to use Armory as the default?</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="1545"/>
+        <location filename="ArmoryQt.py" line="1543"/>
         <source>Since Armory version 0.92 the formats for offline transaction operations has changed to accommodate multi-signature transactions.  This format is &lt;u&gt;not&lt;/u&gt; compatible with versions of Armory before 0.92. &lt;br&gt;&lt;br&gt;To continue, the other system will need to be upgraded to to version 0.92 or later.  If you cannot upgrade the other system, you will need to reinstall an older version of Armory on this system.</source>
         <translation>Since Armory version 0.92 the formats for offline transaction operations has changed to accommodate multi-signature transactions.  This format is &lt;u&gt;not&lt;/u&gt; compatible with versions of Armory before 0.92. &lt;br&gt;&lt;br&gt;To continue, the other system will need to be upgraded to to version 0.92 or later.  If you cannot upgrade the other system, you will need to reinstall an older version of Armory on this system.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="1579"/>
+        <location filename="ArmoryQt.py" line="1577"/>
         <source>The developer tools are not available yet, but will be added soon.  Regardless, developer-mode still offers lots of extra information and functionality that is not available in Standard or Advanced mode.</source>
         <translation>The developer tools are not available yet, but will be added soon.  Regardless, developer-mode still offers lots of extra information and functionality that is not available in Standard or Advanced mode.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="1639"/>
+        <location filename="ArmoryQt.py" line="1637"/>
         <source>No passphrase was selected for the encrypted backup. No backup was created.</source>
         <translation>No passphrase was selected for the encrypted backup. No backup was created.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="1651"/>
+        <location filename="ArmoryQt.py" line="1649"/>
         <source>Your wallet was successfully backed up to the following location:&lt;br&gt;&lt;br&gt;%1</source>
         <translation>Your wallet was successfully backed up to the following location:&lt;br&gt;&lt;br&gt;%1</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="1699"/>
+        <location filename="ArmoryQt.py" line="1697"/>
         <source>You may have to restart Armory for all aspects of the new usermode to go into effect.</source>
         <translation>You may have to restart Armory for all aspects of the new usermode to go into effect.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="1735"/>
+        <location filename="ArmoryQt.py" line="1733"/>
         <source>The date format you specified was not valid.  Please re-enter it using only the strftime symbols shown in the help text.</source>
         <translation>The date format you specified was not valid.  Please re-enter it using only the strftime symbols shown in the help text.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="1767"/>
+        <location filename="ArmoryQt.py" line="1765"/>
         <source>Armory is already running!  You can only have one Armory open at a time.  Exiting...</source>
         <translation>Armory is already running!  You can only have one Armory open at a time.  Exiting...</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="1920"/>
+        <location filename="ArmoryQt.py" line="1918"/>
         <source>You have not entered a URL String yet. Please go back and enter a URL String.</source>
         <translation>You have not entered a URL String yet. Please go back and enter a URL String.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="1938"/>
+        <location filename="ArmoryQt.py" line="1936"/>
         <source>You clicked on a &quot;bitcoin:&quot; link, but Armory is in offline mode, and is not capable of creating transactions. Using links will only work if Armory is connected to the Bitcoin network!</source>
         <translation>You clicked on a &quot;bitcoin:&quot; link, but Armory is in offline mode, and is not capable of creating transactions. Using links will only work if Armory is connected to the Bitcoin network!</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="1944"/>
+        <location filename="ArmoryQt.py" line="1942"/>
         <source>You entered a &quot;bitcoin:&quot; link, but Armory is in offline mode, and is not capable of creating transactions. Using links will only work if Armory is connected to the Bitcoin network!</source>
         <translation>You entered a &quot;bitcoin:&quot; link, but Armory is in offline mode, and is not capable of creating transactions. Using links will only work if Armory is connected to the Bitcoin network!</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="1966"/>
+        <location filename="ArmoryQt.py" line="1964"/>
         <source>The &quot;bitcoin:&quot; link you just clicked does not even contain an address!  There is nothing that Armory can do with this link!</source>
         <translation>The &quot;bitcoin:&quot; link you just clicked does not even contain an address!  There is nothing that Armory can do with this link!</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="1970"/>
+        <location filename="ArmoryQt.py" line="1968"/>
         <source>The &quot;bitcoin:&quot; link you just entered does not even contain an address!  There is nothing that Armory can do with this link!</source>
         <translation>The &quot;bitcoin:&quot; link you just entered does not even contain an address!  There is nothing that Armory can do with this link!</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="1983"/>
+        <location filename="ArmoryQt.py" line="1981"/>
         <source>The address for the &quot;bitcoin:&quot; link you just clicked is for the wrong network!  You are on the &lt;b&gt;%2&lt;/b&gt; and the address you supplied is for the &lt;b&gt;%3&lt;/b&gt;!</source>
         <translation>The address for the &quot;bitcoin:&quot; link you just clicked is for the wrong network!  You are on the &lt;b&gt;%2&lt;/b&gt; and the address you supplied is for the &lt;b&gt;%3&lt;/b&gt;!</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="2002"/>
+        <location filename="ArmoryQt.py" line="2000"/>
         <source>The &quot;bitcoin:&quot; link you just clicked contains fields that are required but not recognized by Armory.  This may be an older version of Armory, or the link you clicked on uses an exotic, unsupported format. &lt;br&gt;&lt;br&gt;The action cannot be completed.</source>
         <translation>The &quot;bitcoin:&quot; link you just clicked contains fields that are required but not recognized by Armory.  This may be an older version of Armory, or the link you clicked on uses an exotic, unsupported format. &lt;br&gt;&lt;br&gt;The action cannot be completed.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="2008"/>
+        <location filename="ArmoryQt.py" line="2006"/>
         <source>The &quot;bitcoin:&quot; link you just entered contains fields that are required but not recognized by Armory.  This may be an older version of Armory, or the link you entered on uses an exotic, unsupported format. &lt;br&gt;&lt;br&gt;The action cannot be completed.</source>
         <translation>The &quot;bitcoin:&quot; link you just entered contains fields that are required but not recognized by Armory.  This may be an older version of Armory, or the link you entered on uses an exotic, unsupported format. &lt;br&gt;&lt;br&gt;The action cannot be completed.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="2024"/>
+        <location filename="ArmoryQt.py" line="2022"/>
         <source>You just clicked on a &quot;bitcoin:&quot; link, but Armory is offline and cannot send transactions.  Please click the link again when Armory is online.</source>
         <translation>You just clicked on a &quot;bitcoin:&quot; link, but Armory is offline and cannot send transactions.  Please click the link again when Armory is online.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="2488"/>
+        <location filename="ArmoryQt.py" line="2486"/>
         <source>Blockchain loading is complete. Your balances and transaction history are now available under the &quot;Transactions&quot; tab.  You can also send and receive bitcoins.</source>
         <translation>Blockchain loading is complete. Your balances and transaction history are now available under the &quot;Transactions&quot; tab.  You can also send and receive bitcoins.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="2730"/>
+        <location filename="ArmoryQt.py" line="2734"/>
         <source>You currently do not have any wallets.  Would you like to create one, now?</source>
         <translation>You currently do not have any wallets.  Would you like to create one, now?</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="2961"/>
+        <location filename="ArmoryQt.py" line="2965"/>
         <source>You are already in the process of scanning the blockchain for the purposes of sweeping other addresses.  You cannot initiate sweeping new addresses until the current operation completes. &lt;br&gt;&lt;br&gt;In the future, you may select &quot;Multiple Keys&quot; when entering addresses to sweep.  There is no limit on the number that can be specified, but they must all be entered at once.</source>
         <translation>You are already in the process of scanning the blockchain for the purposes of sweeping other addresses.  You cannot initiate sweeping new addresses until the current operation completes. &lt;br&gt;&lt;br&gt;In the future, you may select &quot;Multiple Keys&quot; when entering addresses to sweep.  There is no limit on the number that can be specified, but they must all be entered at once.</translation>
     </message>
     <message numerus="yes">
-        <location filename="ArmoryQt.py" line="2983"/>
+        <location filename="ArmoryQt.py" line="2987"/>
         <source>You have chosen to sweep %n key(s), but Armory is currently in offline mode.  The sweep will be performed the next time you go into online mode.  You can initiate online mode (if available) from the dashboard in the main window.</source>
         <translation>
             <numerusform>You have chosen to sweep %n key, but Armory is currently in offline mode.  The sweep will be performed the next time you go into online mode.  You can initiate online mode (if available) from the dashboard in the main window.</numerusform>
@@ -1628,7 +1628,7 @@
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="ArmoryQt.py" line="2991"/>
+        <location filename="ArmoryQt.py" line="2995"/>
         <source>Armory must scan the global transaction history in order to find any bitcoins associated with the keys you supplied. Armory will go into offline mode temporarily while the scan is performed, and you will not have access to balances or be able to create transactions.  The scan may take several minutes.&lt;br&gt;&lt;br&gt;</source>
         <translation>
             <numerusform>Armory must scan the global transaction history in order to find any bitcoins associated with the key you supplied. Armory will go into offline mode temporarily while the scan is performed, and you will not have access to balances or be able to create transactions.  The scan may take several minutes.&lt;br&gt;&lt;br&gt;</numerusform>
@@ -1636,12 +1636,12 @@
         </translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3000"/>
+        <location filename="ArmoryQt.py" line="3004"/>
         <source>There is currently another scan operation being performed. Would you like to start the sweep operation after it completes? </source>
         <translation>There is currently another scan operation being performed. Would you like to start the sweep operation after it completes? </translation>
     </message>
     <message numerus="yes">
-        <location filename="ArmoryQt.py" line="3036"/>
+        <location filename="ArmoryQt.py" line="3040"/>
         <source>The private key(s) you have provided does not appear to contain any funds.  There is nothing to sweep.</source>
         <translation>
             <numerusform>The private key you have provided does not appear to contain any funds.  There is nothing to sweep.</numerusform>
@@ -1649,192 +1649,192 @@
         </translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3108"/>
+        <location filename="ArmoryQt.py" line="3112"/>
         <source>The broadcast process failed unexpectedly. Report this error to the development team if this issue occurs repeatedly</source>
         <translation>The broadcast process failed unexpectedly. Report this error to the development team if this issue occurs repeatedly</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3134"/>
+        <location filename="ArmoryQt.py" line="3156"/>
         <source>The transaction that you just executed failed with the following error message: &lt;br&gt;&lt;br&gt; &lt;b&gt;%1&lt;/b&gt;&lt;br&gt;&lt;br&gt;&lt;br&gt;&lt;br&gt;On time out errors, the transaction may have actually succeeded and this message is displayed prematurely.  To confirm whether the the transaction actually succeeded, you can try this direct link to %2: &lt;br&gt;&lt;br&gt;&lt;a href=&quot;%3&quot;&gt;%4...&lt;/a&gt;&lt;br&gt;&lt;br&gt;If you do not see the transaction on that webpage within one minute, it failed and you should attempt to re-send it. If it &lt;i&gt;does&lt;/i&gt; show up, then you do not need to do anything else -- it will show up in Armory as soon as it receives one confirmation. &lt;br&gt;&lt;br&gt;If the transaction did fail, it is likely because the fee is too low. Try again with a higher fee. If the problem persists, go to &quot;&lt;i&gt;File&lt;/i&gt;&quot; -&gt; &quot;&lt;i&gt;Export Log File&lt;/i&gt;&quot; and then attach it to a support ticket at &lt;a href=&quot;%5&quot;&gt;%5&lt;/a&gt;</source>
         <translation>The transaction that you just executed failed with the following error message: &lt;br&gt;&lt;br&gt; &lt;b&gt;%1&lt;/b&gt;&lt;br&gt;&lt;br&gt;&lt;br&gt;&lt;br&gt;On time out errors, the transaction may have actually succeeded and this message is displayed prematurely.  To confirm whether the the transaction actually succeeded, you can try this direct link to %2: &lt;br&gt;&lt;br&gt;&lt;a href=&quot;%3&quot;&gt;%4...&lt;/a&gt;&lt;br&gt;&lt;br&gt;If you do not see the transaction on that webpage within one minute, it failed and you should attempt to re-send it. If it &lt;i&gt;does&lt;/i&gt; show up, then you do not need to do anything else -- it will show up in Armory as soon as it receives one confirmation. &lt;br&gt;&lt;br&gt;If the transaction did fail, it is likely because the fee is too low. Try again with a higher fee. If the problem persists, go to &quot;&lt;i&gt;File&lt;/i&gt;&quot; -&gt; &quot;&lt;i&gt;Export Log File&lt;/i&gt;&quot; and then attach it to a support ticket at &lt;a href=&quot;%5&quot;&gt;%5&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3184"/>
+        <location filename="ArmoryQt.py" line="3215"/>
         <source>Armory is currently in the middle of scanning the blockchain for your existing wallets.  New wallets cannot be imported until this operation is finished.</source>
         <translation>Armory is currently in the middle of scanning the blockchain for your existing wallets.  New wallets cannot be imported until this operation is finished.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3204"/>
+        <location filename="ArmoryQt.py" line="3235"/>
         <source>You selected a wallet that has the same ID as one already in your wallet (%1)!  If you would like to import it anyway, please delete the duplicate wallet in Armory, first.</source>
         <translation>You selected a wallet that has the same ID as one already in your wallet (%1)!  If you would like to import it anyway, please delete the duplicate wallet in Armory, first.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3223"/>
+        <location filename="ArmoryQt.py" line="3254"/>
         <source>&lt;font color=&quot;red&quot;&gt;&lt;b&gt;WARNING:&lt;/b&gt;&lt;/font&gt; You are about to make an &lt;u&gt;unencrypted&lt;/u&gt; backup of your wallet.  It is highly recommended that you do &lt;u&gt;not&lt;/u&gt; ever save unencrypted wallets to your regular hard drive.  This feature is intended for saving to a USB key or other removable media.</source>
         <translation>&lt;font color=&quot;red&quot;&gt;&lt;b&gt;WARNING:&lt;/b&gt;&lt;/font&gt; You are about to make an &lt;u&gt;unencrypted&lt;/u&gt; backup of your wallet.  It is highly recommended that you do &lt;u&gt;not&lt;/u&gt; ever save unencrypted wallets to your regular hard drive.  This feature is intended for saving to a USB key or other removable media.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3235"/>
+        <location filename="ArmoryQt.py" line="3266"/>
         <source>The address book is created from transaction data available in the blockchain, which has not finished loading.  The address book will become available when Armory is online.</source>
         <translation>The address book is created from transaction data available in the blockchain, which has not finished loading.  The address book will become available when Armory is online.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3240"/>
+        <location filename="ArmoryQt.py" line="3271"/>
         <source>The address book is created from transaction data available in the blockchain, but Armory is currently offline.  The address book will become available when Armory is online.</source>
         <translation>The address book is created from transaction data available in the blockchain, but Armory is currently offline.  The address book will become available when Armory is online.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3246"/>
+        <location filename="ArmoryQt.py" line="3277"/>
         <source>You have no wallets so there is no address book to display.</source>
         <translation>You have no wallets so there is no address book to display.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3298"/>
+        <location filename="ArmoryQt.py" line="3329"/>
         <source>The transaction you requested be displayed does not exist in Armory&apos;s database.  This is unusual...</source>
         <translation>The transaction you requested be displayed does not exist in Armory&apos;s database.  This is unusual...</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3340"/>
+        <location filename="ArmoryQt.py" line="3371"/>
         <source>Armory encountered an error opening your web browser.  To view this transaction on blockchain.info, please copy and paste the following URL into your browser: &lt;br&gt;&lt;br&gt;%1</source>
         <translation>Armory encountered an error opening your web browser.  To view this transaction on blockchain.info, please copy and paste the following URL into your browser: &lt;br&gt;&lt;br&gt;%1</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3372"/>
+        <location filename="ArmoryQt.py" line="3403"/>
         <source>Armory is currently running in offline mode, and has no ability to determine balances or create transactions. &lt;br&gt;&lt;br&gt;In order to send coins from this wallet you must use a full copy of this wallet from an online computer, or initiate an &quot;offline transaction&quot; using a watching-only wallet on an online computer.</source>
         <translation>Armory is currently running in offline mode, and has no ability to determine balances or create transactions. &lt;br&gt;&lt;br&gt;In order to send coins from this wallet you must use a full copy of this wallet from an online computer, or initiate an &quot;offline transaction&quot; using a watching-only wallet on an online computer.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3382"/>
+        <location filename="ArmoryQt.py" line="3413"/>
         <source>Armory is currently scanning the blockchain to collect the information needed to create transactions.  This typically takes between one and five minutes.  Please wait until your balance appears on the main window, then try again.</source>
         <translation>Armory is currently scanning the blockchain to collect the information needed to create transactions.  This typically takes between one and five minutes.  Please wait until your balance appears on the main window, then try again.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3391"/>
+        <location filename="ArmoryQt.py" line="3422"/>
         <source>You cannot send any bitcoins until you create a wallet and receive some coins.  Would you like to create a wallet?</source>
         <translation>You cannot send any bitcoins until you create a wallet and receive some coins.  Would you like to create a wallet?</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3420"/>
+        <location filename="ArmoryQt.py" line="3451"/>
         <source>You just clicked on a &quot;bitcoin:&quot; link requesting bitcoins to be sent to the following address:&lt;br&gt; </source>
         <translation>You just clicked on a &quot;bitcoin:&quot; link requesting bitcoins to be sent to the following address:&lt;br&gt; </translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3447"/>
+        <location filename="ArmoryQt.py" line="3478"/>
         <source>&lt;br&gt;&lt;br&gt;There is no amount specified in the link, so you can decide the amount after selecting a wallet to use for this transaction. </source>
         <translation>&lt;br&gt;&lt;br&gt;There is no amount specified in the link, so you can decide the amount after selecting a wallet to use for this transaction. </translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3451"/>
+        <location filename="ArmoryQt.py" line="3482"/>
         <source>&lt;br&gt;&lt;br&gt;&lt;b&gt;The specified amount &lt;u&gt;can&lt;/u&gt; be changed&lt;/b&gt; on the next screen before hitting the &quot;Send&quot; button. </source>
         <translation>&lt;br&gt;&lt;br&gt;&lt;b&gt;The specified amount &lt;u&gt;can&lt;/u&gt; be changed&lt;/b&gt; on the next screen before hitting the &quot;Send&quot; button. </translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3456"/>
+        <location filename="ArmoryQt.py" line="3487"/>
         <source>You just clicked on a &quot;bitcoin:&quot; link to send money, but you currently have no wallets!  Would you like to create a wallet now?</source>
         <translation>You just clicked on a &quot;bitcoin:&quot; link to send money, but you currently have no wallets!  Would you like to create a wallet now?</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3477"/>
+        <location filename="ArmoryQt.py" line="3508"/>
         <source>You have not created any wallets which means there is nowhere to store you bitcoins!  Would you like to create a wallet now?</source>
         <translation>You have not created any wallets which means there is nowhere to store you bitcoins!  Would you like to create a wallet now?</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3550"/>
+        <location filename="ArmoryQt.py" line="3581"/>
         <source>&lt;b&gt;&lt;u&gt;&lt;font size=3&gt;Wallet Analysis Log Files&lt;/font&gt;&lt;/u&gt;&lt;/b&gt; &lt;br&gt;&lt;br&gt; The wallet analysis logs contain no personally-identifiable information, only a record of errors and inconsistencies found in your wallet file.  No private keys or even public keys are included. &lt;br&gt;&lt;br&gt;&lt;b&gt;&lt;u&gt;&lt;font size=3&gt;Regular Log Files&lt;/font&gt;&lt;/u&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;The regular log files do not contain any &lt;u&gt;security&lt;/u&gt;-sensitive information, but some users may consider the information to be &lt;u&gt;privacy&lt;/u&gt;-sensitive.  The log files may identify some addresses and transactions that are related to your wallets.  It is always recommended you include your log files with any request to the Armory team, unless you are uncomfortable with the privacy implications. &lt;br&gt;&lt;br&gt;&lt;b&gt;&lt;u&gt;&lt;font size=3&gt;Watching-only Wallet&lt;/font&gt;&lt;/u&gt;&lt;/b&gt; &lt;br&gt;&lt;br&gt;A watching-only wallet is a copy of a regular wallet that does not contain any signing keys.  This allows the holder to see the balance and transaction history of the wallet, but not spend any of the funds. &lt;br&gt;&lt;br&gt; You may be requested to submit a watching-only copy of your wallet to make sure that there is no risk to the security of your funds.  You should not even consider sending your watching-only wallet unless it was specifically requested by an Armory representative.</source>
         <translation>&lt;b&gt;&lt;u&gt;&lt;font size=3&gt;Wallet Analysis Log Files&lt;/font&gt;&lt;/u&gt;&lt;/b&gt; &lt;br&gt;&lt;br&gt; The wallet analysis logs contain no personally-identifiable information, only a record of errors and inconsistencies found in your wallet file.  No private keys or even public keys are included. &lt;br&gt;&lt;br&gt;&lt;b&gt;&lt;u&gt;&lt;font size=3&gt;Regular Log Files&lt;/font&gt;&lt;/u&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;The regular log files do not contain any &lt;u&gt;security&lt;/u&gt;-sensitive information, but some users may consider the information to be &lt;u&gt;privacy&lt;/u&gt;-sensitive.  The log files may identify some addresses and transactions that are related to your wallets.  It is always recommended you include your log files with any request to the Armory team, unless you are uncomfortable with the privacy implications. &lt;br&gt;&lt;br&gt;&lt;b&gt;&lt;u&gt;&lt;font size=3&gt;Watching-only Wallet&lt;/font&gt;&lt;/u&gt;&lt;/b&gt; &lt;br&gt;&lt;br&gt;A watching-only wallet is a copy of a regular wallet that does not contain any signing keys.  This allows the holder to see the balance and transaction history of the wallet, but not spend any of the funds. &lt;br&gt;&lt;br&gt; You may be requested to submit a watching-only copy of your wallet to make sure that there is no risk to the security of your funds.  You should not even consider sending your watching-only wallet unless it was specifically requested by an Armory representative.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3584"/>
+        <location filename="ArmoryQt.py" line="3615"/>
         <source>Armory log files do not contain any &lt;u&gt;security&lt;/u&gt;-sensitive information, but some users may consider the information to be &lt;u&gt;privacy&lt;/u&gt;-sensitive.  The log files may identify some addresses and transactions that are related to your wallets. &lt;br&gt;&lt;br&gt; &lt;b&gt;No signing-key data is ever written to the log file&lt;/b&gt;. Only enough data is there to help the Armory developers track down bugs in the software, but it may still be considered sensitive information to some users. &lt;br&gt;&lt;br&gt;Please do not send the log file to the Armory developers if you are not comfortable with the privacy implications!  However, if you do not send the log file, it may be very difficult or impossible for us to help you with your problem.</source>
         <translation>Armory log files do not contain any &lt;u&gt;security&lt;/u&gt;-sensitive information, but some users may consider the information to be &lt;u&gt;privacy&lt;/u&gt;-sensitive.  The log files may identify some addresses and transactions that are related to your wallets. &lt;br&gt;&lt;br&gt; &lt;b&gt;No signing-key data is ever written to the log file&lt;/b&gt;. Only enough data is there to help the Armory developers track down bugs in the software, but it may still be considered sensitive information to some users. &lt;br&gt;&lt;br&gt;Please do not send the log file to the Armory developers if you are not comfortable with the privacy implications!  However, if you do not send the log file, it may be very difficult or impossible for us to help you with your problem.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3652"/>
+        <location filename="ArmoryQt.py" line="3683"/>
         <source>The Bitcoin software appears to be installed now, but it needs to be closed for Armory to work.  Would you like Armory to close it for you?</source>
         <translation>The Bitcoin software appears to be installed now, but it needs to be closed for Armory to work.  Would you like Armory to close it for you?</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3660"/>
+        <location filename="ArmoryQt.py" line="3691"/>
         <source>The Bitcoin software still appears to be missing.  If you just installed it, then please adjust your settings to point to the installation directory.</source>
         <translation>The Bitcoin software still appears to be missing.  If you just installed it, then please adjust your settings to point to the installation directory.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3667"/>
+        <location filename="ArmoryQt.py" line="3698"/>
         <source>Bitcoin Core is still running.  Armory cannot start until it is closed.  Do you want Armory to close it for you?</source>
         <translation>Bitcoin Core is still running.  Armory cannot start until it is closed.  Do you want Armory to close it for you?</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3805"/>
+        <location filename="ArmoryQt.py" line="3836"/>
         <source>Will open your default browser to https://bitcoin.org where you can download the latest version of Bitcoin Core, and get other information and links about Bitcoin, in general.</source>
         <translation>Will open your default browser to https://bitcoin.org where you can download the latest version of Bitcoin Core, and get other information and links about Bitcoin, in general.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3809"/>
+        <location filename="ArmoryQt.py" line="3840"/>
         <source>Change Bitcoin Core/bitcoind management settings or point Armory to a non-standard Bitcoin installation</source>
         <translation>Change Bitcoin Core/bitcoind management settings or point Armory to a non-standard Bitcoin installation</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3812"/>
+        <location filename="ArmoryQt.py" line="3843"/>
         <source>Armory has detected a running Bitcoin Core or bitcoind instance and will force it to exit</source>
         <translation>Armory has detected a running Bitcoin Core or bitcoind instance and will force it to exit</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3864"/>
+        <location filename="ArmoryQt.py" line="3895"/>
         <source>Attempted to kill the running Bitcoin Core/bitcoind instance, but it was not found.</source>
         <translation>Attempted to kill the running Bitcoin Core/bitcoind instance, but it was not found.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="4124"/>
+        <location filename="ArmoryQt.py" line="4155"/>
         <source>For more information about Armory, and even Bitcoin itself, you should visit the &lt;a href=&quot;https://bitcointalk.org/index.php?board=97.0&quot;&gt;Armory Forum&lt;/a&gt; and &lt;a href=&quot;https://bitcoin.org&quot;&gt;Bitcoin.org&lt;/a&gt;.  If you are experiencing problems using this software, please visit the &lt;a href=&quot;https://bitcointalk.org/index.php?board=97.0&quot;&gt;Armory Forum&lt;/a&gt;. Users there will help you with any issues that you have. &lt;br&gt;&lt;br&gt;&lt;b&gt;&lt;u&gt;IMPORTANT:&lt;/u&gt;&lt;/b&gt; Make a backup of your wallet(s)!  Paper backups protect you &lt;i&gt;forever&lt;/i&gt; against forgotten passwords, hard-drive failure, and make it easy for your family to recover your funds if something terrible happens to you.  &lt;i&gt;Each wallet only needs to be backed up once, ever!&lt;/i&gt;  Without it, you are at risk of losing all of your Bitcoins! &lt;br&gt;&lt;br&gt;</source>
         <translation>For more information about Armory, and even Bitcoin itself, you should visit the &lt;a href=&quot;https://bitcointalk.org/index.php?board=97.0&quot;&gt;Armory Forum&lt;/a&gt; and &lt;a href=&quot;https://bitcoin.org&quot;&gt;Bitcoin.org&lt;/a&gt;.  If you are experiencing problems using this software, please visit the &lt;a href=&quot;https://bitcointalk.org/index.php?board=97.0&quot;&gt;Armory Forum&lt;/a&gt;. Users there will help you with any issues that you have. &lt;br&gt;&lt;br&gt;&lt;b&gt;&lt;u&gt;IMPORTANT:&lt;/u&gt;&lt;/b&gt; Make a backup of your wallet(s)!  Paper backups protect you &lt;i&gt;forever&lt;/i&gt; against forgotten passwords, hard-drive failure, and make it easy for your family to recover your funds if something terrible happens to you.  &lt;i&gt;Each wallet only needs to be backed up once, ever!&lt;/i&gt;  Without it, you are at risk of losing all of your Bitcoins! &lt;br&gt;&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="4402"/>
+        <location filename="ArmoryQt.py" line="4433"/>
         <source>There was an error starting the underlying Bitcoin engine. This should not normally happen.  Usually it occurs when you have been using Bitcoin Core prior to using Armory, especially if you have upgraded or downgraded Bitcoin Core recently. Output from bitcoind:&lt;br&gt;</source>
         <translation>There was an error starting the underlying Bitcoin engine. This should not normally happen.  Usually it occurs when you have been using Bitcoin Core prior to using Armory, especially if you have upgraded or downgraded Bitcoin Core recently. Output from bitcoind:&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="4411"/>
+        <location filename="ArmoryQt.py" line="4442"/>
         <source>There was an error starting the underlying Bitcoin engine. This should not normally happen.  Usually it occurs when you have been using Bitcoin Core prior to using Armory, especially if you have upgraded or downgraded Bitcoin Core recently. &lt;br&gt;&lt;br&gt; Unfortunately, this error is so strange, Armory does not recognize it.  Please go to &quot;Export Log File&quot; from the &quot;File&quot; menu and submit an issue at https://github.com/goatpig/BitcoinArmory/issues. We apologize for the inconvenience!</source>
         <translation>There was an error starting the underlying Bitcoin engine. This should not normally happen.  Usually it occurs when you have been using Bitcoin Core prior to using Armory, especially if you have upgraded or downgraded Bitcoin Core recently. &lt;br&gt;&lt;br&gt; Unfortunately, this error is so strange, Armory does not recognize it.  Please go to &quot;Export Log File&quot; from the &quot;File&quot; menu and submit an issue at https://github.com/goatpig/BitcoinArmory/issues. We apologize for the inconvenience!</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="5084"/>
+        <location filename="ArmoryQt.py" line="5127"/>
         <source>The DB has returned the following error: &lt;br&gt;&lt;br&gt; &lt;b&gt; %1 &lt;/b&gt; &lt;br&gt;&lt;br&gt; Armory will now shutdown.</source>
         <translation>The DB has returned the following error: &lt;br&gt;&lt;br&gt; &lt;b&gt; %1 &lt;/b&gt; &lt;br&gt;&lt;br&gt; Armory will now shutdown.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="5536"/>
+        <location filename="ArmoryQt.py" line="5579"/>
         <source>The wallet analysis tool will become available as soon as Armory is done loading. You can close this window and it will reappear when ready.</source>
         <translation>The wallet analysis tool will become available as soon as Armory is done loading. You can close this window and it will reappear when ready.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="5569"/>
+        <location filename="ArmoryQt.py" line="5612"/>
         <source>&lt;b&gt;The following dialogs need closed before you can run the wallet analysis tool:&lt;/b&gt;</source>
         <translation>&lt;b&gt;The following dialogs need closed before you can run the wallet analysis tool:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="5711"/>
+        <location filename="ArmoryQt.py" line="5754"/>
         <source>Armory failed to spawn the DB!&lt;br&gt; Continuing operations in offline mode instead. &lt;br&gt; Refer to the dbLog.txt for more information.</source>
         <translation>Armory failed to spawn the DB!&lt;br&gt; Continuing operations in offline mode instead. &lt;br&gt; Refer to the dbLog.txt for more information.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="1989"/>
+        <location filename="ArmoryQt.py" line="1987"/>
         <source>The address for the &quot;bitcoin:&quot; link you just entered is for the wrong network!  You are on the &lt;b&gt;%2&lt;/b&gt; and the address you supplied is for the &lt;b&gt;%3&lt;/b&gt;!</source>
         <translation>The address for the &quot;bitcoin:&quot; link you just entered is for the wrong network!  You are on the &lt;b&gt;%2&lt;/b&gt; and the address you supplied is for the &lt;b&gt;%3&lt;/b&gt;!</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="912"/>
+        <location filename="ArmoryQt.py" line="910"/>
         <source>Armory detected the following module which is &lt;font color=%1&gt;&lt;b&gt;invalid&lt;/b&gt;&lt;/font&gt;:&lt;br&gt;&lt;br&gt;   &lt;b&gt;Module Name:&lt;/b&gt; %2&lt;br&gt;   &lt;b&gt;Module Path:&lt;/b&gt; %3&lt;br&gt;&lt;br&gt;&lt;br&gt;Armory will only run a module from a zip file that has the required stucture.</source>
         <translation>Armory detected the following module which is &lt;font color=%1&gt;&lt;b&gt;invalid&lt;/b&gt;&lt;/font&gt;:&lt;br&gt;&lt;br&gt;   &lt;b&gt;Module Name:&lt;/b&gt; %2&lt;br&gt;   &lt;b&gt;Module Path:&lt;/b&gt; %3&lt;br&gt;&lt;br&gt;&lt;br&gt;Armory will only run a module from a zip file that has the required stucture.</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="4308"/>
+        <location filename="ArmoryQt.py" line="4339"/>
         <source>&lt;b&gt;To maximize your security, the Bitcoin engine is downloading and verifying the global transaction ledger.  &lt;u&gt;This will take several hours, but only needs to be done once&lt;/u&gt;!&lt;/b&gt;  It is usually best to leave it running over night for this initialization process.  Subsequent loads will only take a few minutes. &lt;br&gt;&lt;br&gt; &lt;b&gt;Please Note:&lt;/b&gt; Between Armory and the underlying Bitcoin engine, you need to have 120-130 GB of spare disk space available to hold the global transaction history. &lt;br&gt;&lt;br&gt; While you wait, you can manage your wallets.  Make new wallets, make digital or paper backups, create Bitcoin addresses to receive payments, sign messages, and/or import private keys.  You will always receive Bitcoin payments regardless of whether you are online, but you will have to verify that payment through another service until Armory is finished this initialization.</source>
         <translation>&lt;b&gt;To maximize your security, the Bitcoin engine is downloading and verifying the global transaction ledger.  &lt;u&gt;This will take several hours, but only needs to be done once&lt;/u&gt;!&lt;/b&gt;  It is usually best to leave it running over night for this initialization process.  Subsequent loads will only take a few minutes. &lt;br&gt;&lt;br&gt; &lt;b&gt;Please Note:&lt;/b&gt; Between Armory and the underlying Bitcoin engine, you need to have 120-130 GB of spare disk space available to hold the global transaction history. &lt;br&gt;&lt;br&gt; While you wait, you can manage your wallets.  Make new wallets, make digital or paper backups, create Bitcoin addresses to receive payments, sign messages, and/or import private keys.  You will always receive Bitcoin payments regardless of whether you are online, but you will have to verify that payment through another service until Armory is finished this initialization.</translation>
     </message>
     <message numerus="yes">
-        <location filename="ArmoryQt.py" line="3043"/>
+        <location filename="ArmoryQt.py" line="3047"/>
         <source>You cannot sweep the funds from the address(es) you specified because the transaction fee would be greater than or equal to the amount swept. &lt;br&gt;&lt;br&gt; &lt;b&gt;Balance of address(es):&lt;/b&gt; %1&lt;br&gt; &lt;b&gt;Fee to sweep address(es):&lt;/b&gt; %2 &lt;br&gt;&lt;br&gt;The sweep operation has been canceled.</source>
         <translation>
             <numerusform>You cannot sweep the funds from the address you specified because the transaction fee would be greater than or equal to the amount swept. &lt;br&gt;&lt;br&gt; &lt;b&gt;Balance of address:&lt;/b&gt; %1&lt;br&gt; &lt;b&gt;Fee to sweep address:&lt;/b&gt; %2 &lt;br&gt;&lt;br&gt;The sweep operation has been canceled.</numerusform>
@@ -1842,35 +1842,65 @@
         </translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="2670"/>
+        <location filename="ArmoryQt.py" line="2668"/>
         <source>*** RBF Flagged *** </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="2672"/>
+        <location filename="ArmoryQt.py" line="2670"/>
         <source>*** Chained ZC *** </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="581"/>
+        <location filename="ArmoryQt.py" line="579"/>
         <source>Not Online</source>
         <translation type="unfinished">Not Online</translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="2668"/>
+        <location filename="ArmoryQt.py" line="2666"/>
         <source>*Right click to bump fee* </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="ArmoryQt.py" line="3325"/>
+        <location filename="ArmoryQt.py" line="3356"/>
         <source>Bump Fee</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="ArmoryQt.py" line="3131"/>
+        <source>Transaction Broadcast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="ArmoryQt.py" line="3131"/>
+        <source>Your Transaction failed to broadcast through the P2P layer but successfully broadcasted through the RPC. This can be a symptom of bad node connectivity to the Bitcoin network, or that your node is overwhelmed by network traffic. If you consistently get this warning, report to the developers for assistance with node maintenance.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="ArmoryQt.py" line="3182"/>
+        <source>The transaction that you just attempted to broadcast has timed out. &lt;br&gt;&lt;br&gt;The RPC interface of your node is disabled, therefor Armory cannot use it to gather more information about the timeout. It is recommended that you enable the RPC and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="ArmoryQt.py" line="4855"/>
+        <source>&lt;font color=%1&gt;&lt;b&gt;Connected (%2 blocks)&lt;/b&gt;&lt;/font&gt; </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="ArmoryQt.py" line="4862"/>
+        <source>RPC disabled!&lt;br&gt;&lt;br&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="ArmoryQt.py" line="4870"/>
+        <source>&lt;font color=%1&gt;&lt;b&gt;Node offline (%2 blocks)&lt;/b&gt;&lt;/font&gt; </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ArmorySplashScreen</name>
     <message>
-        <location filename="qtdialogs.py" line="13710"/>
+        <location filename="qtdialogs.py" line="13715"/>
         <source>Loading: %1%</source>
         <translation>Loading: %1%</translation>
     </message>
@@ -1946,22 +1976,22 @@
 <context>
     <name>CoinControlTreeModel</name>
     <message>
-        <location filename="TreeViewGUI.py" line="955"/>
+        <location filename="TreeViewGUI.py" line="963"/>
         <source>Address/ID</source>
         <translation>Address/ID</translation>
     </message>
     <message>
-        <location filename="TreeViewGUI.py" line="956"/>
+        <location filename="TreeViewGUI.py" line="964"/>
         <source>Comment</source>
         <translation>Comment</translation>
     </message>
     <message>
-        <location filename="TreeViewGUI.py" line="958"/>
+        <location filename="TreeViewGUI.py" line="966"/>
         <source>Count</source>
         <translation>Count</translation>
     </message>
     <message>
-        <location filename="TreeViewGUI.py" line="957"/>
+        <location filename="TreeViewGUI.py" line="965"/>
         <source>Selected Balance/Value</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1977,142 +2007,142 @@
 <context>
     <name>DlgAddressBook</name>
     <message>
-        <location filename="qtdialogs.py" line="7636"/>
+        <location filename="qtdialogs.py" line="7641"/>
         <source>Select</source>
         <translation>Select</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="7656"/>
+        <location filename="qtdialogs.py" line="7661"/>
         <source>&lt;b&gt;Send to Wallet:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Send to Wallet:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="7657"/>
+        <location filename="qtdialogs.py" line="7662"/>
         <source>&lt;b&gt;Send to Address:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Send to Address:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="7710"/>
+        <location filename="qtdialogs.py" line="7715"/>
         <source>Receiving (Mine)</source>
         <translation>Receiving (Mine)</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="7712"/>
+        <location filename="qtdialogs.py" line="7717"/>
         <source>Sending (Other&apos;s)</source>
         <translation>Sending (Other&apos;s)</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="7747"/>
+        <location filename="qtdialogs.py" line="7752"/>
         <source>The next unused address in that wallet will be calculated and selected. </source>
         <translation>The next unused address in that wallet will be calculated and selected. </translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="7749"/>
+        <location filename="qtdialogs.py" line="7754"/>
         <source>Addresses that are in other wallets you own are &lt;b&gt;not showns&lt;/b&gt;.</source>
         <translation>Addresses that are in other wallets you own are &lt;b&gt;not showns&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="7754"/>
+        <location filename="qtdialogs.py" line="7759"/>
         <source>No Wallet Selected</source>
         <translation>No Wallet Selected</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="7755"/>
+        <location filename="qtdialogs.py" line="7760"/>
         <source>Use Bare Multi-Sig (No P2SH)</source>
         <translation>Use Bare Multi-Sig (No P2SH)</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="7766"/>
+        <location filename="qtdialogs.py" line="7771"/>
         <source>No Address Selected</source>
         <translation>No Address Selected</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="7769"/>
+        <location filename="qtdialogs.py" line="7774"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="7775"/>
+        <location filename="qtdialogs.py" line="7780"/>
         <source>&lt;&lt;&lt; Go Back</source>
         <translation>&lt;&lt;&lt; Go Back</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="7882"/>
+        <location filename="qtdialogs.py" line="7887"/>
         <source>None Selected</source>
         <translation>None Selected</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="7974"/>
+        <location filename="qtdialogs.py" line="7979"/>
         <source>%1 Wallet: %2</source>
         <translation>%1 Wallet: %2</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8013"/>
+        <location filename="qtdialogs.py" line="8018"/>
         <source>%1 Address: %2...</source>
         <translation>%1 Address: %2...</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8116"/>
+        <location filename="qtdialogs.py" line="8121"/>
         <source>P2SH Not Allowed</source>
         <translation>P2SH Not Allowed</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8150"/>
+        <location filename="qtdialogs.py" line="8155"/>
         <source>No Public Key</source>
         <translation>No Public Key</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8201"/>
+        <location filename="qtdialogs.py" line="8206"/>
         <source>Copy Address</source>
         <translation>Copy Address</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8202"/>
+        <location filename="qtdialogs.py" line="8207"/>
         <source>Copy Hash160 (hex)</source>
         <translation>Copy Hash160 (hex)</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8203"/>
+        <location filename="qtdialogs.py" line="8208"/>
         <source>Copy Comment</source>
         <translation>Copy Comment</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8079"/>
+        <location filename="qtdialogs.py" line="8084"/>
         <source>Add Address Comment</source>
         <translation>Add Address Comment</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8081"/>
+        <location filename="qtdialogs.py" line="8086"/>
         <source>Change Address Comment</source>
         <translation>Change Address Comment</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="7646"/>
+        <location filename="qtdialogs.py" line="7651"/>
         <source>Choose an address from your transaction history, or your own wallet.  If you choose to send to one of your own wallets, the next unused address in that wallet will be used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="7652"/>
+        <location filename="qtdialogs.py" line="7657"/>
         <source>Browse all receiving addresses in this wallet, and all addresses to which this wallet has sent bitcoins.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="7757"/>
+        <location filename="qtdialogs.py" line="7762"/>
         <source>EXPERT OPTION:  Do not check this box unless you know what it means and you need it!  Forces Armory to exposes public keys to the blockchain before the funds are spent. This is only needed for very specific use cases, and otherwise creates blockchain bloat.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8064"/>
+        <location filename="qtdialogs.py" line="8069"/>
         <source>Bare multi-sig is not available for M-of-N lockboxes on the main Bitcoin network with N higher than 3.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8116"/>
+        <location filename="qtdialogs.py" line="8121"/>
         <source>This operation requires a public key, but you selected a P2SH address which does not have a public key (these addresses start with &quot;2&quot; or &quot;3&quot;).  Please select a different address.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8150"/>
+        <location filename="qtdialogs.py" line="8155"/>
         <source>This operation requires a full public key, not just an address. Unfortunately, Armory cannot find the public key for the address you selected.  In general public keys will only be available for addresses in your wallet.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2120,147 +2150,147 @@
 <context>
     <name>DlgAddressInfo</name>
     <message>
-        <location filename="qtdialogs.py" line="3148"/>
+        <location filename="qtdialogs.py" line="3150"/>
         <source>This is the computer-readable form of the address</source>
         <translation>This is the computer-readable form of the address</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3150"/>
+        <location filename="qtdialogs.py" line="3152"/>
         <source>&lt;b&gt;Public Key Hash&lt;/b&gt;</source>
         <translation>&lt;b&gt;Public Key Hash&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3156"/>
+        <location filename="qtdialogs.py" line="3158"/>
         <source>%1 (Network: %2 / Checksum: %3)</source>
         <translation>%1 (Network: %2 / Checksum: %3)</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3163"/>
+        <location filename="qtdialogs.py" line="3165"/>
         <source>&lt;b&gt;Wallet:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Wallet:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3168"/>
+        <location filename="qtdialogs.py" line="3170"/>
         <source>&lt;b&gt;Address:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Address:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3182"/>
+        <location filename="qtdialogs.py" line="3184"/>
         <source>&lt;b&gt;Address Type:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Address Type:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3196"/>
+        <location filename="qtdialogs.py" line="3198"/>
         <source>Imported</source>
         <translation>Imported</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3186"/>
+        <location filename="qtdialogs.py" line="3188"/>
         <source>Permanent</source>
         <translation>Permanent</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3190"/>
+        <location filename="qtdialogs.py" line="3192"/>
         <source>The index of this address within the wallet.</source>
         <translation>The index of this address within the wallet.</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3192"/>
+        <location filename="qtdialogs.py" line="3194"/>
         <source>&lt;b&gt;Index:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Index:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3204"/>
+        <location filename="qtdialogs.py" line="3206"/>
         <source>&lt;b&gt;Current Balance&lt;/b&gt;</source>
         <translation>&lt;b&gt;Current Balance&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3220"/>
+        <location filename="qtdialogs.py" line="3222"/>
         <source>&lt;b&gt;Comment:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Comment:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3227"/>
+        <location filename="qtdialogs.py" line="3229"/>
         <source>The total number of transactions in which this address was involved</source>
         <translation>The total number of transactions in which this address was involved</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3229"/>
+        <location filename="qtdialogs.py" line="3231"/>
         <source>&lt;b&gt;Transaction Count:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Transaction Count:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3249"/>
+        <location filename="qtdialogs.py" line="3251"/>
         <source>&lt;font size=2&gt;Double-click to expand&lt;/font&gt;</source>
         <translation>&lt;font size=2&gt;Double-click to expand&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3299"/>
+        <location filename="qtdialogs.py" line="3304"/>
         <source>All Address Activity:</source>
         <translation>All Address Activity:</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3308"/>
+        <location filename="qtdialogs.py" line="3313"/>
         <source>Copy Address to Clipboard</source>
         <translation>Copy Address to Clipboard</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3309"/>
+        <location filename="qtdialogs.py" line="3314"/>
         <source>View Address Keys</source>
         <translation>View Address Keys</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3311"/>
+        <location filename="qtdialogs.py" line="3316"/>
         <source>Delete Address</source>
         <translation>Delete Address</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3348"/>
+        <location filename="qtdialogs.py" line="3353"/>
         <source>Available Actions:</source>
         <translation>Available Actions:</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3351"/>
+        <location filename="qtdialogs.py" line="3356"/>
         <source>&lt;&lt;&lt; Go Back</source>
         <translation>&lt;&lt;&lt; Go Back</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3355"/>
+        <location filename="qtdialogs.py" line="3360"/>
         <source>Address Information</source>
         <translation>Address Information</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3364"/>
+        <location filename="qtdialogs.py" line="3369"/>
         <source>&lt;i&gt;Copied!&lt;/i&gt;</source>
         <translation>&lt;i&gt;Copied!&lt;/i&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3373"/>
+        <location filename="qtdialogs.py" line="3378"/>
         <source>Wallet is Locked</source>
         <translation>Wallet is Locked</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3373"/>
+        <location filename="qtdialogs.py" line="3378"/>
         <source>Key information will not include the private key data.</source>
         <translation>Key information will not include the private key data.</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3173"/>
+        <location filename="qtdialogs.py" line="3175"/>
         <source>Address type is either &lt;i&gt;Imported&lt;/i&gt; or &lt;i&gt;Permanent&lt;/i&gt;. &lt;i&gt;Permanent&lt;/i&gt; addresses are part of the base wallet, and are protected by printed paper backups, regardless of when the backup was performed. Imported addresses are only protected by digital backups, or manually printing the individual keys list, and only if the wallet was backed up &lt;i&gt;after&lt;/i&gt; the keys were imported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3201"/>
+        <location filename="qtdialogs.py" line="3203"/>
         <source>This is the current &lt;i&gt;spendable&lt;/i&gt; balance of this address, not including zero-confirmation transactions from others.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3293"/>
+        <location filename="qtdialogs.py" line="3298"/>
         <source>Unlike the wallet-level ledger, this table shows every transaction &lt;i&gt;input&lt;/i&gt; and &lt;i&gt;output&lt;/i&gt; as a separate entry. Therefore, there may be multiple entries for a single transaction, which will happen if money was sent-to-self (explicitly, or as the change-back-to-self address).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3328"/>
+        <location filename="qtdialogs.py" line="3333"/>
         <source>NOTE:  The ledger shows each transaction &lt;i&gt;&lt;b&gt;input&lt;/b&gt;&lt;/i&gt; and &lt;i&gt;&lt;b&gt;output&lt;/b&gt;&lt;/i&gt; for this address.  There are typically many inputs and outputs for each transaction, therefore the entries represent only partial transactions.  Do not worry if these entries do not look familiar.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2268,12 +2298,12 @@
 <context>
     <name>DlgBackupCenter</name>
     <message>
-        <location filename="qtdialogs.py" line="9902"/>
+        <location filename="qtdialogs.py" line="9907"/>
         <source>Done</source>
         <translation>Done</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9913"/>
+        <location filename="qtdialogs.py" line="9918"/>
         <source>Backup Center</source>
         <translation>Backup Center</translation>
     </message>
@@ -2281,27 +2311,27 @@
 <context>
     <name>DlgBadConnection</name>
     <message>
-        <location filename="qtdialogs.py" line="7139"/>
+        <location filename="qtdialogs.py" line="7144"/>
         <source>Continue in Offline Mode</source>
         <translation>Continue in Offline Mode</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="7140"/>
+        <location filename="qtdialogs.py" line="7145"/>
         <source>Close Armory</source>
         <translation>Close Armory</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="7152"/>
+        <location filename="qtdialogs.py" line="7157"/>
         <source>Network not available</source>
         <translation>Network not available</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="7106"/>
+        <location filename="qtdialogs.py" line="7111"/>
         <source>Armory was not able to detect an internet connection, so Armory will operate in &quot;Offline&quot; mode.  In this mode, only wallet -management and unsigned-transaction functionality will be available. &lt;br&gt;&lt;br&gt;If this is an error, please check your internet connection and restart Armory.&lt;br&gt;&lt;br&gt;Would you like to continue in &quot;Offline&quot; mode?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="7114"/>
+        <location filename="qtdialogs.py" line="7119"/>
         <source>Armory was not able to detect the presence of Bitcoin Core or bitcoind client software (available at https://bitcoin.org).  Please make sure that the one of those programs is... &lt;br&gt; &lt;br&gt;&lt;b&gt;(1)&lt;/b&gt; ...open and connected to the network &lt;br&gt;&lt;b&gt;(2)&lt;/b&gt; ...on the same network as Armory (main-network or test-network) &lt;br&gt;&lt;b&gt;(3)&lt;/b&gt; ...synchronized with the blockchain before starting Armory&lt;br&gt;&lt;br&gt;Without the Bitcoin Core or bitcoind open, you will only be able to run Armory in &quot;Offline&quot; mode, which will not have access to new blockchain data, and you will not be able to send outgoing transactions&lt;br&gt;&lt;br&gt;If you do not want to be in &quot;Offline&quot; mode, please restart Armory after one of these programs is open and synchronized with the network</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2309,42 +2339,42 @@
 <context>
     <name>DlgBroadcastBlindTx</name>
     <message>
-        <location filename="qtdialogs.py" line="13595"/>
+        <location filename="qtdialogs.py" line="13600"/>
         <source>Parsed Transaction:</source>
         <translation>Parsed Transaction:</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="13605"/>
+        <location filename="qtdialogs.py" line="13610"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="13606"/>
+        <location filename="qtdialogs.py" line="13611"/>
         <source>Broadcast</source>
         <translation>Broadcast</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="13622"/>
+        <location filename="qtdialogs.py" line="13627"/>
         <source>Broadcast Raw Transaction</source>
         <translation>Broadcast Raw Transaction</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="13675"/>
+        <location filename="qtdialogs.py" line="13680"/>
         <source>Broadcast!</source>
         <translation>Broadcast!</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="13561"/>
+        <location filename="qtdialogs.py" line="13566"/>
         <source>Copy a raw, hex-encoded transaction below to have Armory broadcast it to the Bitcoin network.  This function is provided as a convenience to expert users, and carries no guarantees of usefulness. &lt;br&gt;&lt;br&gt;Specifically, be aware of the following limitations of this broadcast function: &lt;ul&gt;&lt;li&gt;The transaction will be &quot;broadcast&quot; by sending it to the connected Bitcon Core instance which will forward it to the rest of the Bitcoin network. However, if the transaction is non-standard or does not satisfy standard fee rules, Bitcoin Core &lt;u&gt;will&lt;/u&gt; drop it and it will never be seen by the Bitcoin network. &lt;/li&gt;&lt;li&gt;There will be no feedback as to whether the transaction succeeded.  You will have to verify the success of this operation via other means. However, if the transaction sends funds directly to or from an address in one of your wallets, it will still generate a notification and show up in your transaction history for that wallet. &lt;/li&gt;&lt;/ul&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="13648"/>
+        <location filename="qtdialogs.py" line="13653"/>
         <source>&lt;font color=&quot;%1&quot;&gt;&lt;b&gt;Raw transaction is invalid!&lt;/font&gt;&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="13675"/>
+        <location filename="qtdialogs.py" line="13680"/>
         <source>Your transaction was successfully sent to the local Bitcoin Core instance, though there is no guarantees that it was forwarded to the rest of the network.   On testnet, just about every valid transaction will successfully propagate.  On the main Bitcoin network, this will fail unless it was a standard transaction type. The transaction had the following hash: &lt;br&gt;&lt;br&gt; %1 &lt;br&gt;&lt;br&gt;You can check whether it was seen by other nodes on the network with the link below: &lt;br&gt;&lt;br&gt;&lt;a href=&quot;%2&quot;&gt;%3&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2352,7 +2382,7 @@
 <context>
     <name>DlgBrowserWarn</name>
     <message>
-        <location filename="qtdialogs.py" line="13756"/>
+        <location filename="qtdialogs.py" line="13761"/>
         <source>Your default browser will now open and go to the following link: %1. Are you sure you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2475,42 +2505,42 @@ random letters, or 5 or more random words.
 <context>
     <name>DlgConfirmBulkImport</name>
     <message>
-        <location filename="qtdialogs.py" line="3022"/>
+        <location filename="qtdialogs.py" line="3024"/>
         <source>No Addresses to Import</source>
         <translation>No Addresses to Import</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3027"/>
+        <location filename="qtdialogs.py" line="3029"/>
         <source>a new wallet</source>
         <translation>a new wallet</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3030"/>
+        <location filename="qtdialogs.py" line="3032"/>
         <source>wallet, &lt;b&gt;%1&lt;/b&gt; (%2)</source>
         <translation>wallet, &lt;b&gt;%1&lt;/b&gt; (%2)</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3045"/>
+        <location filename="qtdialogs.py" line="3047"/>
         <source>Import</source>
         <translation>Import</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3046"/>
+        <location filename="qtdialogs.py" line="3048"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3058"/>
+        <location filename="qtdialogs.py" line="3060"/>
         <source>Confirm Import</source>
         <translation>Confirm Import</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3022"/>
+        <location filename="qtdialogs.py" line="3024"/>
         <source>There are no addresses to import!</source>
         <translation type="unfinished">There are no addresses to import!</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3031"/>
+        <location filename="qtdialogs.py" line="3033"/>
         <source>You are about to import &lt;b&gt;%1&lt;/b&gt; addresses into %2.&lt;br&gt;&lt;br&gt; The following is a list of addresses to be imported:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2518,47 +2548,47 @@ random letters, or 5 or more random words.
 <context>
     <name>DlgConfirmSend</name>
     <message>
-        <location filename="qtdialogs.py" line="4525"/>
+        <location filename="qtdialogs.py" line="4530"/>
         <source>Send</source>
         <translation>Send</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4526"/>
+        <location filename="qtdialogs.py" line="4531"/>
         <source>Are you sure you want to execute this transaction?</source>
         <translation>Are you sure you want to execute this transaction?</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4528"/>
+        <location filename="qtdialogs.py" line="4533"/>
         <source>Continue</source>
         <translation>Continue</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4529"/>
+        <location filename="qtdialogs.py" line="4534"/>
         <source>Does the above look correct?</source>
         <translation>Does the above look correct?</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4531"/>
+        <location filename="qtdialogs.py" line="4536"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4555"/>
+        <location filename="qtdialogs.py" line="4560"/>
         <source>Confirm Transaction</source>
         <translation>Confirm Transaction</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4462"/>
+        <location filename="qtdialogs.py" line="4467"/>
         <source>To see complete transaction details &lt;a href=&quot;None&quot;&gt;click here&lt;/a&gt;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4471"/>
+        <location filename="qtdialogs.py" line="4476"/>
         <source>This transaction will spend &lt;b&gt;%1 BTC&lt;/b&gt; from &lt;font color=&quot;%2&quot;&gt;Wallet &quot;&lt;b&gt;%3&lt;/b&gt;&quot; (%4)&lt;/font&gt; to the following recipients:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4477"/>
+        <location filename="qtdialogs.py" line="4482"/>
         <source>&lt;font size=3&gt;* Starred outputs are going to the same wallet from which they came and do not affect the wallet&apos;s final balance. The total balance of the wallet will actually only decrease &lt;b&gt;%1 BTC&lt;/b&gt; as a result of this transaction.  %2&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2566,47 +2596,47 @@ random letters, or 5 or more random words.
 <context>
     <name>DlgCorruptWallet</name>
     <message>
-        <location filename="qtdialogs.py" line="13022"/>
+        <location filename="qtdialogs.py" line="13027"/>
         <source>Wallet Consistency Check Failed!</source>
         <translation>Wallet Consistency Check Failed!</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="13024"/>
+        <location filename="qtdialogs.py" line="13029"/>
         <source>Perform Wallet Consistency Check</source>
         <translation>Perform Wallet Consistency Check</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="13076"/>
+        <location filename="qtdialogs.py" line="13081"/>
         <source>Hide</source>
         <translation>Hide</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="13077"/>
+        <location filename="qtdialogs.py" line="13082"/>
         <source>Run Analysis and Recovery Tool</source>
         <translation>Run Analysis and Recovery Tool</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="13109"/>
+        <location filename="qtdialogs.py" line="13114"/>
         <source>Wallet Error</source>
         <translation>Wallet Error</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="13135"/>
+        <location filename="qtdialogs.py" line="13140"/>
         <source>Close</source>
         <translation>Close</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="13224"/>
+        <location filename="qtdialogs.py" line="13229"/>
         <source>Continue</source>
         <translation>Continue</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="13261"/>
+        <location filename="qtdialogs.py" line="13266"/>
         <source>&lt;h2 style=&quot;color: red;&quot;&gt;                                     Consistency check failed! &lt;/h2&gt;</source>
         <translation>&lt;h2 style=&quot;color: red;&quot;&gt;                                     Consistency check failed! &lt;/h2&gt;</translation>
     </message>
     <message numerus="yes">
-        <location filename="qtdialogs.py" line="13246"/>
+        <location filename="qtdialogs.py" line="13251"/>
         <source>Wallet(s) consistent!</source>
         <translation>
             <numerusform>Wallet consistent!</numerusform>
@@ -2614,27 +2644,27 @@ random letters, or 5 or more random words.
         </translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="13026"/>
+        <location filename="qtdialogs.py" line="13031"/>
         <source>&lt;font color=&quot;%1&quot; size=5&gt;&lt;b&gt;&lt;u&gt;%2&lt;/u&gt;&lt;/b&gt;&lt;/font&gt; &lt;br&gt;&lt;br&gt;Armory software now detects and prevents certain kinds of hardware errors that could lead to problems with your wallet. &lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="13045"/>
+        <location filename="qtdialogs.py" line="13050"/>
         <source>Armory will perform a consistency check on &lt;b&gt;Wallet &quot;%1&quot; (%2)&lt;/b&gt; and determine if any further action is required to keep your funds protected.  This check is normally performed on startup on all your wallets, but you can click below to force another check.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="13087"/>
+        <location filename="qtdialogs.py" line="13092"/>
         <source>&lt;u&gt;Your wallets will be ready to fix once the scan is over&lt;/u&gt;&lt;br&gt; You can hide this window until then&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="13239"/>
+        <location filename="qtdialogs.py" line="13244"/>
         <source>&lt;font size=4 color=&quot;%1&quot;&gt;&lt;b&gt;Failed to fix wallets!&lt;/b&gt;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="qtdialogs.py" line="13243"/>
+        <location filename="qtdialogs.py" line="13248"/>
         <source>&lt;font size=4 color=&quot;%1&quot;&gt;&lt;b&gt;Wallet(s) consistent, nothing to fix.&lt;/b&gt;&lt;/font&gt;</source>
         <translation type="unfinished">
             <numerusform>&lt;font size=4 color=&quot;%1&quot;&gt;&lt;b&gt;Wallet consistent, nothing to fix.&lt;/b&gt;&lt;/font&gt;</numerusform>
@@ -2642,12 +2672,12 @@ random letters, or 5 or more random words.
         </translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="13037"/>
+        <location filename="qtdialogs.py" line="13042"/>
         <source>Armory has detected that wallet file &lt;b&gt;Wallet &quot;%1&quot; (%2)&lt;/b&gt; is inconsistent and should be further analyzed to ensure that your funds are protected. &lt;br&gt;&lt;br&gt;&lt;font color=&quot;%3&quot;&gt;This error will pop up every time you start Armory until the wallet has been analyzed and fixed!&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="13251"/>
+        <location filename="qtdialogs.py" line="13256"/>
         <source>&lt;font color=&quot;%1&quot;&gt;&lt;b&gt; &lt;font size=4&gt;&lt;b&gt;&lt;u&gt;There may still be issues with your wallet!&lt;/u&gt;&lt;/b&gt;&lt;/font&gt; &lt;br&gt;It is important that you send us the recovery logs and an email address so the Armory team can check for further risk to your funds!&lt;/b&gt;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2655,192 +2685,192 @@ random letters, or 5 or more random words.
 <context>
     <name>DlgCreatePromNote</name>
     <message>
-        <location filename="MultiSigDialogs.py" line="3160"/>
+        <location filename="MultiSigDialogs.py" line="3155"/>
         <source>Address:</source>
         <translation>Address:</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3161"/>
+        <location filename="MultiSigDialogs.py" line="3156"/>
         <source>Amount:</source>
         <translation>Amount:</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3162"/>
+        <location filename="MultiSigDialogs.py" line="3157"/>
         <source>Add fee:</source>
         <translation>Add fee:</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3164"/>
+        <location filename="MultiSigDialogs.py" line="3159"/>
         <source>BTC</source>
         <translation>BTC</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3206"/>
+        <location filename="MultiSigDialogs.py" line="3201"/>
         <source>Source of Funding</source>
         <translation>Source of Funding</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3213"/>
+        <location filename="MultiSigDialogs.py" line="3208"/>
         <source>Funding Destination</source>
         <translation>Funding Destination</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3236"/>
+        <location filename="MultiSigDialogs.py" line="3231"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3237"/>
+        <location filename="MultiSigDialogs.py" line="3232"/>
         <source>Continue</source>
         <translation>Continue</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3302"/>
+        <location filename="MultiSigDialogs.py" line="3297"/>
         <source>Blockchain Not Available</source>
         <translation>Blockchain Not Available</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3314"/>
+        <location filename="MultiSigDialogs.py" line="3309"/>
         <source>Lockbox Selected</source>
         <translation>Lockbox Selected</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3321"/>
+        <location filename="MultiSigDialogs.py" line="3316"/>
         <source>No Wallet Selected</source>
         <translation>No Wallet Selected</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3331"/>
+        <location filename="MultiSigDialogs.py" line="3326"/>
         <source>Zero Amount</source>
         <translation>Zero Amount</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3336"/>
+        <location filename="MultiSigDialogs.py" line="3331"/>
         <source>Negative Value</source>
         <translation>Negative Value</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3367"/>
+        <location filename="MultiSigDialogs.py" line="3362"/>
         <source>Too much precision</source>
         <translation>Too much precision</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3373"/>
+        <location filename="MultiSigDialogs.py" line="3368"/>
         <source>Missing amount</source>
         <translation>Missing amount</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3351"/>
+        <location filename="MultiSigDialogs.py" line="3346"/>
         <source>Invalid Value String</source>
         <translation>Invalid Value String</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3362"/>
+        <location filename="MultiSigDialogs.py" line="3357"/>
         <source>Negative Fee</source>
         <translation>Negative Fee</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3377"/>
+        <location filename="MultiSigDialogs.py" line="3372"/>
         <source>Invalid Fee String</source>
         <translation>Invalid Fee String</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3387"/>
+        <location filename="MultiSigDialogs.py" line="3382"/>
         <source>Not enough funds!</source>
         <translation>Not enough funds!</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3397"/>
+        <location filename="MultiSigDialogs.py" line="3392"/>
         <source>Coin Selection Error</source>
         <translation>Coin Selection Error</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3429"/>
+        <location filename="MultiSigDialogs.py" line="3424"/>
         <source>Transaction Not Found</source>
         <translation>Transaction Not Found</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3453"/>
+        <location filename="MultiSigDialogs.py" line="3448"/>
         <source>Export Promissory Note</source>
         <translation>Export Promissory Note</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3120"/>
+        <location filename="MultiSigDialogs.py" line="3115"/>
         <source>&lt;font color=&quot;%1&quot; size=4&gt;&lt;b&gt;Create Simulfunding Promissory Note &lt;/b&gt;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3198"/>
+        <location filename="MultiSigDialogs.py" line="3193"/>
         <source>This label will be attached to the promissory note to help identify who is committing these funds.  If you do not fill this in, each other party signing will see &lt;i&gt;[[Unknown Signer]]&lt;/i&gt; for the ID.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3302"/>
+        <location filename="MultiSigDialogs.py" line="3297"/>
         <source>The blockchain has become unavailable since you opened this window.  Creation of the promissory note cannot continue.  If you think you should be online, please try again in a minute, or after restarting Armory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3321"/>
+        <location filename="MultiSigDialogs.py" line="3316"/>
         <source>The wallet selected is not available.  Select another wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3331"/>
+        <location filename="MultiSigDialogs.py" line="3326"/>
         <source>You cannot promise 0 BTC.   &lt;br&gt;Please enter a positive amount.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3362"/>
+        <location filename="MultiSigDialogs.py" line="3357"/>
         <source>You have specified a negative amount. &lt;br&gt;Only positive values are allowed!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3367"/>
+        <location filename="MultiSigDialogs.py" line="3362"/>
         <source>Bitcoins can only be specified down to 8 decimal places. The smallest value that can be sent is  0.0000 0001 BTC. Please enter a new amount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3373"/>
+        <location filename="MultiSigDialogs.py" line="3368"/>
         <source>You did not specify an amount to promise!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3377"/>
+        <location filename="MultiSigDialogs.py" line="3372"/>
         <source>The amount you specified is invalid (%1).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3387"/>
+        <location filename="MultiSigDialogs.py" line="3382"/>
         <source>You specified &lt;b&gt;%1&lt;/b&gt; BTC (amount + fee), but the selected wallet only has &lt;b&gt;%2&lt;/b&gt; BTC spendable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3397"/>
+        <location filename="MultiSigDialogs.py" line="3392"/>
         <source>There was an error constructing your transaction, due to a quirk in the way Bitcoin transactions work.  If you see this error more than once, try sending your BTC in two or more separate transactions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message encoding="UTF-8">
-        <location filename="MultiSigDialogs.py" line="3429"/>
+        <location filename="MultiSigDialogs.py" line="3424"/>
         <source>There was an error creating the promissory note -- the selected coins were not found in the blockchain.  Please go to &quot;&lt;i&gt;Help&lt;/i&gt;&quot;→&quot;&lt;i&gt;Submit Bug Report&lt;/i&gt;&quot; from the main window and submit your log files so the Armory team can review this error.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3125"/>
+        <location filename="MultiSigDialogs.py" line="3120"/>
         <source>Use this form to create a &quot;promissory note&quot; which can be combined with notes from other parties to fund an address or lockbox simultaneously (&lt;i&gt;&quot;Simulfunding&quot;&lt;/i&gt;).  This funding transaction will not be valid until all promissory notes are merged into a single transaction, then all funding parties will review and sign it.&lt;br&gt;&lt;br&gt;If this lockbox is being funded by only one party, using this interface is unnecessary.  Have the funding party send Bitcoins to the destination address or lockbox in the normal way.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3138"/>
+        <location filename="MultiSigDialogs.py" line="3133"/>
         <source>&lt;b&gt;NOTE:&lt;/b&gt; At the moment, Simulfunding is restricted to using single-signature wallets/addresses for funding. More complex Simulfunding transactions will be possible in a future version of Armory.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3314"/>
+        <location filename="MultiSigDialogs.py" line="3309"/>
         <source>Currently, Armory does not implement Simulfunding with lockbox inputs.  Please choose a regular wallet as your input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3454"/>
+        <location filename="MultiSigDialogs.py" line="3449"/>
         <source>The text below includes all the data needed to represent your contribution to a Simulfunding transaction.  Your money cannot move because you have not signed anything, yet.  Once all promissory notes are collected, you will be able to review the entire funding transaction before signing.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2848,287 +2878,287 @@ random letters, or 5 or more random words.
 <context>
     <name>DlgDispTxInfo</name>
     <message>
-        <location filename="qtdialogs.py" line="5291"/>
+        <location filename="qtdialogs.py" line="5296"/>
         <source>Sent-to-Self</source>
         <translation>Sent-to-Self</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5308"/>
+        <location filename="qtdialogs.py" line="5313"/>
         <source>Received</source>
         <translation>Received</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5312"/>
+        <location filename="qtdialogs.py" line="5317"/>
         <source>Sent</source>
         <translation>Sent</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5329"/>
+        <location filename="qtdialogs.py" line="5334"/>
         <source>Transaction Information:</source>
         <translation>Transaction Information:</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5349"/>
+        <location filename="qtdialogs.py" line="5354"/>
         <source>Unique identifier for this transaction</source>
         <translation>Unique identifier for this transaction</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5350"/>
+        <location filename="qtdialogs.py" line="5355"/>
         <source>Transaction ID</source>
         <translation>Transaction ID</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5355"/>
+        <location filename="qtdialogs.py" line="5360"/>
         <source>[[ Transaction ID cannot be determined without all signatures ]]</source>
         <translation>[[ Transaction ID cannot be determined without all signatures ]]</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5379"/>
+        <location filename="qtdialogs.py" line="5384"/>
         <source>Bitcoin Protocol Version Number</source>
         <translation>Bitcoin Protocol Version Number</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5380"/>
+        <location filename="qtdialogs.py" line="5385"/>
         <source>Tx Version:</source>
         <translation>Tx Version:</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5384"/>
+        <location filename="qtdialogs.py" line="5389"/>
         <source>The time at which this transaction becomes valid.</source>
         <translation>The time at which this transaction becomes valid.</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5386"/>
+        <location filename="qtdialogs.py" line="5391"/>
         <source>Lock-Time:</source>
         <translation>Lock-Time:</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5388"/>
+        <location filename="qtdialogs.py" line="5393"/>
         <source>Immediate (0)</source>
         <translation>Immediate (0)</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5390"/>
+        <location filename="qtdialogs.py" line="5395"/>
         <source>Block %1</source>
         <translation>Block %1</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5397"/>
+        <location filename="qtdialogs.py" line="5402"/>
         <source>Comment stored for this transaction in this wallet</source>
         <translation>Comment stored for this transaction in this wallet</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5398"/>
+        <location filename="qtdialogs.py" line="5403"/>
         <source>User Comment:</source>
         <translation>User Comment:</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5402"/>
+        <location filename="qtdialogs.py" line="5407"/>
         <source>&lt;font color=&quot;gray&quot;&gt;[None]&lt;/font&gt;</source>
         <translation>&lt;font color=&quot;gray&quot;&gt;[None]&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5408"/>
+        <location filename="qtdialogs.py" line="5413"/>
         <source>The time that you computer first saw this transaction</source>
         <translation>The time that you computer first saw this transaction</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5446"/>
+        <location filename="qtdialogs.py" line="5451"/>
         <source>Confirmations:</source>
         <translation>Confirmations:</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5456"/>
+        <location filename="qtdialogs.py" line="5461"/>
         <source>Mempool Replaceable: </source>
         <translation>Mempool Replaceable: </translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5470"/>
+        <location filename="qtdialogs.py" line="5475"/>
         <source>Sum of Outputs:</source>
         <translation>Sum of Outputs:</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5474"/>
+        <location filename="qtdialogs.py" line="5479"/>
         <source>Bitcoins were either sent or received, or sent-to-self</source>
         <translation>Bitcoins were either sent or received, or sent-to-self</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5547"/>
+        <location filename="qtdialogs.py" line="5552"/>
         <source>Recipients:</source>
         <translation>Recipients:</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5561"/>
+        <location filename="qtdialogs.py" line="5566"/>
         <source>[%1 more recipients]</source>
         <translation>[%1 more recipients]</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5675"/>
+        <location filename="qtdialogs.py" line="5680"/>
         <source>Transaction Inputs (Sending addresses):</source>
         <translation>Transaction Inputs (Sending addresses):</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5688"/>
+        <location filename="qtdialogs.py" line="5693"/>
         <source>Transaction Outputs (Receiving addresses):</source>
         <translation>Transaction Outputs (Receiving addresses):</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5711"/>
+        <location filename="qtdialogs.py" line="5716"/>
         <source>Copy Raw Tx (Hex)</source>
         <translation>Copy Raw Tx (Hex)</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5713"/>
+        <location filename="qtdialogs.py" line="5718"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5750"/>
+        <location filename="qtdialogs.py" line="5755"/>
         <source>Transaction Info</source>
         <translation>Transaction Info</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5759"/>
+        <location filename="qtdialogs.py" line="5764"/>
         <source>&lt;&lt;&lt; Less Info</source>
         <translation>&lt;&lt;&lt; Less Info</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5769"/>
+        <location filename="qtdialogs.py" line="5774"/>
         <source>Advanced &gt;&gt;&gt;</source>
         <translation>Advanced &gt;&gt;&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5780"/>
+        <location filename="qtdialogs.py" line="5785"/>
         <source>TxIn Script:</source>
         <translation>TxIn Script:</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5787"/>
+        <location filename="qtdialogs.py" line="5792"/>
         <source>TxOut Script:</source>
         <translation>TxOut Script:</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5826"/>
+        <location filename="qtdialogs.py" line="5831"/>
         <source>&lt;i&gt;Copied to Clipboard!&lt;/i&gt;</source>
         <translation>&lt;i&gt;Copied to Clipboard!&lt;/i&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5856"/>
+        <location filename="qtdialogs.py" line="5861"/>
         <source>Copy Sender Address</source>
         <translation>Copy Sender Address</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5892"/>
+        <location filename="qtdialogs.py" line="5897"/>
         <source>Copy Wallet ID</source>
         <translation>Copy Wallet ID</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5893"/>
+        <location filename="qtdialogs.py" line="5898"/>
         <source>Copy Amount</source>
         <translation>Copy Amount</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5859"/>
+        <location filename="qtdialogs.py" line="5864"/>
         <source>More Info</source>
         <translation>More Info</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5891"/>
+        <location filename="qtdialogs.py" line="5896"/>
         <source>Copy Recipient Address</source>
         <translation>Copy Recipient Address</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5894"/>
+        <location filename="qtdialogs.py" line="5899"/>
         <source>Copy Raw Script</source>
         <translation>Copy Raw Script</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5365"/>
+        <location filename="qtdialogs.py" line="5370"/>
         <source>&lt;font color=&quot;gray&quot;&gt; [[ Transaction ID cannot be determined without all signatures ]] &lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5411"/>
+        <location filename="qtdialogs.py" line="5416"/>
         <source>All transactions are eventually included in a &quot;block.&quot;  The time shown here is the time that the block entered the &quot;blockchain.&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5421"/>
+        <location filename="qtdialogs.py" line="5426"/>
         <source>This transaction has not yet been included in a block. It usually takes 5-20 minutes for a transaction to get included in a block after the user hits the &quot;Send&quot; button.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5433"/>
+        <location filename="qtdialogs.py" line="5438"/>
         <source>Every transaction is eventually included in a &quot;block&quot; which is where the transaction is permanently recorded.  A new block is produced approximately every 10 minutes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5442"/>
+        <location filename="qtdialogs.py" line="5447"/>
         <source>The number of blocks that have been produced since this transaction entered the blockchain.  A transaction with 6 or more confirmations is nearly impossible to reverse.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5452"/>
+        <location filename="qtdialogs.py" line="5457"/>
         <source>This transaction can be replaced by another transaction that spends the same inputs if the replacement transaction has a higher fee.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5465"/>
+        <location filename="qtdialogs.py" line="5470"/>
         <source>Most transactions have at least a recipient output and a returned-change output.  You do not have enough information to determine which is which, and so this fields shows the sum of &lt;b&gt;all&lt;/b&gt; outputs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5480"/>
+        <location filename="qtdialogs.py" line="5485"/>
         <source>The value shown here is the net effect on your wallet, including transaction fee.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5503"/>
+        <location filename="qtdialogs.py" line="5508"/>
         <source>Transaction fees go to users supplying the Bitcoin network with computing power for processing transactions and maintaining security.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5541"/>
+        <location filename="qtdialogs.py" line="5546"/>
         <source>All outputs of the transaction &lt;b&gt;excluding&lt;/b&gt; change-back-to-sender outputs.  If this list does not look correct, it is possible that the change-output was detected incorrectly -- please check the complete input/output list below.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5676"/>
+        <location filename="qtdialogs.py" line="5681"/>
         <source>All transactions require previous transaction outputs as inputs.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5678"/>
+        <location filename="qtdialogs.py" line="5683"/>
         <source>&lt;b&gt;Since the blockchain is not available, not all input information is available&lt;/b&gt;.  You need to view this transaction on a system with an internet connection (and blockchain) if you want to see the complete information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5683"/>
+        <location filename="qtdialogs.py" line="5688"/>
         <source>Each input is like an X amount dollar bill.  Usually there are more inputs than necessary for the transaction, and there will be an extra output returning change to the sender</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5689"/>
+        <location filename="qtdialogs.py" line="5694"/>
         <source>Shows &lt;b&gt;all&lt;/b&gt; outputs, including other recipients of the same transaction, and change-back-to-sender outputs (change outputs are displayed in light gray).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5694"/>
+        <location filename="qtdialogs.py" line="5699"/>
         <source>Some outputs might be &quot;change.&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5495"/>
+        <location filename="qtdialogs.py" line="5500"/>
         <source>Size of the transaction in bytes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5497"/>
+        <location filename="qtdialogs.py" line="5502"/>
         <source>Tx Size: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5493"/>
+        <location filename="qtdialogs.py" line="5498"/>
         <source>%1 bytes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3136,112 +3166,112 @@ random letters, or 5 or more random words.
 <context>
     <name>DlgDisplayTxIn</name>
     <message>
-        <location filename="qtdialogs.py" line="5920"/>
+        <location filename="qtdialogs.py" line="5925"/>
         <source>&lt;center&gt;&lt;u&gt;&lt;b&gt;TxIn Information&lt;/b&gt;&lt;/u&gt;&lt;/center&gt;</source>
         <translation>&lt;center&gt;&lt;u&gt;&lt;b&gt;TxIn Information&lt;/b&gt;&lt;/u&gt;&lt;/center&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5945"/>
+        <location filename="qtdialogs.py" line="5950"/>
         <source>[[Cannot determine from TxIn Script]]</source>
         <translation>[[Cannot determine from TxIn Script]]</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5950"/>
+        <location filename="qtdialogs.py" line="5955"/>
         <source>Wallet &quot;%1&quot; (%2)</source>
         <translation>Wallet &quot;%1&quot; (%2)</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5954"/>
+        <location filename="qtdialogs.py" line="5959"/>
         <source>Lockbox %1-of-%2 &quot;%3&quot; (%4)</source>
         <translation>Lockbox %1-of-%2 &quot;%3&quot; (%4)</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5959"/>
+        <location filename="qtdialogs.py" line="5964"/>
         <source>&lt;font size=4&gt;&lt;u&gt;&lt;b&gt;Information on TxIn&lt;/b&gt;&lt;/u&gt;&lt;/font&gt;:</source>
         <translation>&lt;font size=4&gt;&lt;u&gt;&lt;b&gt;Information on TxIn&lt;/b&gt;&lt;/u&gt;&lt;/font&gt;:</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5960"/>
+        <location filename="qtdialogs.py" line="5965"/>
         <source>   &lt;b&gt;TxIn Index:&lt;/b&gt;         %1</source>
         <translation>   &lt;b&gt;TxIn Index:&lt;/b&gt;         %1</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5961"/>
+        <location filename="qtdialogs.py" line="5966"/>
         <source>   &lt;b&gt;TxIn Spending:&lt;/b&gt;      %1:%2</source>
         <translation>   &lt;b&gt;TxIn Spending:&lt;/b&gt;      %1:%2</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5962"/>
+        <location filename="qtdialogs.py" line="5967"/>
         <source>   &lt;b&gt;TxIn Sequence&lt;/b&gt;:      0x%1</source>
         <translation>   &lt;b&gt;TxIn Sequence&lt;/b&gt;:      0x%1</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5964"/>
+        <location filename="qtdialogs.py" line="5969"/>
         <source>   &lt;b&gt;TxIn Script Type&lt;/b&gt;:   %1</source>
         <translation>   &lt;b&gt;TxIn Script Type&lt;/b&gt;:   %1</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5965"/>
+        <location filename="qtdialogs.py" line="5970"/>
         <source>   &lt;b&gt;TxIn Source&lt;/b&gt;:        %1</source>
         <translation>   &lt;b&gt;TxIn Source&lt;/b&gt;:        %1</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5967"/>
+        <location filename="qtdialogs.py" line="5972"/>
         <source>   &lt;b&gt;TxIn Wallet&lt;/b&gt;:        %1</source>
         <translation>   &lt;b&gt;TxIn Wallet&lt;/b&gt;:        %1</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5968"/>
+        <location filename="qtdialogs.py" line="5973"/>
         <source>   &lt;b&gt;TxIn Script&lt;/b&gt;:</source>
         <translation>   &lt;b&gt;TxIn Script&lt;/b&gt;:</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5996"/>
+        <location filename="qtdialogs.py" line="6001"/>
         <source>&lt;font size=4&gt;&lt;u&gt;&lt;b&gt;Information on TxOut being spent by this TxIn&lt;/b&gt;&lt;/u&gt;&lt;/font&gt;:</source>
         <translation>&lt;font size=4&gt;&lt;u&gt;&lt;b&gt;Information on TxOut being spent by this TxIn&lt;/b&gt;&lt;/u&gt;&lt;/font&gt;:</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5997"/>
+        <location filename="qtdialogs.py" line="6002"/>
         <source>   &lt;b&gt;Tx Hash:&lt;/b&gt;            %1</source>
         <translation>   &lt;b&gt;Tx Hash:&lt;/b&gt;            %1</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5998"/>
+        <location filename="qtdialogs.py" line="6003"/>
         <source>   &lt;b&gt;Tx Out Index:&lt;/b&gt;       %1</source>
         <translation>   &lt;b&gt;Tx Out Index:&lt;/b&gt;       %1</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5999"/>
+        <location filename="qtdialogs.py" line="6004"/>
         <source>   &lt;b&gt;Tx in Block#:&lt;/b&gt;       %1</source>
         <translation>   &lt;b&gt;Tx in Block#:&lt;/b&gt;       %1</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="6000"/>
+        <location filename="qtdialogs.py" line="6005"/>
         <source>   &lt;b&gt;TxOut Value:&lt;/b&gt;        %1</source>
         <translation>   &lt;b&gt;TxOut Value:&lt;/b&gt;        %1</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="6001"/>
+        <location filename="qtdialogs.py" line="6006"/>
         <source>   &lt;b&gt;TxOut Script Type:&lt;/b&gt;  %1</source>
         <translation>   &lt;b&gt;TxOut Script Type:&lt;/b&gt;  %1</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="6002"/>
+        <location filename="qtdialogs.py" line="6007"/>
         <source>   &lt;b&gt;TxOut Address:&lt;/b&gt;      %1</source>
         <translation>   &lt;b&gt;TxOut Address:&lt;/b&gt;      %1</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="6004"/>
+        <location filename="qtdialogs.py" line="6009"/>
         <source>   &lt;b&gt;TxOut Wallet:&lt;/b&gt;       %1</source>
         <translation>   &lt;b&gt;TxOut Wallet:&lt;/b&gt;       %1</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="6005"/>
+        <location filename="qtdialogs.py" line="6010"/>
         <source>   &lt;b&gt;TxOUt Script:&lt;/b&gt;</source>
         <translation>   &lt;b&gt;TxOUt Script:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="6020"/>
+        <location filename="qtdialogs.py" line="6025"/>
         <source>Ok</source>
         <translation>Ok</translation>
     </message>
@@ -3249,52 +3279,52 @@ random letters, or 5 or more random words.
 <context>
     <name>DlgDisplayTxOut</name>
     <message>
-        <location filename="qtdialogs.py" line="6038"/>
+        <location filename="qtdialogs.py" line="6043"/>
         <source>&lt;center&gt;&lt;u&gt;&lt;b&gt;TxOut Information&lt;/b&gt;&lt;/u&gt;&lt;/center&gt;</source>
         <translation>&lt;center&gt;&lt;u&gt;&lt;b&gt;TxOut Information&lt;/b&gt;&lt;/u&gt;&lt;/center&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="6074"/>
+        <location filename="qtdialogs.py" line="6079"/>
         <source>&lt;font size=4&gt;&lt;u&gt;&lt;b&gt;Information on TxOut&lt;/b&gt;&lt;/u&gt;&lt;/font&gt;:</source>
         <translation>&lt;font size=4&gt;&lt;u&gt;&lt;b&gt;Information on TxOut&lt;/b&gt;&lt;/u&gt;&lt;/font&gt;:</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="6075"/>
+        <location filename="qtdialogs.py" line="6080"/>
         <source>   &lt;b&gt;Tx Out Index:&lt;/b&gt;       %1</source>
         <translation>   &lt;b&gt;Tx Out Index:&lt;/b&gt;       %1</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="6076"/>
+        <location filename="qtdialogs.py" line="6081"/>
         <source>   &lt;b&gt;TxOut Value:&lt;/b&gt;        %1</source>
         <translation>   &lt;b&gt;TxOut Value:&lt;/b&gt;        %1</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="6077"/>
+        <location filename="qtdialogs.py" line="6082"/>
         <source>   &lt;b&gt;TxOut Script Type:&lt;/b&gt;  %1</source>
         <translation>   &lt;b&gt;TxOut Script Type:&lt;/b&gt;  %1</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="6078"/>
+        <location filename="qtdialogs.py" line="6083"/>
         <source>   &lt;b&gt;TxOut Address:&lt;/b&gt;      %1</source>
         <translation>   &lt;b&gt;TxOut Address:&lt;/b&gt;      %1</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="6080"/>
+        <location filename="qtdialogs.py" line="6085"/>
         <source>   &lt;b&gt;TxOut Wallet:&lt;/b&gt;       %1</source>
         <translation>   &lt;b&gt;TxOut Wallet:&lt;/b&gt;       %1</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="6082"/>
+        <location filename="qtdialogs.py" line="6087"/>
         <source>   &lt;b&gt;TxOut Wallet:&lt;/b&gt;       [[Unrelated to any loaded wallets]]</source>
         <translation>   &lt;b&gt;TxOut Wallet:&lt;/b&gt;       [[Unrelated to any loaded wallets]]</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="6083"/>
+        <location filename="qtdialogs.py" line="6088"/>
         <source>   &lt;b&gt;TxOut Script:&lt;/b&gt;</source>
         <translation>   &lt;b&gt;TxOut Script:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="6098"/>
+        <location filename="qtdialogs.py" line="6103"/>
         <source>Ok</source>
         <translation>Ok</translation>
     </message>
@@ -3302,37 +3332,37 @@ random letters, or 5 or more random words.
 <context>
     <name>DlgDuplicateAddr</name>
     <message>
-        <location filename="qtdialogs.py" line="3072"/>
+        <location filename="qtdialogs.py" line="3074"/>
         <source>No Addresses to Import</source>
         <translation>No Addresses to Import</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3072"/>
+        <location filename="qtdialogs.py" line="3074"/>
         <source>There are no addresses to import!</source>
         <translation>There are no addresses to import!</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3095"/>
+        <location filename="qtdialogs.py" line="3097"/>
         <source>Continue</source>
         <translation>Continue</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3096"/>
+        <location filename="qtdialogs.py" line="3098"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3109"/>
+        <location filename="qtdialogs.py" line="3111"/>
         <source>Duplicate Addresses</source>
         <translation>Duplicate Addresses</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3089"/>
+        <location filename="qtdialogs.py" line="3091"/>
         <source>Duplicate addresses cannot be imported.  If you continue, the addresses above will be ignored, and only new addresses will be imported to this wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3076"/>
+        <location filename="qtdialogs.py" line="3078"/>
         <source>&lt;font color=%1&gt;Duplicate addresses detected!&lt;/font&gt; The following addresses already exist in other Armory wallets:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3340,62 +3370,62 @@ random letters, or 5 or more random words.
 <context>
     <name>DlgECDSACalc</name>
     <message>
-        <location filename="qtdialogs.py" line="7380"/>
+        <location filename="qtdialogs.py" line="7385"/>
         <source>Multiply Scalars (mod n)</source>
         <translation>Multiply Scalars (mod n)</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="7381"/>
+        <location filename="qtdialogs.py" line="7386"/>
         <source>Scalar Multiply EC Point</source>
         <translation>Scalar Multiply EC Point</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="7382"/>
+        <location filename="qtdialogs.py" line="7387"/>
         <source>Add EC Points</source>
         <translation>Add EC Points</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="7497"/>
+        <location filename="qtdialogs.py" line="7502"/>
         <source>Clear</source>
         <translation>Clear</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="7501"/>
+        <location filename="qtdialogs.py" line="7506"/>
         <source>&lt;&lt;&lt; Go Back</source>
         <translation>&lt;&lt;&lt; Go Back</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="7517"/>
+        <location filename="qtdialogs.py" line="7522"/>
         <source>ECDSA Calculator</source>
         <translation>ECDSA Calculator</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="7527"/>
+        <location filename="qtdialogs.py" line="7532"/>
         <source>Bad Input</source>
         <translation>Bad Input</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="7581"/>
+        <location filename="qtdialogs.py" line="7586"/>
         <source>Invalid EC Point</source>
         <translation>Invalid EC Point</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="7527"/>
+        <location filename="qtdialogs.py" line="7532"/>
         <source>Value &quot;%1&quot; is invalid. Make sure the value is specified in hex, big-endian.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="7581"/>
+        <location filename="qtdialogs.py" line="7586"/>
         <source>The point you specified (&lt;b&gt;B&lt;/b&gt;) is not on the elliptic curve used in Bitcoin (secp256k1).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="7575"/>
+        <location filename="qtdialogs.py" line="7580"/>
         <source>The point you specified (&lt;b&gt;A&lt;/b&gt;) is not on the elliptic curve used in Bitcoin (secp256k1).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="7484"/>
+        <location filename="qtdialogs.py" line="7489"/>
         <source>Use this form to perform Bitcoin elliptic curve calculations.  All operations are performed on the secp256k1 elliptic curve, which is the one used for Bitcoin. Supply all values as 32-byte, big-endian, hex-encoded integers. &lt;br&gt;&lt;br&gt;The following is the secp256k1 generator point coordinates (G): &lt;br&gt; &lt;b&gt;G&lt;/b&gt;&lt;sub&gt;x&lt;/sub&gt;: %1 &lt;br&gt; &lt;b&gt;G&lt;/b&gt;&lt;sub&gt;y&lt;/sub&gt;: %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3403,27 +3433,27 @@ random letters, or 5 or more random words.
 <context>
     <name>DlgEULA</name>
     <message>
-        <location filename="qtdialogs.py" line="3522"/>
+        <location filename="qtdialogs.py" line="3527"/>
         <source>I agree to all the terms of the license above</source>
         <translation>I agree to all the terms of the license above</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3524"/>
+        <location filename="qtdialogs.py" line="3529"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3525"/>
+        <location filename="qtdialogs.py" line="3530"/>
         <source>Accept</source>
         <translation>Accept</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3554"/>
+        <location filename="qtdialogs.py" line="3559"/>
         <source>Armory License Agreement</source>
         <translation>Armory License Agreement</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3533"/>
+        <location filename="qtdialogs.py" line="3538"/>
         <source>&lt;b&gt;Armory Bitcoin Client is licensed in part under the &lt;i&gt;Affero General Public License, Version 3 (AGPLv3)&lt;/i&gt; and in part under the &lt;i&gt;MIT License&lt;/i&gt;&lt;/b&gt; &lt;br&gt;&lt;br&gt;Additionally, as a condition of receiving this software for free, you accept all risks associated with using it and the developers of Armory will not be held liable for any loss of money or bitcoins due to software defects. &lt;br&gt;&lt;br&gt;&lt;b&gt;Please read the full terms of the license and indicate your agreement with its terms.&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3431,62 +3461,62 @@ random letters, or 5 or more random words.
 <context>
     <name>DlgEnterOneFrag</name>
     <message>
-        <location filename="qtdialogs.py" line="12246"/>
+        <location filename="qtdialogs.py" line="12251"/>
         <source>&lt;b&gt;Backup Type:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Backup Type:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="12293"/>
+        <location filename="qtdialogs.py" line="12298"/>
         <source>Done</source>
         <translation>Done</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="12294"/>
+        <location filename="qtdialogs.py" line="12299"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="12310"/>
+        <location filename="qtdialogs.py" line="12315"/>
         <source>Restore Single-Sheet Backup</source>
         <translation>Restore Single-Sheet Backup</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="12394"/>
+        <location filename="qtdialogs.py" line="12399"/>
         <source>Verify Wallet ID</source>
         <translation>Verify Wallet ID</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="12413"/>
+        <location filename="qtdialogs.py" line="12418"/>
         <source>Verify Fragment ID</source>
         <translation>Verify Fragment ID</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="12194"/>
+        <location filename="qtdialogs.py" line="12199"/>
         <source>You have entered fragments %1, so far.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="12376"/>
+        <location filename="qtdialogs.py" line="12381"/>
         <source>The ID field indicates that this is a SecurePrint&#xe2;&#x84;&#xa2; Backup Type. You have either entered the ID incorrectly or have chosen an incorrect Backup Type.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="12394"/>
+        <location filename="qtdialogs.py" line="12399"/>
         <source>There is an error in the data you entered that could not be fixed automatically.  Please double-check that you entered the text exactly as it appears on the wallet-backup page. &lt;br&gt;&lt;br&gt; The error occured on the &quot;%1&quot; line.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="12196"/>
+        <location filename="qtdialogs.py" line="12201"/>
         <source>&lt;b&gt;&lt;u&gt;Enter Another Fragment...&lt;/u&gt;&lt;/b&gt; &lt;br&gt;&lt;br&gt; %1 The fragments can be entered in any order, as long as you provide enough of them to restore the wallet.  If any fragments use a SecurePrintu200bu2122 code, please enter it once on the previous window, and it will be applied to all fragments that require it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="12278"/>
+        <location filename="qtdialogs.py" line="12283"/>
         <source>SecurePrintu200bu2122 Code:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="12413"/>
+        <location filename="qtdialogs.py" line="12418"/>
         <source>The data you entered is for fragment: &lt;br&gt;&lt;br&gt; &lt;font color=&quot;%1&quot; size=3&gt;&lt;b&gt;%2&lt;/b&gt;&lt;/font&gt;  &lt;br&gt;&lt;br&gt; Does this ID match the &quot;Fragment:&quot; field displayed on your backup? If not, click &quot;No&quot; and re-enter the fragment data.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3494,27 +3524,27 @@ random letters, or 5 or more random words.
 <context>
     <name>DlgEnterSecurePrintCode</name>
     <message>
-        <location filename="qtdialogs.py" line="12157"/>
+        <location filename="qtdialogs.py" line="12162"/>
         <source>Done</source>
         <translation>Done</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="12158"/>
+        <location filename="qtdialogs.py" line="12163"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="12170"/>
+        <location filename="qtdialogs.py" line="12175"/>
         <source>Enter Secure Print Code</source>
         <translation>Enter Secure Print Code</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="12148"/>
+        <location filename="qtdialogs.py" line="12153"/>
         <source>This fragment file requires a SecurePrintu200bu2122 code. You will only have to enter this code once since it is the same on all fragments.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="12153"/>
+        <location filename="qtdialogs.py" line="12158"/>
         <source>SecurePrintu200bu2122 Code: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3522,7 +3552,7 @@ random letters, or 5 or more random words.
 <context>
     <name>DlgExecLongProcess</name>
     <message>
-        <location filename="qtdialogs.py" line="7296"/>
+        <location filename="qtdialogs.py" line="7301"/>
         <source>Please Wait...</source>
         <translation>Please Wait...</translation>
     </message>
@@ -3530,57 +3560,57 @@ random letters, or 5 or more random words.
 <context>
     <name>DlgExpWOWltData</name>
     <message>
-        <location filename="qtdialogs.py" line="10022"/>
+        <location filename="qtdialogs.py" line="10027"/>
         <source>Export Watching-Only Wallet File</source>
         <translation>Export Watching-Only Wallet File</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10023"/>
+        <location filename="qtdialogs.py" line="10028"/>
         <source>Copy to clipboard</source>
         <translation>Copy to clipboard</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10025"/>
+        <location filename="qtdialogs.py" line="10030"/>
         <source>Save to Text File</source>
         <translation>Save to Text File</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10026"/>
+        <location filename="qtdialogs.py" line="10031"/>
         <source>Print Root Data</source>
         <translation>Print Root Data</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10045"/>
+        <location filename="qtdialogs.py" line="10050"/>
         <source>Watch-Only Wallet Export</source>
         <translation>Watch-Only Wallet Export</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10057"/>
+        <location filename="qtdialogs.py" line="10062"/>
         <source>&lt;i&gt;Copied!&lt;/i&gt;</source>
         <translation>&lt;i&gt;Copied!&lt;/i&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10087"/>
+        <location filename="qtdialogs.py" line="10092"/>
         <source>Done</source>
         <translation>Done</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10038"/>
+        <location filename="qtdialogs.py" line="10043"/>
         <source>Watch-Only Root ID:&lt;br&gt;&lt;b&gt;%1&lt;/b&gt;&lt;br&gt;&lt;br&gt;Watch-Only Root Data:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10062"/>
+        <location filename="qtdialogs.py" line="10067"/>
         <source>&lt;center&gt;&lt;b&gt;&lt;u&gt;&lt;font size=4 color=&quot;%1&quot;&gt;Export Watch-Only Wallet: %2&lt;/font&gt;&lt;/u&gt;&lt;/b&gt;&lt;/center&gt; &lt;br&gt;Use a watching-only wallet on an online computer to distribute payment addresses, verify transactions and monitor balances, but without the ability to move the funds.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10070"/>
+        <location filename="qtdialogs.py" line="10075"/>
         <source>&lt;center&gt;&lt;b&gt;&lt;u&gt;Entire Wallet File&lt;/u&gt;&lt;/b&gt;&lt;/center&gt; &lt;br&gt;&lt;i&gt;&lt;b&gt;&lt;font color=&quot;%1&quot;&gt;(Recommended)&lt;/font&gt;&lt;/b&gt;&lt;/i&gt; An exact copy of your wallet file but without any of the private signing keys. All existing comments and labels will be carried with the file. Use this option if it is easy to transfer files from this system to the target system.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10079"/>
+        <location filename="qtdialogs.py" line="10084"/>
         <source>&lt;center&gt;&lt;b&gt;&lt;u&gt;Only Root Data&lt;/u&gt;&lt;/b&gt;&lt;/center&gt; &lt;br&gt;Same as above, but only five lines of text that are easy to print, email inline, or copy by hand.  Only produces the wallet addresses.   No comments or labels are carried with it.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3588,42 +3618,42 @@ random letters, or 5 or more random words.
 <context>
     <name>DlgExportAsciiBlock</name>
     <message>
-        <location filename="MultiSigDialogs.py" line="2317"/>
+        <location filename="MultiSigDialogs.py" line="2312"/>
         <source>Copy to Clipboard</source>
         <translation>Copy to Clipboard</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="2318"/>
+        <location filename="MultiSigDialogs.py" line="2313"/>
         <source>Save to File</source>
         <translation>Save to File</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="2319"/>
+        <location filename="MultiSigDialogs.py" line="2314"/>
         <source>Send Email</source>
         <translation>Send Email</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="2320"/>
+        <location filename="MultiSigDialogs.py" line="2315"/>
         <source>Done</source>
         <translation>Done</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="2342"/>
+        <location filename="MultiSigDialogs.py" line="2337"/>
         <source>Export ASCII Block</source>
         <translation>Export ASCII Block</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="2374"/>
+        <location filename="MultiSigDialogs.py" line="2369"/>
         <source>Email Triggered</source>
         <translation>Email Triggered</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="2374"/>
+        <location filename="MultiSigDialogs.py" line="2369"/>
         <source>Do not show this message again</source>
         <translation>Do not show this message again</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="2374"/>
+        <location filename="MultiSigDialogs.py" line="2369"/>
         <source>Armory attempted to execute a &quot;mailto:&quot; link which should trigger your email application or web browser to open a compose-email window. This does not work in all environments, and you might have to manually copy and paste the text in the box into an email. </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3631,204 +3661,204 @@ random letters, or 5 or more random words.
 <context>
     <name>DlgExportTxHistory</name>
     <message>
-        <location filename="qtdialogs.py" line="8983"/>
+        <location filename="qtdialogs.py" line="8988"/>
         <source>My Wallets</source>
         <translation>My Wallets</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8984"/>
+        <location filename="qtdialogs.py" line="8989"/>
         <source>Offline Wallets</source>
         <translation>Offline Wallets</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8985"/>
+        <location filename="qtdialogs.py" line="8990"/>
         <source>Other Wallets</source>
         <translation>Other Wallets</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8988"/>
+        <location filename="qtdialogs.py" line="8993"/>
         <source>All Wallets</source>
         <translation>All Wallets</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8989"/>
+        <location filename="qtdialogs.py" line="8994"/>
         <source>All Lockboxes</source>
         <translation>All Lockboxes</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8990"/>
+        <location filename="qtdialogs.py" line="8995"/>
         <source>All Wallets &amp; Lockboxes</source>
         <translation>All Wallets &amp; Lockboxes</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9003"/>
+        <location filename="qtdialogs.py" line="9008"/>
         <source>Date (newest first)</source>
         <translation>Date (newest first)</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9004"/>
+        <location filename="qtdialogs.py" line="9009"/>
         <source>Date (oldest first)</source>
         <translation>Date (oldest first)</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9009"/>
+        <location filename="qtdialogs.py" line="9014"/>
         <source>Comma-Separated Values (*.csv)</source>
         <translation>Comma-Separated Values (*.csv)</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9013"/>
+        <location filename="qtdialogs.py" line="9018"/>
         <source>Use any of the following symbols:&lt;br&gt;</source>
         <translation>Use any of the following symbols:&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9024"/>
+        <location filename="qtdialogs.py" line="9029"/>
         <source>Reset to Default</source>
         <translation>Reset to Default</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9034"/>
+        <location filename="qtdialogs.py" line="9039"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9035"/>
+        <location filename="qtdialogs.py" line="9040"/>
         <source>Export</source>
         <translation>Export</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9044"/>
+        <location filename="qtdialogs.py" line="9049"/>
         <source>Export Format:</source>
         <translation>Export Format:</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9051"/>
+        <location filename="qtdialogs.py" line="9056"/>
         <source>Wallet(s) to export:</source>
         <translation>Wallet(s) to export:</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9058"/>
+        <location filename="qtdialogs.py" line="9063"/>
         <source>Sort Table:</source>
         <translation>Sort Table:</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9064"/>
+        <location filename="qtdialogs.py" line="9069"/>
         <source>Date Format:</source>
         <translation>Date Format:</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9089"/>
+        <location filename="qtdialogs.py" line="9094"/>
         <source>Example: %1</source>
         <translation>Example: %1</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9092"/>
+        <location filename="qtdialogs.py" line="9097"/>
         <source>Example: [[invalid date format]]</source>
         <translation>Example: [[invalid date format]]</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9104"/>
+        <location filename="qtdialogs.py" line="9109"/>
         <source>Invalid date format</source>
         <translation>Invalid date format</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9104"/>
+        <location filename="qtdialogs.py" line="9109"/>
         <source>Cannot create CSV without a valid format for transaction dates and times</source>
         <translation>Cannot create CSV without a valid format for transaction dates and times</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9200"/>
+        <location filename="qtdialogs.py" line="9205"/>
         <source>Export Date: %1
 </source>
         <translation>Export Date: %1
 </translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9201"/>
+        <location filename="qtdialogs.py" line="9206"/>
         <source>Total Funds: %1
 </source>
         <translation>Total Funds: %1
 </translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9202"/>
+        <location filename="qtdialogs.py" line="9207"/>
         <source>Spendable Funds: %1
 </source>
         <translation>Spendable Funds: %1
 </translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9203"/>
+        <location filename="qtdialogs.py" line="9208"/>
         <source>Unconfirmed Funds: %1
 </source>
         <translation>Unconfirmed Funds: %1
 </translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9206"/>
+        <location filename="qtdialogs.py" line="9211"/>
         <source>Included Wallets:
 </source>
         <translation>Included Wallets:
 </translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9213"/>
+        <location filename="qtdialogs.py" line="9218"/>
         <source>%1 (lockbox),%2
 </source>
         <translation>%1 (lockbox),%2
 </translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9217"/>
+        <location filename="qtdialogs.py" line="9222"/>
         <source>Date</source>
         <translation>Date</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9217"/>
+        <location filename="qtdialogs.py" line="9222"/>
         <source>Transaction ID</source>
         <translation>Transaction ID</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9217"/>
+        <location filename="qtdialogs.py" line="9222"/>
         <source>Number of Confirmations</source>
         <translation>Number of Confirmations</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9217"/>
+        <location filename="qtdialogs.py" line="9222"/>
         <source>Wallet ID</source>
         <translation>Wallet ID</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9218"/>
+        <location filename="qtdialogs.py" line="9223"/>
         <source>Wallet Name</source>
         <translation>Wallet Name</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9218"/>
+        <location filename="qtdialogs.py" line="9223"/>
         <source>Credit</source>
         <translation>Credit</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9218"/>
+        <location filename="qtdialogs.py" line="9223"/>
         <source>Debit</source>
         <translation>Debit</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9218"/>
+        <location filename="qtdialogs.py" line="9223"/>
         <source>Fee (paid by this wallet)</source>
         <translation>Fee (paid by this wallet)</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9219"/>
+        <location filename="qtdialogs.py" line="9224"/>
         <source>Wallet Balance</source>
         <translation>Wallet Balance</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9219"/>
+        <location filename="qtdialogs.py" line="9224"/>
         <source>Total Balance</source>
         <translation>Total Balance</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9219"/>
+        <location filename="qtdialogs.py" line="9224"/>
         <source>Label</source>
         <translation>Label</translation>
     </message>
@@ -3836,112 +3866,112 @@ random letters, or 5 or more random words.
 <context>
     <name>DlgFactoryReset</name>
     <message>
-        <location filename="qtdialogs.py" line="13333"/>
+        <location filename="qtdialogs.py" line="13338"/>
         <source>Do not delete settings files</source>
         <translation>Do not delete settings files</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="13364"/>
+        <location filename="qtdialogs.py" line="13369"/>
         <source>Continue</source>
         <translation>Continue</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="13365"/>
+        <location filename="qtdialogs.py" line="13370"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="13379"/>
+        <location filename="qtdialogs.py" line="13384"/>
         <source>Factory Reset</source>
         <translation>Factory Reset</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="13438"/>
+        <location filename="qtdialogs.py" line="13443"/>
         <source>Confirmation</source>
         <translation>Confirmation</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="13476"/>
+        <location filename="qtdialogs.py" line="13481"/>
         <source>Aborted</source>
         <translation>Aborted</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="13492"/>
+        <location filename="qtdialogs.py" line="13497"/>
         <source>Restart Armory</source>
         <translation>Restart Armory</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="13293"/>
+        <location filename="qtdialogs.py" line="13298"/>
         <source>&lt;b&gt;&lt;u&gt;Armory Factory Reset&lt;/u&gt;&lt;/b&gt; &lt;br&gt;&lt;br&gt;It is &lt;i&gt;strongly&lt;/i&gt; recommended that you make backups of your wallets before continuing, though &lt;b&gt;wallet files will never be intentionally deleted!&lt;/b&gt;  All Armory wallet files, and the wallet.dat file used by Bitcoin Core/bitcoind should remain untouched in their current locations.  All Armory wallets will automatically be detected and loaded after the reset. &lt;br&gt;&lt;br&gt;If you are not sure which option to pick, try the &quot;lightest option&quot; first, and see if your problems are resolved before trying the more extreme options.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="13310"/>
+        <location filename="qtdialogs.py" line="13315"/>
         <source>&lt;b&gt;Delete settings and rescan (lightest option)&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="13312"/>
+        <location filename="qtdialogs.py" line="13317"/>
         <source>Only delete the settings file and transient network data.  The databases built by Armory will be rescanned (about 5-45 minutes)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="13317"/>
+        <location filename="qtdialogs.py" line="13322"/>
         <source>&lt;b&gt;Also delete databases and rebuild&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="13323"/>
+        <location filename="qtdialogs.py" line="13328"/>
         <source>&lt;b&gt;Also re-download the blockchain (extreme)&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="13324"/>
+        <location filename="qtdialogs.py" line="13329"/>
         <source>This will delete settings, network data, Armory&apos;s databases, &lt;b&gt;and&lt;/b&gt; Bitcoin Core&apos;s databases.  Bitcoin Core will have to download the blockchain again. This can take 8-72 hours depending on your system&apos;s speed and connection.  Only use this if you suspect blockchain corruption, such as receiving StdOut/StdErr errors on the dashboard.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="13389"/>
+        <location filename="qtdialogs.py" line="13394"/>
         <source>You are about to delete your settings and force Armory to rescan its databases.  Are you sure you want to do this?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="13404"/>
+        <location filename="qtdialogs.py" line="13409"/>
         <source>You are about to delete your settings and force Armory to delete and rebuild its databases.  Are you sure you want to do this?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="13476"/>
+        <location filename="qtdialogs.py" line="13481"/>
         <source>You canceled the factory reset operation.  No changes were made.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="13451"/>
+        <location filename="qtdialogs.py" line="13456"/>
         <source>&lt;b&gt;Bitcoin Core (or bitcoind) must be closed to do the reset!&lt;/b&gt; Please close all Bitcoin software, &lt;u&gt;&lt;b&gt;right now&lt;/b&gt;&lt;/u&gt;, before clicking &quot;Continue&quot;. &lt;br&gt;&lt;br&gt;Armory will now close.  Please restart Bitcoin Core/bitcoind first and wait for it to finish synchronizing before restarting Armory.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="13470"/>
+        <location filename="qtdialogs.py" line="13475"/>
         <source>Armory will now close to apply the requested changes.  Please restart it when you are ready to start the blockchain download again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="13492"/>
+        <location filename="qtdialogs.py" line="13497"/>
         <source>Armory will now close so that the requested changes can be applied.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="13318"/>
+        <location filename="qtdialogs.py" line="13323"/>
         <source>Will delete settings, network data, and delete Armory&apos;s databases. The databases will be rebuilt and rescanned (45 min to 3 hours)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="13430"/>
+        <location filename="qtdialogs.py" line="13435"/>
         <source>You are about to delete your settings and delete &lt;b&gt;all&lt;/b&gt; blockchain databases on your system.  The Bitcoin software will have to redownload all of the blockchain data over the peer-to-peer network again. This can take from 8 to 72 hours depending on your system&apos;s speed and connection.  &lt;br&gt;&lt;br&gt;&lt;b&gt;Are you absolutely sure you want to do this?&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="13422"/>
+        <location filename="qtdialogs.py" line="13427"/>
         <source>You are about to delete &lt;b&gt;all&lt;/b&gt; blockchain databases on your system.  The Bitcoin software will have to redownload all of the blockchain data over the peer-to-peer network again. This can take from 8 to 72 hours depending on your system&apos;s speed and connection.  &lt;br&gt;&lt;br&gt;&lt;b&gt;Are you absolutely sure you want to do this?&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3949,27 +3979,27 @@ random letters, or 5 or more random words.
 <context>
     <name>DlgForkedImports</name>
     <message>
-        <location filename="qtdialogs.py" line="13503"/>
+        <location filename="qtdialogs.py" line="13508"/>
         <source>&lt;h2 style=&quot;color: red; text-align: center;&quot;&gt;Forked imported addresses have been       detected in your wallets!!!&lt;/h2&gt;</source>
         <translation>&lt;h2 style=&quot;color: red; text-align: center;&quot;&gt;Forked imported addresses have been       detected in your wallets!!!&lt;/h2&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="13506"/>
+        <location filename="qtdialogs.py" line="13511"/>
         <source>The following wallets have forked imported addresses: &lt;br&gt;&lt;br&gt;&lt;b&gt;</source>
         <translation>The following wallets have forked imported addresses: &lt;br&gt;&lt;br&gt;&lt;b&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="13509"/>
+        <location filename="qtdialogs.py" line="13514"/>
         <source>When you fix a corrupted wallet, any damaged private keys will be off       the deterministic chain. It means these private keys cannot be recreated       by your paper backup. If such private keys are encountered, Armory saves       them as forked imported private keys after it fixes the relevant wallets.</source>
         <translation>When you fix a corrupted wallet, any damaged private keys will be off       the deterministic chain. It means these private keys cannot be recreated       by your paper backup. If such private keys are encountered, Armory saves       them as forked imported private keys after it fixes the relevant wallets.</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="13550"/>
+        <location filename="qtdialogs.py" line="13555"/>
         <source>Forked Imported Addresses</source>
         <translation>Forked Imported Addresses</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="13514"/>
+        <location filename="qtdialogs.py" line="13519"/>
         <source>&lt;h1 style=&quot;color: orange;&quot;&gt; - Do not accept payments to these wallets anymore&lt;br&gt;      - Do not delete or overwrite these wallets. &lt;br&gt;       - Transfer all funds to a fresh and backed up wallet&lt;/h1&gt;</source>
         <translation>&lt;h1 style=&quot;color: orange;&quot;&gt; - Do not accept payments to these wallets anymore&lt;br&gt;      - Do not delete or overwrite these wallets. &lt;br&gt;       - Transfer all funds to a fresh and backed up wallet&lt;/h1&gt;</translation>
     </message>
@@ -3977,37 +4007,37 @@ random letters, or 5 or more random words.
 <context>
     <name>DlgFragBackup</name>
     <message>
-        <location filename="qtdialogs.py" line="10412"/>
+        <location filename="qtdialogs.py" line="10417"/>
         <source>Close</source>
         <translation>Close</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10502"/>
+        <location filename="qtdialogs.py" line="10507"/>
         <source>&lt;u&gt;&lt;b&gt;Required Fragments&lt;/b&gt;&lt;/u&gt; </source>
         <translation>&lt;u&gt;&lt;b&gt;Required Fragments&lt;/b&gt;&lt;/u&gt; </translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10503"/>
+        <location filename="qtdialogs.py" line="10508"/>
         <source>&lt;u&gt;&lt;b&gt;Total Fragments&lt;/b&gt;&lt;/u&gt; </source>
         <translation>&lt;u&gt;&lt;b&gt;Total Fragments&lt;/b&gt;&lt;/u&gt; </translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10507"/>
+        <location filename="qtdialogs.py" line="10512"/>
         <source>Print All Fragments</source>
         <translation>Print All Fragments</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10549"/>
+        <location filename="qtdialogs.py" line="10554"/>
         <source>&lt;b&gt;Fragment ID:&lt;br&gt;%1-%2&lt;/b&gt;</source>
         <translation>&lt;b&gt;Fragment ID:&lt;br&gt;%1-%2&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10581"/>
+        <location filename="qtdialogs.py" line="10586"/>
         <source>View/Print</source>
         <translation>View/Print</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10582"/>
+        <location filename="qtdialogs.py" line="10587"/>
         <source>Save to File</source>
         <translation>Save to File</translation>
     </message>
@@ -4017,7 +4047,7 @@ random letters, or 5 or more random words.
         <translation type="obsolete">Fragments</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10626"/>
+        <location filename="qtdialogs.py" line="10631"/>
         <source>Secure Backup?</source>
         <translation>Secure Backup?</translation>
     </message>
@@ -4032,47 +4062,47 @@ random letters, or 5 or more random words.
         <translation type="obsolete">Wallet Fragments (*.frag)</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10702"/>
+        <location filename="qtdialogs.py" line="10707"/>
         <source>Success</source>
         <translation>Success</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10373"/>
+        <location filename="qtdialogs.py" line="10378"/>
         <source>&lt;b&gt;&lt;u&gt;Create M-of-N Fragmented Backup&lt;/u&gt; of &quot;%1&quot; (%2)&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10534"/>
+        <location filename="qtdialogs.py" line="10539"/>
         <source>Any &lt;font color=&quot;%1&quot;&gt;&lt;b&gt;%2&lt;/b&gt;&lt;/font&gt; of these &lt;font color=&quot;%1&quot;&gt;&lt;b&gt;%3&lt;/b&gt;&lt;/font&gt;fragments are sufficient to restore your wallet, and each fragment has the ID, &lt;font color=&quot;%1&quot;&gt;&lt;b&gt;%4&lt;/b&gt;&lt;/font&gt;.  All fragments with the same fragment ID are compatible with each other!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10687"/>
+        <location filename="qtdialogs.py" line="10692"/>
         <source>The fragment was successfully saved to the following location: &lt;br&gt;&lt;br&gt; %1 &lt;br&gt;&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10429"/>
+        <location filename="qtdialogs.py" line="10434"/>
         <source>Use SecurePrintu200bu2122 to prevent exposing keys to printer or other devices</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10436"/>
+        <location filename="qtdialogs.py" line="10441"/>
         <source>SecurePrintu200bu2122 encrypts your backup with a code displayed on the screen, so that no other devices or processes has access to the unencrypted private keys (either network devices when printing, or other applications if you save a fragment to disk or USB device). &lt;u&gt;You must keep the SecurePrintu200bu2122 code with the backup!&lt;/u&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10442"/>
+        <location filename="qtdialogs.py" line="10447"/>
         <source>&lt;b&gt;&lt;font color=&quot;%1&quot;&gt;&lt;u&gt;IMPORTANT:&lt;/u&gt;  You must keep the SecurePrintu200bu2122 encryption code with your backup! Your SecurePrintu200bu2122 code is &lt;/font&gt; &lt;font color=&quot;%2&quot;&gt;%3&lt;/font&gt;&lt;font color=&quot;%4&quot;&gt;. All fragments for a given wallet use the same code.&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10692"/>
+        <location filename="qtdialogs.py" line="10697"/>
         <source>&lt;b&gt;&lt;u&gt;&lt;font color=&quot;%1&quot;&gt;Important&lt;/font&lt;/u&gt;&lt;/b&gt;: The fragment was encrypted with the SecurePrintu200bu2122 encryption code.  You must keep this code with the backup in order to use it!  The code &lt;u&gt;is&lt;/u&gt; case-sensitive! &lt;br&gt;&lt;br&gt; &lt;font color=&quot;%2&quot; size=5&gt;&lt;b&gt;%3&lt;/b&gt;&lt;/font&gt;&lt;br&gt;&lt;br&gt;The above code &lt;u&gt;&lt;b&gt;is&lt;/b&gt;&lt;/u&gt; case-sensitive!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10626"/>
+        <location filename="qtdialogs.py" line="10631"/>
         <source>You have selected to use SecurePrintu200bu2122 for the printed backups, which can also be applied to fragments saved to file. Doing so will require you store the SecurePrintu200bu2122 code with the backup, but it will prevent unencrypted key data from touching any disks.  &lt;br&gt;&lt;br&gt; Do you want to encrypt the fragment file with the same SecurePrintu200bu2122 code?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4080,32 +4110,32 @@ random letters, or 5 or more random words.
 <context>
     <name>DlgFundLockbox</name>
     <message>
-        <location filename="MultiSigDialogs.py" line="1863"/>
+        <location filename="MultiSigDialogs.py" line="1858"/>
         <source>Create Transaction</source>
         <translation>Create Transaction</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1864"/>
+        <location filename="MultiSigDialogs.py" line="1859"/>
         <source>Review and Sign</source>
         <translation>Review and Sign</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1865"/>
+        <location filename="MultiSigDialogs.py" line="1860"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1849"/>
+        <location filename="MultiSigDialogs.py" line="1844"/>
         <source>To spend from a multi-sig lockbox, one party/device must create a proposed spending transaction, then all parties/devices must review and sign that transaction.  Once it has enough signatures, any device, can broadcast the transaction to the network.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1855"/>
+        <location filename="MultiSigDialogs.py" line="1850"/>
         <source>I am creating a new proposed spending transaction and will pass it to each party or device that needs to sign it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1859"/>
+        <location filename="MultiSigDialogs.py" line="1854"/>
         <source>Another party or device created the transaction, I just need to review and sign it.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4136,32 +4166,32 @@ random letters, or 5 or more random words.
 <context>
     <name>DlgHelpAbout</name>
     <message>
-        <location filename="qtdialogs.py" line="8259"/>
+        <location filename="qtdialogs.py" line="8264"/>
         <source>Armory Bitcoin Wallet : Version %1-beta-%2</source>
         <translation>Armory Bitcoin Wallet : Version %1-beta-%2</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8262"/>
+        <location filename="qtdialogs.py" line="8267"/>
         <source>Copyright &amp;copy; 2011-2015 Armory Technologies, Inc.</source>
         <translation>Copyright &amp;copy; 2011-2015 Armory Technologies, Inc.</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8263"/>
+        <location filename="qtdialogs.py" line="8268"/>
         <source>Copyright &amp;copy; 2016 Goatpig</source>
         <translation>Copyright &amp;copy; 2016 Goatpig</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8264"/>
+        <location filename="qtdialogs.py" line="8269"/>
         <source>Licensed to Armory Technologies, Inc. under the &lt;a href=&quot;http://www.gnu.org/licenses/agpl-3.0.html&quot;&gt;Affero General Public License, Version 3&lt;/a&gt; (AGPLv3)</source>
         <translation>Licensed to Armory Technologies, Inc. under the &lt;a href=&quot;http://www.gnu.org/licenses/agpl-3.0.html&quot;&gt;Affero General Public License, Version 3&lt;/a&gt; (AGPLv3)</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8268"/>
+        <location filename="qtdialogs.py" line="8273"/>
         <source>Licensed to Goatpig under the &lt;a href=&quot;https://opensource.org/licenses/mit-license.php&quot;&gt;MIT License</source>
         <translation>Licensed to Goatpig under the &lt;a href=&quot;https://opensource.org/licenses/mit-license.php&quot;&gt;MIT License</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8286"/>
+        <location filename="qtdialogs.py" line="8291"/>
         <source>About Armory</source>
         <translation>About Armory</translation>
     </message>
@@ -4169,171 +4199,171 @@ random letters, or 5 or more random words.
 <context>
     <name>DlgImportAddress</name>
     <message>
-        <location filename="qtdialogs.py" line="2422"/>
+        <location filename="qtdialogs.py" line="2424"/>
         <source>Enter:</source>
         <translation>Enter:</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2424"/>
+        <location filename="qtdialogs.py" line="2426"/>
         <source>One Key</source>
         <translation>One Key</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2425"/>
+        <location filename="qtdialogs.py" line="2427"/>
         <source>Multiple Keys</source>
         <translation>Multiple Keys</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2577"/>
+        <location filename="qtdialogs.py" line="2579"/>
         <source>Private Key Import</source>
         <translation>Private Key Import</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2634"/>
+        <location filename="qtdialogs.py" line="2636"/>
         <source>Invalid Private Key</source>
         <translation>Invalid Private Key</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2634"/>
+        <location filename="qtdialogs.py" line="2636"/>
         <source>The private key you have entered is actually not valid for the elliptic curve used by Bitcoin (secp256k1). Almost any 64-character hex is a valid private key &lt;b&gt;except&lt;/b&gt; for those greater than: &lt;br&gt;&lt;br&gt;fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141&lt;br&gt;&lt;br&gt;Please try a different private key.</source>
         <translation>The private key you have entered is actually not valid for the elliptic curve used by Bitcoin (secp256k1). Almost any 64-character hex is a valid private key &lt;b&gt;except&lt;/b&gt; for those greater than: &lt;br&gt;&lt;br&gt;fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141&lt;br&gt;&lt;br&gt;Please try a different private key.</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2650"/>
+        <location filename="qtdialogs.py" line="2652"/>
         <source>Entry Error</source>
         <translation>Entry Error</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2658"/>
+        <location filename="qtdialogs.py" line="2660"/>
         <source>Invalid Data</source>
         <translation>Invalid Data</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2663"/>
+        <location filename="qtdialogs.py" line="2665"/>
         <source>Unsupported key type</source>
         <translation>Unsupported key type</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2670"/>
+        <location filename="qtdialogs.py" line="2672"/>
         <source>Error Processing Key</source>
         <translation>Error Processing Key</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2679"/>
+        <location filename="qtdialogs.py" line="2681"/>
         <source>Verify Address</source>
         <translation>Verify Address</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2691"/>
+        <location filename="qtdialogs.py" line="2693"/>
         <source>Try Again</source>
         <translation>Try Again</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2755"/>
+        <location filename="qtdialogs.py" line="2757"/>
         <source>The key you entered is already part of another wallet you own:&lt;br&gt;&lt;br&gt;&lt;b&gt;Address&lt;/b&gt;: </source>
         <translation>The key you entered is already part of another wallet you own:&lt;br&gt;&lt;br&gt;&lt;b&gt;Address&lt;/b&gt;: </translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2853"/>
+        <location filename="qtdialogs.py" line="2855"/>
         <source>Duplicate Addresses!</source>
         <translation>Duplicate Addresses!</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2853"/>
+        <location filename="qtdialogs.py" line="2855"/>
         <source>You are attempting to sweep %1 addresses, but %2 of them are already part of existing wallets.  That means that some or all of the bitcoins you sweep may already be owned by you. &lt;br&gt;&lt;br&gt;Would you like to continue anyway?</source>
         <translation>You are attempting to sweep %1 addresses, but %2 of them are already part of existing wallets.  That means that some or all of the bitcoins you sweep may already be owned by you. &lt;br&gt;&lt;br&gt;Would you like to continue anyway?</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2901"/>
+        <location filename="qtdialogs.py" line="2903"/>
         <source>Unlock Wallet to Import</source>
         <translation>Unlock Wallet to Import</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2903"/>
+        <location filename="qtdialogs.py" line="2905"/>
         <source>Wallet is Locked</source>
         <translation>Wallet is Locked</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2932"/>
+        <location filename="qtdialogs.py" line="2934"/>
         <source>Nothing Imported!</source>
         <translation>Nothing Imported!</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2937"/>
+        <location filename="qtdialogs.py" line="2939"/>
         <source>Error!</source>
         <translation>Error!</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2951"/>
+        <location filename="qtdialogs.py" line="2953"/>
         <source>Success!</source>
         <translation>Success!</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2945"/>
+        <location filename="qtdialogs.py" line="2947"/>
         <source>Success: %1 private keys were imported into your wallet. &lt;br&gt;&lt;br&gt;The other %2 private keys were skipped, because they were already part of your wallet.</source>
         <translation>Success: %1 private keys were imported into your wallet. &lt;br&gt;&lt;br&gt;The other %2 private keys were skipped, because they were already part of your wallet.</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2954"/>
+        <location filename="qtdialogs.py" line="2956"/>
         <source>Partial Success!</source>
         <translation>Partial Success!</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2439"/>
+        <location filename="qtdialogs.py" line="2441"/>
         <source>The key can either be imported into your wallet, or have its available balance &quot;swept&quot; to another address in your wallet.  Only import private key data if you are absolutely sure that no one else has access to it.  Otherwise, sweep it to get the funds out of it.  All standard private-key formats are supported &lt;i&gt;except for private keys created by Bitcoin Core version 0.6.0 and later (compressed)&lt;/i&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2451"/>
+        <location filename="qtdialogs.py" line="2453"/>
         <source>Supported formats are any hexadecimal or Base58 representation of a 32-byte private key (with or without checksums), and mini-private-key format used on Casascius physical bitcoins.  Private keys that use &lt;i&gt;compressed&lt;/i&gt; public keys are not yet supported by Armory.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2466"/>
+        <location filename="qtdialogs.py" line="2468"/>
         <source>Enter a list of private keys to be &quot;swept&quot; or imported. All standard private-key formats are supported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2471"/>
+        <location filename="qtdialogs.py" line="2473"/>
         <source>One private key per line, in any standard format. Data may be copied directly from the &quot;Export Key Lists&quot; dialog (all text on a line preceding the key data, separated by a colon, will be ignored).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2506"/>
+        <location filename="qtdialogs.py" line="2508"/>
         <source>Sweep any funds owned by these addresses into your wallet
 Select this option if someone else gave you this key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2509"/>
+        <location filename="qtdialogs.py" line="2511"/>
         <source>Import these addresses to your wallet
 Only select this option if you are positive that no one else has access to this key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2516"/>
+        <location filename="qtdialogs.py" line="2518"/>
         <source>Sweep any funds owned by this address into your wallet
 Select this option if someone else gave you this key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2524"/>
+        <location filename="qtdialogs.py" line="2526"/>
         <source>Sweep any funds owned by this address into your wallet
 (Not available in offline mode)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2533"/>
+        <location filename="qtdialogs.py" line="2535"/>
         <source>You should never add an untrusted key to your wallet.  By choosing this option, you are only moving the funds into your wallet, but not the key itself.  You should use this option for Casascius physical bitcoins.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2538"/>
+        <location filename="qtdialogs.py" line="2540"/>
         <source>This option will make the key part of your wallet, meaning that it can be used to securely receive future payments.  &lt;b&gt;Never&lt;/b&gt; select this option for private keys that other people may have access to.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2679"/>
+        <location filename="qtdialogs.py" line="2681"/>
         <source>The key data you entered appears to correspond to the following Bitcoin address:
 
  %1 
@@ -4342,52 +4372,52 @@ Is this the correct address?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2650"/>
+        <location filename="qtdialogs.py" line="2652"/>
         <source>The private key data you supplied appears to contain a consistency check.  This consistency check failed.  Please verify you entered the key data correctly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2658"/>
+        <location filename="qtdialogs.py" line="2660"/>
         <source>Something went terribly wrong!  (key data unrecognized)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2663"/>
+        <location filename="qtdialogs.py" line="2665"/>
         <source>You entered a key for an address that uses a compressed public key, usually produced in Bitcoin Core/bitcoind wallets created after version 0.6.0.  Armory does not yet support this key type.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2670"/>
+        <location filename="qtdialogs.py" line="2672"/>
         <source>There was an error processing the private key data. Please check that you entered it correctly</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2903"/>
+        <location filename="qtdialogs.py" line="2905"/>
         <source>Cannot import private keys without unlocking wallet!</source>
         <translation type="unfinished">Cannot import private keys without unlocking wallet!</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2932"/>
+        <location filename="qtdialogs.py" line="2934"/>
         <source>All addresses chosen to be imported are already part of this wallet. Nothing was imported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2937"/>
+        <location filename="qtdialogs.py" line="2939"/>
         <source>Failed:  No addresses could be imported. Please check the logfile (ArmoryQt.exe.log) or the console output for information about why it failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2951"/>
+        <location filename="qtdialogs.py" line="2953"/>
         <source>Success: %1 private keys were imported into your wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2954"/>
+        <location filename="qtdialogs.py" line="2956"/>
         <source>%1 private keys were imported into your wallet, but there were also %2 addresses that could not be imported (see console or log file for more information).  It is safe to try this operation again: all addresses previously imported will be skipped.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2691"/>
+        <location filename="qtdialogs.py" line="2693"/>
         <source>It is possible that the key was supplied in a &quot;reversed&quot; form.  When the data you provide is reversed, the following address is obtained:
 
  %1 
@@ -4396,17 +4426,17 @@ Is this the correct address?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2486"/>
+        <location filename="qtdialogs.py" line="2488"/>
         <source>This is from a backup with SecurePrint&#x99;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2528"/>
+        <location filename="qtdialogs.py" line="2530"/>
         <source>Sweep any funds owned by this address into your wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2627"/>
+        <location filename="qtdialogs.py" line="2629"/>
         <source>You entered all zeros.  This is not a valid private key!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4414,32 +4444,32 @@ Is this the correct address?</source>
 <context>
     <name>DlgImportAsciiBlock</name>
     <message>
-        <location filename="MultiSigDialogs.py" line="2090"/>
+        <location filename="MultiSigDialogs.py" line="2085"/>
         <source>Load from file</source>
         <translation>Load from file</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="2091"/>
+        <location filename="MultiSigDialogs.py" line="2086"/>
         <source>Done</source>
         <translation>Done</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="2092"/>
+        <location filename="MultiSigDialogs.py" line="2087"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="2113"/>
+        <location filename="MultiSigDialogs.py" line="2108"/>
         <source>Load Data</source>
         <translation>Load Data</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="2129"/>
+        <location filename="MultiSigDialogs.py" line="2124"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="2129"/>
+        <location filename="MultiSigDialogs.py" line="2124"/>
         <source>There was an error reading the ASCII block entered.  Please make sure it was entered/copied correctly, and that you have copied the header and footer lines that start with &quot;=====&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4447,52 +4477,52 @@ Is this the correct address?</source>
 <context>
     <name>DlgImportLockbox</name>
     <message>
-        <location filename="MultiSigDialogs.py" line="2404"/>
+        <location filename="MultiSigDialogs.py" line="2399"/>
         <source>Load from file</source>
         <translation>Load from file</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="2405"/>
+        <location filename="MultiSigDialogs.py" line="2400"/>
         <source>Done</source>
         <translation>Done</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="2406"/>
+        <location filename="MultiSigDialogs.py" line="2401"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="2422"/>
+        <location filename="MultiSigDialogs.py" line="2417"/>
         <source>Import Lockbox</source>
         <translation>Import Lockbox</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="2428"/>
+        <location filename="MultiSigDialogs.py" line="2423"/>
         <source>Load Lockbox</source>
         <translation>Load Lockbox</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="2445"/>
+        <location filename="MultiSigDialogs.py" line="2440"/>
         <source>Non-lockbox</source>
         <translation>Non-lockbox</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="2451"/>
+        <location filename="MultiSigDialogs.py" line="2446"/>
         <source>Duplicate Lockbox</source>
         <translation>Duplicate Lockbox</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="2393"/>
+        <location filename="MultiSigDialogs.py" line="2388"/>
         <source>&lt;b&gt;&lt;u&gt;Import Lockbox&lt;/u&gt;&lt;/b&gt; &lt;br&gt;&lt;br&gt;Copy the lockbox text block from file or email into the box below.  If you have a file with the lockbox in it, you can load it using the &quot;Load Lockbox&quot; button at the bottom.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="2445"/>
+        <location filename="MultiSigDialogs.py" line="2440"/>
         <source>You are attempting to load something that is not a Lockbox. Please clear the display and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="2451"/>
+        <location filename="MultiSigDialogs.py" line="2446"/>
         <source>You just attempted to import a lockbox with ID, %1.  This lockbox is already in your available list of lockboxes. &lt;br&gt;&lt;br&gt;Even with the same ID, the lockbox information may be different.  Would you like to overwrite the lockbox information already stored for %2?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4500,77 +4530,77 @@ Is this the correct address?</source>
 <context>
     <name>DlgImportPaperWallet</name>
     <message>
-        <location filename="qtdialogs.py" line="3695"/>
+        <location filename="qtdialogs.py" line="3700"/>
         <source>Root Key:</source>
         <translation>Root Key:</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3697"/>
+        <location filename="qtdialogs.py" line="3702"/>
         <source>Chain Code:</source>
         <translation>Chain Code:</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3720"/>
+        <location filename="qtdialogs.py" line="3725"/>
         <source>Encrypt Wallet</source>
         <translation>Encrypt Wallet</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3729"/>
+        <location filename="qtdialogs.py" line="3734"/>
         <source>Recover Wallet from Paper Backup</source>
         <translation>Recover Wallet from Paper Backup</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3804"/>
+        <location filename="qtdialogs.py" line="3809"/>
         <source>Verify Wallet ID</source>
         <translation>Verify Wallet ID</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3778"/>
+        <location filename="qtdialogs.py" line="3783"/>
         <source>Errors Corrected!</source>
         <translation>Errors Corrected!</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3795"/>
+        <location filename="qtdialogs.py" line="3800"/>
         <source>Duplicate Wallet!</source>
         <translation>Duplicate Wallet!</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3819"/>
+        <location filename="qtdialogs.py" line="3824"/>
         <source>Cannot Encrypt</source>
         <translation>Cannot Encrypt</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3837"/>
+        <location filename="qtdialogs.py" line="3842"/>
         <source>PaperBackup - %1</source>
         <translation>PaperBackup - %1</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3846"/>
+        <location filename="qtdialogs.py" line="3851"/>
         <source>Computing New Addresses</source>
         <translation>Computing New Addresses</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3852"/>
+        <location filename="qtdialogs.py" line="3857"/>
         <source>Recovering wallet...</source>
         <translation>Recovering wallet...</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3700"/>
+        <location filename="qtdialogs.py" line="3705"/>
         <source>Enter the characters exactly as they are printed on the paper-backup page.  Alternatively, you can scan the QR code from another application, then copy&amp;paste into the entry boxes below.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3705"/>
+        <location filename="qtdialogs.py" line="3710"/>
         <source>The data can be entered &lt;i&gt;with&lt;/i&gt; or &lt;i&gt;without&lt;/i&gt; spaces, and up to one character per line will be corrected automatically.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3760"/>
+        <location filename="qtdialogs.py" line="3765"/>
         <source>There is an error on line %1 of the data you entered, which could not be fixed automatically.  Please double-check that you entered the text exactly as it appears on the wallet-backup page.</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="qtdialogs.py" line="3778"/>
+        <location filename="qtdialogs.py" line="3783"/>
         <source>Detected %n error(s) on line(s) %1 in the data you entered.  Armory attempted to fix the error(s) but it is not always right.  Be sure to verify the &quot;Wallet Unique ID&quot; closely on the next window.</source>
         <translation type="unfinished">
             <numerusform>Detected %n error on line %1 in the data you entered.  Armory attempted to fix the error but it is not always right.  Be sure to verify the &quot;Wallet Unique ID&quot; closely on the next window.</numerusform>
@@ -4578,7 +4608,7 @@ Is this the correct address?</source>
         </translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3795"/>
+        <location filename="qtdialogs.py" line="3800"/>
         <source>The data you entered is for a wallet with a ID: 
 
  %1 
@@ -4588,7 +4618,7 @@ You already own this wallet!
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3804"/>
+        <location filename="qtdialogs.py" line="3809"/>
         <source>The data you entered corresponds to a wallet with a wallet ID: 
 
  %1 
@@ -4597,7 +4627,7 @@ Does this ID match the &quot;Wallet Unique ID&quot; printed on your paper backup
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3819"/>
+        <location filename="qtdialogs.py" line="3824"/>
         <source>You requested your restored wallet be encrypted, but no valid passphrase was supplied.  Aborting wallet recovery.</source>
         <translation type="unfinished">You requested your restored wallet be encrypted, but no valid passphrase was supplied.  Aborting wallet recovery.</translation>
     </message>
@@ -4678,7 +4708,7 @@ Does this ID match the &quot;Wallet Unique ID&quot; printed on your paper backup
 <context>
     <name>DlgInflatedQR</name>
     <message>
-        <location filename="qtdefines.py" line="850"/>
+        <location filename="qtdefines.py" line="854"/>
         <source>&lt;b&gt;Double-click or press ESC to close&lt;/b&gt;</source>
         <translation>&lt;b&gt;Double-click or press ESC to close&lt;/b&gt;</translation>
     </message>
@@ -4686,120 +4716,125 @@ Does this ID match the &quot;Wallet Unique ID&quot; printed on your paper backup
 <context>
     <name>DlgIntroMessage</name>
     <message>
-        <location filename="qtdialogs.py" line="3582"/>
+        <location filename="qtdialogs.py" line="3587"/>
         <source>&lt;b&gt;Welcome to Armory!&lt;/b&gt;</source>
         <translation>&lt;b&gt;Welcome to Armory!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3585"/>
+        <location filename="qtdialogs.py" line="3590"/>
         <source>&lt;i&gt;The most advanced Bitcoin Client on Earth!&lt;/i&gt;</source>
         <translation>&lt;i&gt;The most advanced Bitcoin Client on Earth!&lt;/i&gt;</translation>
     </message>
     <message>
         <location filename="qtdialogs.py" line="3588"/>
         <source>&lt;b&gt;You are about to use the most secure and feature-rich Bitcoin clientsoftware available!&lt;/b&gt;  But please remember, this softwareis still &lt;i&gt;Beta&lt;/i&gt; - Armory developers will not be held responsiblefor loss of bitcoins resulting from the use of this software!&lt;br&gt;&lt;br&gt;</source>
-        <translation>&lt;b&gt;You are about to use the most secure and feature-rich Bitcoin clientsoftware available!&lt;/b&gt;  But please remember, this softwareis still &lt;i&gt;Beta&lt;/i&gt; - Armory developers will not be held responsiblefor loss of bitcoins resulting from the use of this software!&lt;br&gt;&lt;br&gt;</translation>
+        <translation type="obsolete">&lt;b&gt;You are about to use the most secure and feature-rich Bitcoin clientsoftware available!&lt;/b&gt;  But please remember, this softwareis still &lt;i&gt;Beta&lt;/i&gt; - Armory developers will not be held responsiblefor loss of bitcoins resulting from the use of this software!&lt;br&gt;&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3603"/>
+        <location filename="qtdialogs.py" line="3608"/>
         <source>Do not show this window again</source>
         <translation>Do not show this window again</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3611"/>
+        <location filename="qtdialogs.py" line="3616"/>
         <source>Create Your First Wallet!</source>
         <translation>Create Your First Wallet!</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3612"/>
+        <location filename="qtdialogs.py" line="3617"/>
         <source>Import Existing Wallet</source>
         <translation>Import Existing Wallet</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3613"/>
+        <location filename="qtdialogs.py" line="3618"/>
         <source>Skip</source>
         <translation>Skip</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3627"/>
+        <location filename="qtdialogs.py" line="3632"/>
         <source>OK!</source>
         <translation>OK!</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3642"/>
+        <location filename="qtdialogs.py" line="3647"/>
         <source>Greetings!</source>
         <translation>Greetings!</translation>
+    </message>
+    <message>
+        <location filename="qtdialogs.py" line="3593"/>
+        <source>&lt;b&gt;You are about to use the most secure and feature-rich Bitcoin client software available!&lt;/b&gt;  But please remember, this software is still &lt;i&gt;Beta&lt;/i&gt; - Armory developers will not be held responsible for loss of bitcoins resulting from the use of this software!&lt;br&gt;&lt;br&gt;</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DlgKeypoolSettings</name>
     <message>
-        <location filename="qtdialogs.py" line="2092"/>
+        <location filename="qtdialogs.py" line="2094"/>
         <source>Armory pre-computes a pool of addresses beyond the last address you have used, and keeps them in your wallet to &quot;look-ahead.&quot;  One reason it does this is in case you have restored this wallet from a backup, and Armory does not know how many addresses you have actually used. &lt;br&gt;&lt;br&gt;If this wallet was restored from a backup and was very active after it was backed up, then it is possible Armory did not pre-compute enough addresses to find your entire balance.  &lt;b&gt;This condition is rare&lt;/b&gt;, but it can happen.  You may extend the keypool manually, below.</source>
         <translation>Armory pre-computes a pool of addresses beyond the last address you have used, and keeps them in your wallet to &quot;look-ahead.&quot;  One reason it does this is in case you have restored this wallet from a backup, and Armory does not know how many addresses you have actually used. &lt;br&gt;&lt;br&gt;If this wallet was restored from a backup and was very active after it was backed up, then it is possible Armory did not pre-compute enough addresses to find your entire balance.  &lt;b&gt;This condition is rare&lt;/b&gt;, but it can happen.  You may extend the keypool manually, below.</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2105"/>
+        <location filename="qtdialogs.py" line="2107"/>
         <source>Addresses used: </source>
         <translation>Addresses used: </translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2106"/>
+        <location filename="qtdialogs.py" line="2108"/>
         <source>Addresses computed: </source>
         <translation>Addresses computed: </translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2110"/>
+        <location filename="qtdialogs.py" line="2112"/>
         <source>Compute this many more addresses: </source>
         <translation>Compute this many more addresses: </translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2115"/>
+        <location filename="qtdialogs.py" line="2117"/>
         <source>Address computation is very slow.  It may take up to one minute to compute 200-1000 addresses (system-dependent).  Only generate as many as you think you need.</source>
         <translation>Address computation is very slow.  It may take up to one minute to compute 200-1000 addresses (system-dependent).  Only generate as many as you think you need.</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2122"/>
+        <location filename="qtdialogs.py" line="2124"/>
         <source>Compute</source>
         <translation>Compute</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2123"/>
+        <location filename="qtdialogs.py" line="2125"/>
         <source>Done</source>
         <translation>Done</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2147"/>
+        <location filename="qtdialogs.py" line="2149"/>
         <source>Extend Address Pool</source>
         <translation>Extend Address Pool</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2166"/>
+        <location filename="qtdialogs.py" line="2168"/>
         <source>Invalid input</source>
         <translation>Invalid input</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2172"/>
+        <location filename="qtdialogs.py" line="2174"/>
         <source>Are you sure?</source>
         <translation>Are you sure?</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2172"/>
+        <location filename="qtdialogs.py" line="2174"/>
         <source>You have entered that you want to compute %1 more addressesfor this wallet.  This operation will take a very long time, and Armory will become unresponsive until the computation is finished.  Armory estimates it will take about %2 minutes.&lt;br&gt;&lt;br&gt;Do you want to continue?</source>
         <translation>You have entered that you want to compute %1 more addressesfor this wallet.  This operation will take a very long time, and Armory will become unresponsive until the computation is finished.  Armory estimates it will take about %2 minutes.&lt;br&gt;&lt;br&gt;Do you want to continue?</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2184"/>
+        <location filename="qtdialogs.py" line="2186"/>
         <source>&lt;font color=&quot;%1&quot;&gt;Calculating...&lt;/font&gt;</source>
         <translation>&lt;font color=&quot;%1&quot;&gt;Calculating...&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2189"/>
+        <location filename="qtdialogs.py" line="2191"/>
         <source>Computing New Addresses</source>
         <translation>Computing New Addresses</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2166"/>
+        <location filename="qtdialogs.py" line="2168"/>
         <source>The value you entered is invalid.  Please enter a positive number of addresses to generate.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4920,107 +4955,107 @@ Does this ID match the &quot;Wallet Unique ID&quot; printed on your paper backup
         <translation>Done</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="765"/>
+        <location filename="MultiSigDialogs.py" line="760"/>
         <source>Dashboard</source>
         <translation>Dashboard</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="766"/>
+        <location filename="MultiSigDialogs.py" line="761"/>
         <source>Info</source>
         <translation>Info</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="767"/>
+        <location filename="MultiSigDialogs.py" line="762"/>
         <source>Transactions</source>
         <translation>Transactions</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="820"/>
+        <location filename="MultiSigDialogs.py" line="815"/>
         <source>Create Lockbox</source>
         <translation>Create Lockbox</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="823"/>
+        <location filename="MultiSigDialogs.py" line="818"/>
         <source>Collect public keys</source>
         <translation>Collect public keys</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="835"/>
+        <location filename="MultiSigDialogs.py" line="830"/>
         <source>Select Public Key</source>
         <translation>Select Public Key</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="838"/>
+        <location filename="MultiSigDialogs.py" line="833"/>
         <source>Send to organizer</source>
         <translation>Send to organizer</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="849"/>
+        <location filename="MultiSigDialogs.py" line="844"/>
         <source>Export Lockbox</source>
         <translation>Export Lockbox</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="852"/>
+        <location filename="MultiSigDialogs.py" line="847"/>
         <source>Send to other devices or parties</source>
         <translation>Send to other devices or parties</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="859"/>
+        <location filename="MultiSigDialogs.py" line="854"/>
         <source>Select lockbox to export</source>
         <translation>Select lockbox to export</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="863"/>
+        <location filename="MultiSigDialogs.py" line="858"/>
         <source>Import Lockbox</source>
         <translation>Import Lockbox</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="866"/>
+        <location filename="MultiSigDialogs.py" line="861"/>
         <source>From organizer or other device</source>
         <translation>From organizer or other device</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="878"/>
+        <location filename="MultiSigDialogs.py" line="873"/>
         <source>Edit Lockbox</source>
         <translation>Edit Lockbox</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="882"/>
+        <location filename="MultiSigDialogs.py" line="877"/>
         <source>Edit an existing lockbox</source>
         <translation>Edit an existing lockbox</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="883"/>
+        <location filename="MultiSigDialogs.py" line="878"/>
         <source>Select lockbox to edit</source>
         <translation>Select lockbox to edit</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="910"/>
+        <location filename="MultiSigDialogs.py" line="905"/>
         <source>Merge Promissory Notes</source>
         <translation>Merge Promissory Notes</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="922"/>
+        <location filename="MultiSigDialogs.py" line="917"/>
         <source>Create Promissory Note</source>
         <translation>Create Promissory Note</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="925"/>
+        <location filename="MultiSigDialogs.py" line="920"/>
         <source>Make a funding commitment to a lockbox</source>
         <translation>Make a funding commitment to a lockbox</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="934"/>
+        <location filename="MultiSigDialogs.py" line="929"/>
         <source>Select lockbox to commit funds to</source>
         <translation>Select lockbox to commit funds to</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="935"/>
+        <location filename="MultiSigDialogs.py" line="930"/>
         <source>Must be online to create</source>
         <translation>Must be online to create</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="938"/>
+        <location filename="MultiSigDialogs.py" line="933"/>
         <source>Review and Sign</source>
         <translation>Review and Sign</translation>
     </message>
@@ -5030,252 +5065,252 @@ Does this ID match the &quot;Wallet Unique ID&quot; printed on your paper backup
         <translation type="obsolete">Multi-sig spend or simulfunding</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="952"/>
+        <location filename="MultiSigDialogs.py" line="947"/>
         <source>Create Spending Tx</source>
         <translation>Create Spending Tx</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="955"/>
+        <location filename="MultiSigDialogs.py" line="950"/>
         <source>Send bitcoins from lockbox</source>
         <translation>Send bitcoins from lockbox</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="961"/>
+        <location filename="MultiSigDialogs.py" line="956"/>
         <source>Select lockbox to spend from</source>
         <translation>Select lockbox to spend from</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="962"/>
+        <location filename="MultiSigDialogs.py" line="957"/>
         <source>Must be online to spend</source>
         <translation>Must be online to spend</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="966"/>
+        <location filename="MultiSigDialogs.py" line="961"/>
         <source>Collect Sigs &amp;&amp; Broadcast</source>
         <translation>Collect Sigs &amp;&amp; Broadcast</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="969"/>
+        <location filename="MultiSigDialogs.py" line="964"/>
         <source>Merge signatures to finalize</source>
         <translation>Merge signatures to finalize</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="970"/>
+        <location filename="MultiSigDialogs.py" line="965"/>
         <source>Merge signatures and broadcast transaction</source>
         <translation>Merge signatures and broadcast transaction</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="972"/>
+        <location filename="MultiSigDialogs.py" line="967"/>
         <source>(must be online to broadcast)</source>
         <translation>(must be online to broadcast)</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1133"/>
+        <location filename="MultiSigDialogs.py" line="1128"/>
         <source>Fund from Wallet</source>
         <translation>Fund from Wallet</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1134"/>
+        <location filename="MultiSigDialogs.py" line="1129"/>
         <source>QR Code</source>
         <translation>QR Code</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1135"/>
+        <location filename="MultiSigDialogs.py" line="1130"/>
         <source>Request Payment</source>
         <translation>Request Payment</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1171"/>
+        <location filename="MultiSigDialogs.py" line="1166"/>
         <source>Copy Address</source>
         <translation>Copy Address</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1324"/>
+        <location filename="MultiSigDialogs.py" line="1319"/>
         <source>Invalid Tx</source>
         <translation>Invalid Tx</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1324"/>
+        <location filename="MultiSigDialogs.py" line="1319"/>
         <source>The transaction you requested be displayed does not exist in Armory&apos;s database.  This is unusual...</source>
         <translation>The transaction you requested be displayed does not exist in Armory&apos;s database.  This is unusual...</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1355"/>
+        <location filename="MultiSigDialogs.py" line="1350"/>
         <source>View on blockexplorer.com</source>
         <translation>View on blockexplorer.com</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1358"/>
+        <location filename="MultiSigDialogs.py" line="1353"/>
         <source>View on blockchain.info</source>
         <translation>View on blockchain.info</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1362"/>
+        <location filename="MultiSigDialogs.py" line="1357"/>
         <source>View Details</source>
         <translation>View Details</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1364"/>
+        <location filename="MultiSigDialogs.py" line="1359"/>
         <source>Change Comment</source>
         <translation>Change Comment</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1365"/>
+        <location filename="MultiSigDialogs.py" line="1360"/>
         <source>Copy Transaction ID</source>
         <translation>Copy Transaction ID</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1436"/>
+        <location filename="MultiSigDialogs.py" line="1431"/>
         <source>Could not open browser</source>
         <translation>Could not open browser</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1376"/>
+        <location filename="MultiSigDialogs.py" line="1371"/>
         <source>Armory encountered an error opening your web browser.  To view this transaction on blockchain.info, please copy and paste the following URL into your browser: &lt;br&gt;&lt;br&gt;%1</source>
         <translation>Armory encountered an error opening your web browser.  To view this transaction on blockchain.info, please copy and paste the following URL into your browser: &lt;br&gt;&lt;br&gt;%1</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1398"/>
+        <location filename="MultiSigDialogs.py" line="1393"/>
         <source>Copy P2SH address</source>
         <translation>Copy P2SH address</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1399"/>
+        <location filename="MultiSigDialogs.py" line="1394"/>
         <source>Display address QR code</source>
         <translation>Display address QR code</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1401"/>
+        <location filename="MultiSigDialogs.py" line="1396"/>
         <source>View address on %1</source>
         <translation>View address on %1</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1404"/>
+        <location filename="MultiSigDialogs.py" line="1399"/>
         <source>Request payment to this lockbox</source>
         <translation>Request payment to this lockbox</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1405"/>
+        <location filename="MultiSigDialogs.py" line="1400"/>
         <source>Copy hash160 value (hex)</source>
         <translation>Copy hash160 value (hex)</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1406"/>
+        <location filename="MultiSigDialogs.py" line="1401"/>
         <source>Copy balance</source>
         <translation>Copy balance</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1407"/>
+        <location filename="MultiSigDialogs.py" line="1402"/>
         <source>Delete Lockbox</source>
         <translation>Delete Lockbox</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1451"/>
+        <location filename="MultiSigDialogs.py" line="1446"/>
         <source>Compatibility Warning</source>
         <translation>Compatibility Warning</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1451"/>
+        <location filename="MultiSigDialogs.py" line="1446"/>
         <source>Do not show this message again</source>
         <translation>Do not show this message again</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1714"/>
+        <location filename="MultiSigDialogs.py" line="1709"/>
         <source>Confirm Delete</source>
         <translation>Confirm Delete</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1592"/>
+        <location filename="MultiSigDialogs.py" line="1587"/>
         <source>&lt;b&gt;Multisig:&lt;/b&gt;&amp;nbsp;&amp;nbsp;&amp;nbsp;&amp;nbsp;&amp;nbsp;&amp;nbsp;%1-of-%2</source>
         <translation>&lt;b&gt;Multisig:&lt;/b&gt;&amp;nbsp;&amp;nbsp;&amp;nbsp;&amp;nbsp;&amp;nbsp;&amp;nbsp;%1-of-%2</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1593"/>
+        <location filename="MultiSigDialogs.py" line="1588"/>
         <source>&lt;b&gt;Lockbox ID:&lt;/b&gt;&amp;nbsp;&amp;nbsp;&amp;nbsp;&amp;nbsp;%1</source>
         <translation>&lt;b&gt;Lockbox ID:&lt;/b&gt;&amp;nbsp;&amp;nbsp;&amp;nbsp;&amp;nbsp;%1</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1594"/>
+        <location filename="MultiSigDialogs.py" line="1589"/>
         <source>&lt;b&gt;P2SH Address:&lt;/b&gt;&amp;nbsp;&amp;nbsp;%1</source>
         <translation>&lt;b&gt;P2SH Address:&lt;/b&gt;&amp;nbsp;&amp;nbsp;%1</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1595"/>
+        <location filename="MultiSigDialogs.py" line="1590"/>
         <source>&lt;b&gt;Lockbox Name:&lt;/b&gt;&amp;nbsp;&amp;nbsp;%1</source>
         <translation>&lt;b&gt;Lockbox Name:&lt;/b&gt;&amp;nbsp;&amp;nbsp;%1</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1596"/>
+        <location filename="MultiSigDialogs.py" line="1591"/>
         <source>&lt;b&gt;Created:&lt;/b&gt;&amp;nbsp;&amp;nbsp;&amp;nbsp;&amp;nbsp;&amp;nbsp;&amp;nbsp;&amp;nbsp;%1</source>
         <translation>&lt;b&gt;Created:&lt;/b&gt;&amp;nbsp;&amp;nbsp;&amp;nbsp;&amp;nbsp;&amp;nbsp;&amp;nbsp;&amp;nbsp;%1</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1597"/>
+        <location filename="MultiSigDialogs.py" line="1592"/>
         <source>&lt;b&gt;Extended Info:&lt;/b&gt;&lt;hr&gt;&lt;blockquote&gt;%1&lt;/blockquote&gt;&lt;hr&gt;</source>
         <translation>&lt;b&gt;Extended Info:&lt;/b&gt;&lt;hr&gt;&lt;blockquote&gt;%1&lt;/blockquote&gt;&lt;hr&gt;</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1598"/>
+        <location filename="MultiSigDialogs.py" line="1593"/>
         <source>&lt;b&gt;Stored Key Details&lt;/b&gt;</source>
         <translation>&lt;b&gt;Stored Key Details&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1608"/>
+        <location filename="MultiSigDialogs.py" line="1603"/>
         <source>&amp;nbsp;&amp;nbsp;&lt;b&gt;Key #%1&lt;/b&gt;</source>
         <translation>&amp;nbsp;&amp;nbsp;&lt;b&gt;Key #%1&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1609"/>
+        <location filename="MultiSigDialogs.py" line="1604"/>
         <source>&amp;nbsp;&amp;nbsp;&amp;nbsp;&amp;nbsp;&amp;nbsp;&lt;b&gt;Name/ID:&lt;/b&gt;&amp;nbsp;%1</source>
         <translation>&amp;nbsp;&amp;nbsp;&amp;nbsp;&amp;nbsp;&amp;nbsp;&lt;b&gt;Name/ID:&lt;/b&gt;&amp;nbsp;%1</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1610"/>
+        <location filename="MultiSigDialogs.py" line="1605"/>
         <source>&amp;nbsp;&amp;nbsp;&amp;nbsp;&amp;nbsp;&amp;nbsp;&lt;b&gt;Address:&lt;/b&gt;&amp;nbsp;%1</source>
         <translation>&amp;nbsp;&amp;nbsp;&amp;nbsp;&amp;nbsp;&amp;nbsp;&lt;b&gt;Address:&lt;/b&gt;&amp;nbsp;%1</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1611"/>
+        <location filename="MultiSigDialogs.py" line="1606"/>
         <source>&amp;nbsp;&amp;nbsp;&amp;nbsp;&amp;nbsp;&amp;nbsp;&lt;b&gt;PubKey:&lt;/b&gt;&amp;nbsp;&amp;nbsp;%1</source>
         <translation>&amp;nbsp;&amp;nbsp;&amp;nbsp;&amp;nbsp;&amp;nbsp;&lt;b&gt;PubKey:&lt;/b&gt;&amp;nbsp;&amp;nbsp;%1</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1613"/>
+        <location filename="MultiSigDialogs.py" line="1608"/>
         <source>&lt;/font&gt;</source>
         <translation>&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1783"/>
+        <location filename="MultiSigDialogs.py" line="1778"/>
         <source>Import Signature Collector</source>
         <translation>Import Signature Collector</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1737"/>
+        <location filename="MultiSigDialogs.py" line="1732"/>
         <source>[WARNING]</source>
         <translation>[WARNING]</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1762"/>
+        <location filename="MultiSigDialogs.py" line="1757"/>
         <source>Funding %1-of-%2</source>
         <translation>Funding %1-of-%2</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="824"/>
+        <location filename="MultiSigDialogs.py" line="819"/>
         <source>Create a lockbox by collecting public keys from each device or person that will be a signing authority over the funds.  Once created you will be given a chunk of text to send to each party so they can recognize and sign transactions related to the lockbox.</source>
         <translation>Create a lockbox by collecting public keys from each device or person that will be a signing authority over the funds.  Once created you will be given a chunk of text to send to each party so they can recognize and sign transactions related to the lockbox.</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="839"/>
+        <location filename="MultiSigDialogs.py" line="834"/>
         <source>In order to create a lockbox all devices and/or parties need to provide a public key that they control to be merged by the organizer.  Once all keys are collected, the organizer will send you the final lockbox definition to import.</source>
         <translation>In order to create a lockbox all devices and/or parties need to provide a public key that they control to be merged by the organizer.  Once all keys are collected, the organizer will send you the final lockbox definition to import.</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="853"/>
+        <location filename="MultiSigDialogs.py" line="848"/>
         <source>Export a lockbox definition to be imported by other devices or parties.  Normally the lockbox organizer will do this after all public keys are collected, but any participant who already has it can send it, such as if one party/device accidentally deletes it.</source>
         <translation>Export a lockbox definition to be imported by other devices or parties.  Normally the lockbox organizer will do this after all public keys are collected, but any participant who already has it can send it, such as if one party/device accidentally deletes it.</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="867"/>
+        <location filename="MultiSigDialogs.py" line="862"/>
         <source>Import a lockbox definition to begin tracking its funds and to be able to sign related transactions. Normally, the organizer will send you the data to import after you provide a public key from one of your wallets.</source>
         <translation>Import a lockbox definition to begin tracking its funds and to be able to sign related transactions. Normally, the organizer will send you the data to import after you provide a public key from one of your wallets.</translation>
     </message>
@@ -5290,17 +5325,17 @@ Does this ID match the &quot;Wallet Unique ID&quot; printed on your paper backup
         <translation type="obsolete">Review and sign any lockbox-related transaction that requires multiple signatures.  This includes spending transactions from a regular lockbox, as well as completing a simulfunding transaction.</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="956"/>
+        <location filename="MultiSigDialogs.py" line="951"/>
         <source>Create a proposed transaction sending bitcoins to an address, wallet or another lockbox. The transaction will not be final until enough signatures have been collected and then broadcast from an online computer.</source>
         <translation>Create a proposed transaction sending bitcoins to an address, wallet or another lockbox. The transaction will not be final until enough signatures have been collected and then broadcast from an online computer.</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1289"/>
+        <location filename="MultiSigDialogs.py" line="1284"/>
         <source>Add Transaction Comment</source>
         <translation>Add Transaction Comment</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1291"/>
+        <location filename="MultiSigDialogs.py" line="1286"/>
         <source>Change Transaction Comment</source>
         <translation>Change Transaction Comment</translation>
     </message>
@@ -5310,37 +5345,37 @@ Does this ID match the &quot;Wallet Unique ID&quot; printed on your paper backup
         <translation type="obsolete">A &quot;promissory note&quot; provides blockchain information about how your wallet will contribute funds to a simulfunding transaction. A promissory note does &lt;b&gt;not&lt;/b&gt; move any money in your wallet.  The organizer will create a single transaction that includes all promissory notes and you will be able to  review it in its entirety before signing.</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1186"/>
+        <location filename="MultiSigDialogs.py" line="1181"/>
         <source>Anyone can send funds to this lockbox using this Bitcoin address: &lt;br&gt;&lt;b&gt;%1&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1436"/>
+        <location filename="MultiSigDialogs.py" line="1431"/>
         <source>Armory encountered an error opening your web browser.  To view this address on %1, please copy and paste the following URL into your browser: &lt;br&gt;&lt;br&gt;&lt;a href=&quot;%2&quot;&gt;%3&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1451"/>
+        <location filename="MultiSigDialogs.py" line="1446"/>
         <source>You are about to request payment to a &quot;P2SH&quot; address which is the format used for receiving to multi-signature addresses/lockboxes.  &quot;P2SH&quot; are like regular Bitcoin  addresses but start with %1 instead of %2. &lt;br&gt;&lt;br&gt;Unfortunately, not all software and services support sending to P2SH addresses.  If the sender or service indicates an error sending to this address, you might have to request payment to a regular wallet address and then send the funds from that wallet to the lockbox once it is confirmed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1475"/>
+        <location filename="MultiSigDialogs.py" line="1470"/>
         <source>&quot;Removing&quot; a lockbox does not delete any signing keys, so you maintain signing authority for any coins that are sent there. However, it will remove it from the list of lockboxes, and you will have to re-import it later in order to send any funds to or from the lockbox.&lt;br&gt;&lt;br&gt;You are about to remove the following lockbox:&lt;br&gt;&lt;br&gt;&lt;font color=&quot;%1&quot;&gt;%2&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1535"/>
+        <location filename="MultiSigDialogs.py" line="1530"/>
         <source>&lt;br&gt;&lt;br&gt;&lt;font color=&quot;%1&quot;&gt;&lt;center&gt;&lt;b&gt; Select a lockbox from the table above to view its info&lt;/b&gt;&lt;/center&gt; &lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1590"/>
+        <location filename="MultiSigDialogs.py" line="1585"/>
         <source>&lt;font color=&quot;%1&quot; size=4&gt;&lt;center&gt;&lt;u&gt;Lockbox Information for &lt;b&gt;%2&lt;/b&gt;&lt;/u&gt;&lt;/center&gt;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1714"/>
+        <location filename="MultiSigDialogs.py" line="1709"/>
         <source>&quot;Removing&quot; a lockbox does not delete any signing keys, so you maintain signing authority for any coins that are sent there. However, Armory will stop tracking its history and balance, and you will have to re-import it later in order to sign any transactions. &lt;br&gt;&lt;br&gt;You are about to remove the following lockbox: &lt;br&gt;&lt;br&gt;&lt;font color=&quot;%1&quot;&gt;%2&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5355,42 +5390,42 @@ Does this ID match the &quot;Wallet Unique ID&quot; printed on your paper backup
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="914"/>
+        <location filename="MultiSigDialogs.py" line="909"/>
         <source>Collect promissory notes from all funders of a Simulfunding transaction.  Use this to merge them into a single transaction that the funders can review and sign.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="926"/>
+        <location filename="MultiSigDialogs.py" line="921"/>
         <source>A &quot;promissory note&quot; provides blockchain information about how your wallet will contribute funds to a Simulfunding transaction. A promissory note does &lt;b&gt;not&lt;/b&gt; move any money in your wallet.  The organizer will create a single transaction that includes all promissory notes and you will be able to  review it in its entirety before signing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="941"/>
+        <location filename="MultiSigDialogs.py" line="936"/>
         <source>Multi-sig spend or Simulfunding</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="942"/>
+        <location filename="MultiSigDialogs.py" line="937"/>
         <source>Review and sign any lockbox-related transaction that requires multiple signatures.  This includes spending transactions from a regular lockbox, as well as completing a Simulfunding transaction.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="986"/>
+        <location filename="MultiSigDialogs.py" line="981"/>
         <source>If this lockbox will be funded by multiple parties and not all parties are fully trusted, use &quot;Simulfunding&quot; to ensure that funds are committed at the same time.  Check the &quot;Simul&quot; box to show Simulfunding options in the table.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1693"/>
+        <location filename="MultiSigDialogs.py" line="1688"/>
         <source>Import a &lt;i&gt;Signature Collector&lt;/i&gt; block to review and sign the lockbox-spend or Simulfunding transaction.  This text block is produced by the organizer and will contain &quot;=====TXSIGCOLLECT&quot; on the first line.   Or you can import it from a file, which is saved by default with a &lt;i&gt;*.sigcollect.tx&lt;/i&gt; extension.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1737"/>
+        <location filename="MultiSigDialogs.py" line="1732"/>
         <source>&lt;b&gt;&lt;font color=&quot;%1&quot;&gt;WARNING:&lt;/font&gt; &lt;/b&gt; If this lockbox is being used to hold escrow for multiple parties, and requires being funded by multiple participants, you &lt;u&gt;must&lt;/u&gt; use a special funding process to ensure simultaneous funding.  Otherwise, one of the other parties may be able to scam you!&lt;br&gt;&lt;br&gt;It is safe to continue if any of the following conditions are true:&lt;ul&gt;&lt;li&gt;You are the only one expected to fund this lockbox/escrow&lt;/li&gt;&lt;li&gt;All other parties in the lockbox/escrow are fully trusted&lt;/li&gt;&lt;li&gt;This lockbox is being used for personal savings&lt;/li&gt;&lt;/ul&gt;If the above does not apply to you, please press &quot;Cancel&quot; and select the &quot;Simulfund&quot; checkbox on the lockbox dashboard.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1784"/>
+        <location filename="MultiSigDialogs.py" line="1779"/>
         <source>Import a &lt;i&gt;Signature Collector&lt;/i&gt; text block to review and sign the Simulfunding transaction.  This text block is produced by the party that collected and merged all the promissory notes. Files containing signature-collecting data usually end with &lt;i&gt;*.sigcollect.tx&lt;/i&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5398,137 +5433,137 @@ Does this ID match the &quot;Wallet Unique ID&quot; printed on your paper backup
 <context>
     <name>DlgMergePromNotes</name>
     <message>
-        <location filename="MultiSigDialogs.py" line="3516"/>
+        <location filename="MultiSigDialogs.py" line="3511"/>
         <source>Lockbox Being Funded</source>
         <translation>Lockbox Being Funded</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3519"/>
+        <location filename="MultiSigDialogs.py" line="3514"/>
         <source>Address Being Funded</source>
         <translation>Address Being Funded</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3556"/>
+        <location filename="MultiSigDialogs.py" line="3551"/>
         <source>Loaded Promissory Notes</source>
         <translation>Loaded Promissory Notes</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3631"/>
+        <location filename="MultiSigDialogs.py" line="3626"/>
         <source>Import Promissory Note</source>
         <translation>Import Promissory Note</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3580"/>
+        <location filename="MultiSigDialogs.py" line="3575"/>
         <source>Create &amp;&amp; Add Promissory Note</source>
         <translation>Create &amp;&amp; Add Promissory Note</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3585"/>
+        <location filename="MultiSigDialogs.py" line="3580"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3586"/>
+        <location filename="MultiSigDialogs.py" line="3581"/>
         <source>Use bare multisig (no P2SH)</source>
         <translation>Use bare multisig (no P2SH)</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3593"/>
+        <location filename="MultiSigDialogs.py" line="3588"/>
         <source>Continue</source>
         <translation>Continue</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3644"/>
+        <location filename="MultiSigDialogs.py" line="3639"/>
         <source>Invalid Promissory Note</source>
         <translation>Invalid Promissory Note</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3655"/>
+        <location filename="MultiSigDialogs.py" line="3650"/>
         <source>Not Online</source>
         <translation>Not Online</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3683"/>
+        <location filename="MultiSigDialogs.py" line="3678"/>
         <source>Already Loaded</source>
         <translation>Already Loaded</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3722"/>
+        <location filename="MultiSigDialogs.py" line="3717"/>
         <source>Mismatched Funding Target</source>
         <translation>Mismatched Funding Target</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3764"/>
+        <location filename="MultiSigDialogs.py" line="3759"/>
         <source>Nothing Loaded</source>
         <translation>Nothing Loaded</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3770"/>
+        <location filename="MultiSigDialogs.py" line="3765"/>
         <source>Merging One Note</source>
         <translation>Merging One Note</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3816"/>
+        <location filename="MultiSigDialogs.py" line="3811"/>
         <source>Export Simulfunding Transaction</source>
         <translation>Export Simulfunding Transaction</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3498"/>
+        <location filename="MultiSigDialogs.py" line="3493"/>
         <source>&lt;font color=&quot;%1&quot; size=4&gt;&lt;b&gt;Merge Promissory Notes &lt;/b&gt;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3557"/>
+        <location filename="MultiSigDialogs.py" line="3552"/>
         <source>&lt;font size=4&gt;&lt;b&gt;No Promissory Notes Have Been Added&lt;/b&gt;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3587"/>
+        <location filename="MultiSigDialogs.py" line="3582"/>
         <source>EXPERT OPTION:  Do not check this box unless you know what it means and you need it!  Forces Armory to exposes public keys to the blockchain before the funds are spent. This is only needed for very specific use cases, and otherwise creates blockchain bloat.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3644"/>
+        <location filename="MultiSigDialogs.py" line="3639"/>
         <source>No promissory note was loaded.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3655"/>
+        <location filename="MultiSigDialogs.py" line="3650"/>
         <source>Armory is currently in offline mode and cannot create any transactions or promissory notes.  You can only merge pre-existing promissory notes at this time.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3683"/>
+        <location filename="MultiSigDialogs.py" line="3678"/>
         <source>This promissory note has already been loaded!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3722"/>
+        <location filename="MultiSigDialogs.py" line="3717"/>
         <source>The promissory note you loaded is for a different funding target. Please make sure that all promissory notes are for the target specified on the previous window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3503"/>
+        <location filename="MultiSigDialogs.py" line="3498"/>
         <source>Collect promissory notes from two or more parties to combine them into a single &lt;i&gt;Simulfunding&lt;/i&gt; transaction.  Once all notes are collected you will be able to send it to each contributing party for review and signing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3632"/>
+        <location filename="MultiSigDialogs.py" line="3627"/>
         <source>Import a promissory note to add to this Simulfunding transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3764"/>
+        <location filename="MultiSigDialogs.py" line="3759"/>
         <source>No promissory notes were loaded.  Cannot create Simulfunding transaction.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3770"/>
+        <location filename="MultiSigDialogs.py" line="3765"/>
         <source>Only one promissory note was entered, so there is nothing to merge.&lt;br&gt;&lt;br&gt;The Simulfunding interface is intended to merge promissory notes from multiple parties to ensure simultaneous funding for escrow.  If only person is funding, they can simply send money to the address or lockbox like they would any other transaction, without going through the Simulfunding interface. &lt;br&gt;&lt;br&gt;Click &quot;Ok&quot; to continue to the multi-signing interface, but there will only be one input to sign.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3817"/>
+        <location filename="MultiSigDialogs.py" line="3812"/>
         <source>The text block below contains the Simulfunding transaction to be signed by all parties funding this lockbox.  Copy the text block into an email to all parties contributing funds.  Each party can review the final Simulfunding transaction, add their signature(s), then send back to you to finalize it.&lt;br&gt;&lt;br&gt;When you click &quot;Done&quot;, you will be taken to a window that you can use to merge the TXSIGCOLLECT blocks from all parties and broadcast the final transaction.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5536,7 +5571,7 @@ Does this ID match the &quot;Wallet Unique ID&quot; printed on your paper backup
 <context>
     <name>DlgMultiSpendReview</name>
     <message>
-        <location filename="MultiSigDialogs.py" line="2479"/>
+        <location filename="MultiSigDialogs.py" line="2474"/>
         <source>The following transaction is a proposed spend of funds controlled by multiple parties.  The keyholes next to each input represent required signatures for the tx to be valid.  White means it has not yet been signed, and cannot be signed by you.  Green represents signatures that can be added by one of your wallets. Gray keyholes are already signed. &lt;br&gt;&lt;br&gt;Change outputs have been hidden where it is obvious (such as coins returning to the same lockbox from where it came).  If there is any ambiguity, Armory will display all outputs.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5544,57 +5579,57 @@ Does this ID match the &quot;Wallet Unique ID&quot; printed on your paper backup
 <context>
     <name>DlgNewAddressDisp</name>
     <message>
-        <location filename="qtdialogs.py" line="2240"/>
+        <location filename="qtdialogs.py" line="2242"/>
         <source>The following address can be used to receive bitcoins:</source>
         <translation>The following address can be used to receive bitcoins:</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2245"/>
+        <location filename="qtdialogs.py" line="2246"/>
         <source>Copy to Clipboard</source>
         <translation>Copy to Clipboard</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2247"/>
+        <location filename="qtdialogs.py" line="2248"/>
         <source> or </source>
         <translation> or </translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2258"/>
+        <location filename="qtdialogs.py" line="2259"/>
         <source>Create Clickable Link</source>
         <translation>Create Clickable Link</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2299"/>
+        <location filename="qtdialogs.py" line="2300"/>
         <source>(Optional) Add a label to this address, which will be shown with any relevant transactions in the &quot;Transactions&quot; tab.</source>
         <translation>(Optional) Add a label to this address, which will be shown with any relevant transactions in the &quot;Transactions&quot; tab.</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2330"/>
+        <location filename="qtdialogs.py" line="2331"/>
         <source>Done</source>
         <translation>Done</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2342"/>
+        <location filename="qtdialogs.py" line="2343"/>
         <source>&lt;b&gt;Scan QR code with phone or other barcode reader&lt;/b&gt;&lt;br&gt;&lt;br&gt;&lt;font size=2&gt;(Double-click to expand)&lt;/font&gt;</source>
         <translation>&lt;b&gt;Scan QR code with phone or other barcode reader&lt;/b&gt;&lt;br&gt;&lt;br&gt;&lt;font size=2&gt;(Double-click to expand)&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2383"/>
+        <location filename="qtdialogs.py" line="2386"/>
         <source>New Receiving Address</source>
         <translation>New Receiving Address</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2411"/>
+        <location filename="qtdialogs.py" line="2413"/>
         <source>&lt;i&gt;Copied!&lt;/i&gt;</source>
         <translation>&lt;i&gt;Copied!&lt;/i&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2262"/>
+        <location filename="qtdialogs.py" line="2263"/>
         <source>You can securely use this address as many times as you want. However, all people to whom you give this address will be able to see the number and amount of bitcoins &lt;b&gt;ever&lt;/b&gt; sent to it.  Therefore, using a new address for each transaction improves overall privacy, but there is no security issues with reusing any address.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2316"/>
+        <location filename="qtdialogs.py" line="2317"/>
         <source>Bitcoins sent to this address will appear in the wallet:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5733,52 +5768,52 @@ Anyone who gets hold of your paper backup will be able to spend the money in you
 <context>
     <name>DlgOfflineSelect</name>
     <message>
-        <location filename="qtdialogs.py" line="4691"/>
+        <location filename="qtdialogs.py" line="4696"/>
         <source>Create New Offline Transaction</source>
         <translation>Create New Offline Transaction</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4692"/>
+        <location filename="qtdialogs.py" line="4697"/>
         <source>Sign and/or Broadcast Transaction</source>
         <translation>Sign and/or Broadcast Transaction</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4696"/>
+        <location filename="qtdialogs.py" line="4701"/>
         <source>No wallets available!</source>
         <translation>No wallets available!</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4699"/>
+        <location filename="qtdialogs.py" line="4704"/>
         <source>Sign Offline Transaction</source>
         <translation>Sign Offline Transaction</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4702"/>
+        <location filename="qtdialogs.py" line="4707"/>
         <source>No watching-only wallets available!</source>
         <translation>No watching-only wallets available!</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4707"/>
+        <location filename="qtdialogs.py" line="4712"/>
         <source>&lt;&lt;&lt; Go Back</source>
         <translation>&lt;&lt;&lt; Go Back</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4674"/>
+        <location filename="qtdialogs.py" line="4679"/>
         <source>In order to execute an offline transaction, three steps must be followed:&lt;ol&gt;&lt;li&gt;&lt;u&gt;On&lt;/u&gt;line Computer:  Create the unsigned transaction&lt;/li&gt; &lt;li&gt;&lt;u&gt;Off&lt;/u&gt;line Computer: Get the transaction signed&lt;/li&gt; &lt;li&gt;&lt;u&gt;On&lt;/u&gt;line Computer:  Broadcast the signed transaction&lt;/li&gt;&lt;/ol&gt; You must create the transaction using a watch-only wallet on an online system, but watch-only wallets cannot sign it.  Only the offline system can create a valid signature.  The easiest way to execute all three steps is to use a USB key to move the data between computers.&lt;br&gt;&lt;br&gt; All the data saved to the removable medium during all three steps are completely safe and do not reveal any private information that would benefit an attacker trying to steal your funds.  However, this transaction data does reveal some addresses in your wallet, and may represent a breach of &lt;i&gt;privacy&lt;/i&gt; if not protected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4718"/>
+        <location filename="qtdialogs.py" line="4723"/>
         <source>Create a transaction from an Offline/Watching-Only wallet to be signed by the computer with the full wallet </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4722"/>
+        <location filename="qtdialogs.py" line="4727"/>
         <source>Review an unsigned transaction and sign it if you have the private keys needed for it </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4726"/>
+        <location filename="qtdialogs.py" line="4731"/>
         <source>Send a pre-signed transaction to the Bitcoin network to finalize it</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5786,27 +5821,27 @@ Anyone who gets hold of your paper backup will be able to spend the money in you
 <context>
     <name>DlgOfflineTxCreated</name>
     <message>
-        <location filename="qtdialogs.py" line="4655"/>
+        <location filename="qtdialogs.py" line="4660"/>
         <source>Review Offline Transaction</source>
         <translation>Review Offline Transaction</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4631"/>
+        <location filename="qtdialogs.py" line="4636"/>
         <source>Continue</source>
         <translation>Continue</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4633"/>
+        <location filename="qtdialogs.py" line="4638"/>
         <source>Done</source>
         <translation>Done</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4636"/>
+        <location filename="qtdialogs.py" line="4641"/>
         <source>By clicking Done you will exit the offline transaction process for now. When you are ready to sign and/or broadcast the transaction, click the Offline Transactions button in the main window, then click the Sign and/or Broadcast Transaction button in the Select Offline Action dialog.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4642"/>
+        <location filename="qtdialogs.py" line="4647"/>
         <source>By clicking Continue you will continue to the next step in the offline transaction process to sign and/or broadcast the transaction.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5842,37 +5877,37 @@ Anyone who gets hold of your paper backup will be able to spend the money in you
 <context>
     <name>DlgPrintBackup</name>
     <message>
-        <location filename="qtdialogs.py" line="6413"/>
+        <location filename="qtdialogs.py" line="6418"/>
         <source>Error Creating Backup</source>
         <translation>Error Creating Backup</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="6494"/>
+        <location filename="qtdialogs.py" line="6499"/>
         <source>Print imported keys</source>
         <translation>Print imported keys</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="6497"/>
+        <location filename="qtdialogs.py" line="6502"/>
         <source>Page:</source>
         <translation>Page:</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="6631"/>
+        <location filename="qtdialogs.py" line="6636"/>
         <source>Lots to Print!</source>
         <translation>Lots to Print!</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="6665"/>
+        <location filename="qtdialogs.py" line="6670"/>
         <source>of %1</source>
         <translation>of %1</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="6708"/>
+        <location filename="qtdialogs.py" line="6713"/>
         <source>SecurePrint Code</source>
         <translation>SecurePrint Code</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="6780"/>
+        <location filename="qtdialogs.py" line="6785"/>
         <source>Fragmented Backup (%1-of-%2)</source>
         <translation>Fragmented Backup (%1-of-%2)</translation>
     </message>
@@ -5882,102 +5917,102 @@ Anyone who gets hold of your paper backup will be able to spend the money in you
         <translation type="obsolete">&lt;b&gt;%1-&lt;font color=&quot;%2&quot;&gt;#%2&lt;/font&gt;&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="6413"/>
+        <location filename="qtdialogs.py" line="6418"/>
         <source>There was an error with the backup creator.  The operation is being canceled to avoid making bad backups!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="6542"/>
+        <location filename="qtdialogs.py" line="6547"/>
         <source>&lt;b&gt;&lt;u&gt;Print Wallet Backup Fragments&lt;/u&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt; When any %1 of these fragments are combined, all &lt;u&gt;previous &lt;b&gt;and&lt;/b&gt; future&lt;/u&gt; addresses generated by this wallet will be restored, giving you complete access to your bitcoins.  The data can be copied by hand if a working printer is not available.  Please make sure that all data lines contain &lt;b&gt;9 columns&lt;/b&gt; of &lt;b&gt;4 characters each&lt;/b&gt; (excluding &quot;ID&quot; lines).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="6553"/>
+        <location filename="qtdialogs.py" line="6558"/>
         <source>&lt;b&gt;&lt;u&gt;Print a Forever-Backup&lt;/u&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt; Printing this sheet protects all &lt;u&gt;previous &lt;b&gt;and&lt;/b&gt; future&lt;/u&gt; addresses generated by this wallet!  You can copy the &quot;Root Key&quot; %1 by hand if a working printer is not available.  Please make sure that all data lines contain &lt;b&gt;9 columns&lt;/b&gt; of &lt;b&gt;4 characters each&lt;/b&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="6631"/>
+        <location filename="qtdialogs.py" line="6636"/>
         <source>This wallet contains &lt;b&gt;%1&lt;/b&gt; imported keys, which will require &lt;b&gt;%2&lt;/b&gt; pages to print.  Not only will this use a lot of paper, it will be a lot of work to manually type in these keys in the event that you need to restore this backup. It is recommended that you do &lt;u&gt;not&lt;/u&gt; print your imported keys and instead make a digital backup, which can be restored instantly if needed. &lt;br&gt;&lt;br&gt; Do you want to print the imported keys, anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="6809"/>
+        <location filename="qtdialogs.py" line="6814"/>
         <source>Any subset of &lt;font color=&quot;%1&quot;&gt;&lt;b&gt;%2&lt;/b&gt;&lt;/font&gt; fragments with this ID (&lt;font color=&quot;%3&quot;&gt;&lt;b&gt;%4&lt;/b&gt;&lt;/font&gt;) are sufficient to recover all the coins contained in this wallet.  To optimize the physical security of your wallet, please store the fragments in different locations.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="6817"/>
+        <location filename="qtdialogs.py" line="6822"/>
         <source>&lt;font color=&quot;#aa0000&quot;&gt;&lt;b&gt;WARNING:&lt;/b&gt;&lt;/font&gt; Anyone who has access to this page has access to all the bitcoins in %1!  Please keep this page in a safe place.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="6835"/>
+        <location filename="qtdialogs.py" line="6840"/>
         <source>The following %1 lines backup all addresses &lt;i&gt;ever generated&lt;/i&gt; by this wallet (previous and future). This can be used to recover your wallet if you forget your passphrase or suffer hardware failure and lose your wallet files.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="6850"/>
+        <location filename="qtdialogs.py" line="6855"/>
         <source>The following is a list of all private keys imported into your wallet before this backup was made.  Each one must be copied manually into the application where you wish to import them.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="6856"/>
+        <location filename="qtdialogs.py" line="6861"/>
         <source>The following is fragment &lt;font color=&quot;%1&quot;&gt;&lt;b&gt;#%2&lt;/b&gt;&lt;/font&gt; for this wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="6986"/>
+        <location filename="qtdialogs.py" line="6991"/>
         <source>The following QR code is for convenience only.  It contains the exact same data as the %1 lines above.  If you copy this backup by hand, you can safely ignore this QR code.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="6524"/>
+        <location filename="qtdialogs.py" line="6529"/>
         <source>&lt;b&gt;&lt;font color=&quot;%1&quot;&gt;&lt;u&gt;IMPORTANT:&lt;/u&gt;&lt;/b&gt;  You must write the SecurePrintu200bu2122 encryption code on each printed backup page!  Your SecurePrintu200bu2122 code is &lt;/font&gt; &lt;font color=&quot;%2&quot;&gt;%3&lt;/font&gt;.  &lt;font color=&quot;%4&quot;&gt;Your backup will not work if this code is lost!&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="6708"/>
+        <location filename="qtdialogs.py" line="6713"/>
         <source>&lt;br&gt;&lt;b&gt;You must write your SecurePrintu200bu2122 code on each sheet of paper you just printed!&lt;/b&gt; Write it in the red box in upper-right corner of each printed page. &lt;br&gt;&lt;br&gt;SecurePrintu200bu2122 code: &lt;font color=&quot;%1&quot; size=5&gt;&lt;b&gt;%2&lt;/b&gt;&lt;/font&gt; &lt;br&gt;&lt;br&gt; &lt;b&gt;NOTE: the above code &lt;u&gt;is&lt;/u&gt; case-sensitive!&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="6842"/>
+        <location filename="qtdialogs.py" line="6847"/>
         <source>The following is a list of all private keys imported into your wallet before this backup was made.   These keys are encrypted with the SecurePrintu200bu2122 code and can only be restored by entering them into Armory.  Print a copy of this backup without the SecurePrintu200bu2122 option if you want to be able to import them into another application.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="6879"/>
+        <location filename="qtdialogs.py" line="6884"/>
         <source>&lt;b&gt;&lt;font color=&quot;#770000&quot;&gt;CRITICAL:&lt;/font&gt;  This backup will not work without the SecurePrintu200bu2122 code displayed on the screen during printing. Copy it here in ink:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="6510"/>
+        <location filename="qtdialogs.py" line="6515"/>
         <source>Use SecurePrintu200bu2122 to prevent exposing keys to printer or other network devices</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="6516"/>
+        <location filename="qtdialogs.py" line="6521"/>
         <source>SecurePrintu200bu2122 encrypts your backup with a code displayed on the screen, so that no other devices on your network see the sensitive data when you send it to the printer.  If you turn on SecurePrintu200bu2122 &lt;u&gt;you must write the code on the page after it is done printing!&lt;/u&gt;  There is no point in using this feature if you copy the data by hand.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="6774"/>
+        <location filename="qtdialogs.py" line="6779"/>
         <source> (SecurePrintu200bu2122)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="6774"/>
+        <location filename="qtdialogs.py" line="6779"/>
         <source> (Unencrypted)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="6776"/>
+        <location filename="qtdialogs.py" line="6781"/>
         <source>Single-Sheet %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="6778"/>
+        <location filename="qtdialogs.py" line="6783"/>
         <source>Imported Keys %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5985,17 +6020,17 @@ Anyone who gets hold of your paper backup will be able to spend the money in you
 <context>
     <name>DlgProgress</name>
     <message>
-        <location filename="qtdialogs.py" line="12837"/>
+        <location filename="qtdialogs.py" line="12842"/>
         <source>Close</source>
         <translation>Close</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="12868"/>
+        <location filename="qtdialogs.py" line="12873"/>
         <source>Enter Passphrase</source>
         <translation>Enter Passphrase</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="12987"/>
+        <location filename="qtdialogs.py" line="12992"/>
         <source>Progress Bar</source>
         <translation>Progress Bar</translation>
     </message>
@@ -6003,7 +6038,7 @@ Anyone who gets hold of your paper backup will be able to spend the money in you
 <context>
     <name>DlgRegAndTest</name>
     <message>
-        <location filename="qtdialogs.py" line="13724"/>
+        <location filename="qtdialogs.py" line="13729"/>
         <source>Error: You cannot run the Regression Test network and Bitcoin Test Network at the same time.</source>
         <translation>Error: You cannot run the Regression Test network and Bitcoin Test Network at the same time.</translation>
     </message>
@@ -6011,7 +6046,7 @@ Anyone who gets hold of your paper backup will be able to spend the money in you
 <context>
     <name>DlgRemoveAddress</name>
     <message>
-        <location filename="qtdialogs.py" line="4191"/>
+        <location filename="qtdialogs.py" line="4196"/>
         <source>&lt;b&gt;!!! WARNING !!!&lt;/b&gt;
 
 </source>
@@ -6020,47 +6055,47 @@ Anyone who gets hold of your paper backup will be able to spend the money in you
 </translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4203"/>
+        <location filename="qtdialogs.py" line="4208"/>
         <source>Address:</source>
         <translation>Address:</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4206"/>
+        <location filename="qtdialogs.py" line="4211"/>
         <source>Comment:</source>
         <translation>Comment:</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4210"/>
+        <location filename="qtdialogs.py" line="4215"/>
         <source>In Wallet:</source>
         <translation>In Wallet:</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4217"/>
+        <location filename="qtdialogs.py" line="4222"/>
         <source>Address Balance (w/ unconfirmed):</source>
         <translation>Address Balance (w/ unconfirmed):</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4268"/>
+        <location filename="qtdialogs.py" line="4273"/>
         <source>Confirm Delete Address</source>
         <translation>Confirm Delete Address</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4272"/>
+        <location filename="qtdialogs.py" line="4277"/>
         <source>One more time...</source>
         <translation>One more time...</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4195"/>
+        <location filename="qtdialogs.py" line="4200"/>
         <source>&lt;i&gt;You have requested that the following address be deleted from your wallet:&lt;/i&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4254"/>
+        <location filename="qtdialogs.py" line="4259"/>
         <source>Do you want to delete this address?  No other addresses in this wallet will be affected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4272"/>
+        <location filename="qtdialogs.py" line="4277"/>
         <source>Simply deleting an address does not prevent anyone from sending money to it.  If you have given this address to anyone in the past, make sure that they know not to use it again, since any bitcoins sent to it will be inaccessible.
 
  If you are maintaining an external copy of this address please ignore this warning
@@ -6072,7 +6107,7 @@ Are you absolutely sure you want to delete %1 ?</source>
 <context>
     <name>DlgRemoveWallet</name>
     <message>
-        <location filename="qtdialogs.py" line="3906"/>
+        <location filename="qtdialogs.py" line="3911"/>
         <source>&lt;b&gt;!!! WARNING !!!&lt;/b&gt;
 
 </source>
@@ -6081,142 +6116,142 @@ Are you absolutely sure you want to delete %1 ?</source>
 </translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3918"/>
+        <location filename="qtdialogs.py" line="3923"/>
         <source>Wallet Unique ID:</source>
         <translation>Wallet Unique ID:</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3921"/>
+        <location filename="qtdialogs.py" line="3926"/>
         <source>Wallet Name:</source>
         <translation>Wallet Name:</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3924"/>
+        <location filename="qtdialogs.py" line="3929"/>
         <source>Description:</source>
         <translation>Description:</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3939"/>
+        <location filename="qtdialogs.py" line="3944"/>
         <source>Current Balance (w/ unconfirmed):</source>
         <translation>Current Balance (w/ unconfirmed):</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3991"/>
+        <location filename="qtdialogs.py" line="3996"/>
         <source>Permanently delete this wallet</source>
         <translation>Permanently delete this wallet</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3992"/>
+        <location filename="qtdialogs.py" line="3997"/>
         <source>Delete private keys only, make watching-only</source>
         <translation>Delete private keys only, make watching-only</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4082"/>
+        <location filename="qtdialogs.py" line="4087"/>
         <source>Delete</source>
         <translation>Delete</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4083"/>
+        <location filename="qtdialogs.py" line="4088"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4092"/>
+        <location filename="qtdialogs.py" line="4097"/>
         <source>Delete Wallet Options</source>
         <translation>Delete Wallet Options</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4100"/>
+        <location filename="qtdialogs.py" line="4105"/>
         <source>Unlock Paper Backup</source>
         <translation>Unlock Paper Backup</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4102"/>
+        <location filename="qtdialogs.py" line="4107"/>
         <source>Operation Aborted</source>
         <translation>Operation Aborted</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4115"/>
+        <location filename="qtdialogs.py" line="4120"/>
         <source>Confirm Delete</source>
         <translation>Confirm Delete</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4125"/>
+        <location filename="qtdialogs.py" line="4130"/>
         <source>Are you absolutely sure?!?</source>
         <translation>Are you absolutely sure?!?</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4151"/>
+        <location filename="qtdialogs.py" line="4156"/>
         <source>Wallet %1 was replaced with a watching-only wallet.</source>
         <translation>Wallet %1 was replaced with a watching-only wallet.</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4158"/>
+        <location filename="qtdialogs.py" line="4163"/>
         <source>Wallet %1 was deleted!</source>
         <translation>Wallet %1 was deleted!</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3910"/>
+        <location filename="qtdialogs.py" line="3915"/>
         <source>&lt;i&gt;You have requested that the following wallet be removed from Armory:&lt;/i&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3978"/>
+        <location filename="qtdialogs.py" line="3983"/>
         <source>&lt;b&gt;WALLET IS NOT EMPTY.  Only delete this wallet if you have a backup on paper or saved to a another location outside your settings directory.&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3983"/>
+        <location filename="qtdialogs.py" line="3988"/>
         <source>&lt;b&gt;WALLET IS PART OF A LOCKBOX.  Only delete this wallet if you have a backup on paper or saved to a another location outside your settings directory.&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4001"/>
+        <location filename="qtdialogs.py" line="4006"/>
         <source>This will delete the wallet file, removing all its private keys from your settings directory. If you intend to keep using addresses from this wallet, do not select this option unless the wallet is backed up elsewhere.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4007"/>
+        <location filename="qtdialogs.py" line="4012"/>
         <source>This will delete the private keys from your wallet, leaving you with a watching-only wallet, which can be used to generate addresses and monitor incoming payments.  This option would be used if you created the wallet on this computer &lt;i&gt;in order to transfer it to a different computer or device and want to remove the private data from this system for security.&lt;/i&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4017"/>
+        <location filename="qtdialogs.py" line="4022"/>
         <source>Print a paper backup of this wallet before deleting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4021"/>
+        <location filename="qtdialogs.py" line="4026"/>
         <source>This will delete the wallet file from your system. Since this is a watching-only wallet, no private keys will be deleted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4025"/>
+        <location filename="qtdialogs.py" line="4030"/>
         <source>This wallet is already a watching-only wallet so this option is pointless</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4115"/>
+        <location filename="qtdialogs.py" line="4120"/>
         <source>You are about to delete a watching-only wallet.  Are you sure you want to do this?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4119"/>
+        <location filename="qtdialogs.py" line="4124"/>
         <source>Are you absolutely sure you want to permanently delete this wallet?  Unless this wallet is saved on another device you will permanently lose access to all the addresses in this wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4125"/>
+        <location filename="qtdialogs.py" line="4130"/>
         <source>&lt;i&gt;This will permanently delete the information you need to spend funds from this wallet!&lt;/i&gt;  You will only be able to receive coins, but not spend them.  Only do this if you have another copy of this wallet elsewhere, such as a paper backup or on an offline computer with the full wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4064"/>
+        <location filename="qtdialogs.py" line="4069"/>
         <source>If this box is checked, you will have the ability to print off an unencrypted version of your wallet before it is deleted.  &lt;b&gt;If printing is unsuccessful, please press *CANCEL* on the print dialog to prevent the delete operation from continuing&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4102"/>
+        <location filename="qtdialogs.py" line="4107"/>
         <source>You requested a paper backup before deleting the wallet, but clicked &quot;Cancel&quot; on the backup printing window.  So, the delete operation was canceled as well.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6224,27 +6259,27 @@ Are you absolutely sure you want to delete %1 ?</source>
 <context>
     <name>DlgReplaceWallet</name>
     <message>
-        <location filename="qtdialogs.py" line="12502"/>
+        <location filename="qtdialogs.py" line="12507"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="12503"/>
+        <location filename="qtdialogs.py" line="12508"/>
         <source>Overwrite</source>
         <translation>Overwrite</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="12504"/>
+        <location filename="qtdialogs.py" line="12509"/>
         <source>Merge</source>
         <translation>Merge</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="12552"/>
+        <location filename="qtdialogs.py" line="12557"/>
         <source>Ripping Meta Data</source>
         <translation>Ripping Meta Data</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="12488"/>
+        <location filename="qtdialogs.py" line="12493"/>
         <source>&lt;b&gt;You already have this wallet loaded!&lt;/b&gt;&lt;br&gt;You can choose to:&lt;br&gt;- Cancel wallet restore operation&lt;br&gt;- Set new password and fix any errors&lt;br&gt;- Overwrite old wallet (delete comments &amp; labels)&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6252,198 +6287,198 @@ Are you absolutely sure you want to delete %1 ?</source>
 <context>
     <name>DlgRequestPayment</name>
     <message>
-        <location filename="qtdialogs.py" line="9692"/>
+        <location filename="qtdialogs.py" line="9697"/>
         <source>Other Options &gt;&gt;&gt;</source>
         <translation>Other Options &gt;&gt;&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9380"/>
+        <location filename="qtdialogs.py" line="9385"/>
         <source>Copy to Clipboard</source>
         <translation>Copy to Clipboard</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9381"/>
+        <location filename="qtdialogs.py" line="9386"/>
         <source>Copy Raw HTML</source>
         <translation>Copy Raw HTML</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9382"/>
+        <location filename="qtdialogs.py" line="9387"/>
         <source>Copy Raw URL</source>
         <translation>Copy Raw URL</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9383"/>
+        <location filename="qtdialogs.py" line="9388"/>
         <source>Copy All Text</source>
         <translation>Copy All Text</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9406"/>
+        <location filename="qtdialogs.py" line="9411"/>
         <source>Create a clickable link that you can copy into email or webpage to request a payment.   If the user is running a Bitcoin program that supports &quot;bitcoin:&quot; links, that program will open with all this information pre-filled after they click the link.</source>
         <translation>Create a clickable link that you can copy into email or webpage to request a payment.   If the user is running a Bitcoin program that supports &quot;bitcoin:&quot; links, that program will open with all this information pre-filled after they click the link.</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9416"/>
+        <location filename="qtdialogs.py" line="9421"/>
         <source>The following Bitcoin desktop applications &lt;i&gt;try&lt;/i&gt; to register themselves with your computer to handle &quot;bitcoin:&quot; links: Armory, Multibit, Electrum</source>
         <translation>The following Bitcoin desktop applications &lt;i&gt;try&lt;/i&gt; to register themselves with your computer to handle &quot;bitcoin:&quot; links: Armory, Multibit, Electrum</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9420"/>
+        <location filename="qtdialogs.py" line="9425"/>
         <source>This is the text to be shown as the clickable link.  It should usually begin with &quot;Click here...&quot; to reaffirm to the user it is is clickable.</source>
         <translation>This is the text to be shown as the clickable link.  It should usually begin with &quot;Click here...&quot; to reaffirm to the user it is is clickable.</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9424"/>
+        <location filename="qtdialogs.py" line="9429"/>
         <source>All amounts are specifed in BTC</source>
         <translation>All amounts are specifed in BTC</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9426"/>
+        <location filename="qtdialogs.py" line="9431"/>
         <source>The person clicking the link will be sending bitcoins to this address</source>
         <translation>The person clicking the link will be sending bitcoins to this address</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9428"/>
+        <location filename="qtdialogs.py" line="9433"/>
         <source>This will be pre-filled as the label/comment field after the user clicks the link. They can modify it if desired, but you can provide useful info such as contact details, order number, etc, as convenience to them.</source>
         <translation>This will be pre-filled as the label/comment field after the user clicks the link. They can modify it if desired, but you can provide useful info such as contact details, order number, etc, as convenience to them.</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9436"/>
+        <location filename="qtdialogs.py" line="9441"/>
         <source>Close</source>
         <translation>Close</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9444"/>
+        <location filename="qtdialogs.py" line="9449"/>
         <source>&lt;b&gt;Link Text:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Link Text:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9449"/>
+        <location filename="qtdialogs.py" line="9454"/>
         <source>&lt;b&gt;Address (yours):&lt;/b&gt;</source>
         <translation>&lt;b&gt;Address (yours):&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9454"/>
+        <location filename="qtdialogs.py" line="9459"/>
         <source>&lt;b&gt;Request (BTC):&lt;/b&gt;</source>
         <translation>&lt;b&gt;Request (BTC):&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9458"/>
+        <location filename="qtdialogs.py" line="9463"/>
         <source>&lt;b&gt;Label:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Label:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9464"/>
+        <location filename="qtdialogs.py" line="9469"/>
         <source>Copy and paste the following text into email or other document:</source>
         <translation>Copy and paste the following text into email or other document:</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9473"/>
+        <location filename="qtdialogs.py" line="9478"/>
         <source>Creating QR Code Please Wait</source>
         <translation>Creating QR Code Please Wait</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9477"/>
+        <location filename="qtdialogs.py" line="9482"/>
         <source>This QR code contains address &lt;b&gt;and&lt;/b&gt; the other payment information shown to the left.</source>
         <translation>This QR code contains address &lt;b&gt;and&lt;/b&gt; the other payment information shown to the left.</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9511"/>
+        <location filename="qtdialogs.py" line="9516"/>
         <source>Create Payment Request Link</source>
         <translation>Create Payment Request Link</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9568"/>
+        <location filename="qtdialogs.py" line="9573"/>
         <source>Amount</source>
         <translation>Amount</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9578"/>
+        <location filename="qtdialogs.py" line="9583"/>
         <source>Message</source>
         <translation>Message</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9583"/>
+        <location filename="qtdialogs.py" line="9588"/>
         <source>Address</source>
         <translation>Address</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9588"/>
+        <location filename="qtdialogs.py" line="9593"/>
         <source>Inputs</source>
         <translation>Inputs</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9592"/>
+        <location filename="qtdialogs.py" line="9597"/>
         <source>&lt;font color=&quot;red&quot;&gt;Invalid %1&lt;/font&gt;</source>
         <translation>&lt;font color=&quot;red&quot;&gt;Invalid %1&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9608"/>
+        <location filename="qtdialogs.py" line="9613"/>
         <source>If clicking on the line above does not work, use this payment info:</source>
         <translation>If clicking on the line above does not work, use this payment info:</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9610"/>
+        <location filename="qtdialogs.py" line="9615"/>
         <source>&lt;b&gt;Pay to&lt;/b&gt;:<byte value="x9"/>%1&lt;br&gt;</source>
         <translation>&lt;b&gt;Pay to&lt;/b&gt;:&lt;byte value=&quot;x9&quot;/&gt;%1&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9612"/>
+        <location filename="qtdialogs.py" line="9617"/>
         <source>&lt;b&gt;Amount&lt;/b&gt;:<byte value="x9"/>%1 BTC&lt;br&gt;</source>
         <translation>&lt;b&gt;Amount&lt;/b&gt;:&lt;byte value=&quot;x9&quot;/&gt;%1 BTC&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9614"/>
+        <location filename="qtdialogs.py" line="9619"/>
         <source>&lt;b&gt;Message&lt;/b&gt;:<byte value="x9"/>%1&lt;br&gt;</source>
         <translation>&lt;b&gt;Message&lt;/b&gt;:&lt;byte value=&quot;x9&quot;/&gt;%1&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9624"/>
+        <location filename="qtdialogs.py" line="9629"/>
         <source>If clicking on the line above does not work, use this payment info:
 </source>
         <translation>If clicking on the line above does not work, use this payment info:
 </translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9625"/>
+        <location filename="qtdialogs.py" line="9630"/>
         <source>Pay to:  %1</source>
         <translation>Pay to:  %1</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9627"/>
+        <location filename="qtdialogs.py" line="9632"/>
         <source>
 Amount:  %1 BTC</source>
         <translation>
 Amount:  %1 BTC</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9629"/>
+        <location filename="qtdialogs.py" line="9634"/>
         <source>
 Message: %1</source>
         <translation>
 Message: %1</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9633"/>
+        <location filename="qtdialogs.py" line="9638"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt; &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;meta http-equiv=&quot;Content-Type&quot; content=&quot;text/html; charset=utf-8&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt; p, li { white-space: pre-wrap; } &lt;/style&gt;&lt;/head&gt;&lt;body&gt;&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;!--StartFragment--&gt;&lt;a href=&quot;%1&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;%2&lt;/span&gt;&lt;/a&gt;&lt;br /&gt;If clicking on the line above does not work, use this payment info:&lt;br /&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Pay to&lt;/span&gt;: %3</source>
         <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt; &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;meta http-equiv=&quot;Content-Type&quot; content=&quot;text/html; charset=utf-8&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt; p, li { white-space: pre-wrap; } &lt;/style&gt;&lt;/head&gt;&lt;body&gt;&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;!--StartFragment--&gt;&lt;a href=&quot;%1&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;%2&lt;/span&gt;&lt;/a&gt;&lt;br /&gt;If clicking on the line above does not work, use this payment info:&lt;br /&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Pay to&lt;/span&gt;: %3</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9647"/>
+        <location filename="qtdialogs.py" line="9652"/>
         <source>&lt;br /&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Amount&lt;/span&gt;: %1</source>
         <translation>&lt;br /&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Amount&lt;/span&gt;: %1</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9650"/>
+        <location filename="qtdialogs.py" line="9655"/>
         <source>&lt;br /&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Message&lt;/span&gt;: %1</source>
         <translation>&lt;br /&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Message&lt;/span&gt;: %1</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9712"/>
+        <location filename="qtdialogs.py" line="9717"/>
         <source>&lt;i&gt;Copied!&lt;/i&gt;</source>
         <translation>&lt;i&gt;Copied!&lt;/i&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9690"/>
+        <location filename="qtdialogs.py" line="9695"/>
         <source>Hide Buttons &lt;&lt;&lt;</source>
         <translation>Hide Buttons &lt;&lt;&lt;</translation>
     </message>
@@ -6451,72 +6486,72 @@ Message: %1</translation>
 <context>
     <name>DlgRestoreFragged</name>
     <message>
-        <location filename="qtdialogs.py" line="11494"/>
+        <location filename="qtdialogs.py" line="11499"/>
         <source>Restore Wallet from Fragments</source>
         <translation>Restore Wallet from Fragments</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11520"/>
+        <location filename="qtdialogs.py" line="11525"/>
         <source>Input Fragments Below:</source>
         <translation>Input Fragments Below:</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11521"/>
+        <location filename="qtdialogs.py" line="11526"/>
         <source>+Frag</source>
         <translation>+Frag</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11522"/>
+        <location filename="qtdialogs.py" line="11527"/>
         <source>-Frag</source>
         <translation>-Frag</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11526"/>
+        <location filename="qtdialogs.py" line="11531"/>
         <source>Encrypt Restored Wallet</source>
         <translation>Encrypt Restored Wallet</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11535"/>
+        <location filename="qtdialogs.py" line="11540"/>
         <source>Test Backup</source>
         <translation>Test Backup</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11535"/>
+        <location filename="qtdialogs.py" line="11540"/>
         <source>Restore from Fragments</source>
         <translation>Restore from Fragments</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11537"/>
+        <location filename="qtdialogs.py" line="11542"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11585"/>
+        <location filename="qtdialogs.py" line="11590"/>
         <source>Fragments</source>
         <translation>Fragments</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11587"/>
+        <location filename="qtdialogs.py" line="11592"/>
         <source>Advanced Options</source>
         <translation>Advanced Options</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11602"/>
+        <location filename="qtdialogs.py" line="11607"/>
         <source>Restore wallet from fragments</source>
         <translation>Restore wallet from fragments</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11620"/>
+        <location filename="qtdialogs.py" line="11625"/>
         <source>Type Data</source>
         <translation>Type Data</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11621"/>
+        <location filename="qtdialogs.py" line="11626"/>
         <source>Load File</source>
         <translation>Load File</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11622"/>
+        <location filename="qtdialogs.py" line="11627"/>
         <source>Clear</source>
         <translation>Clear</translation>
     </message>
@@ -6531,52 +6566,52 @@ Message: %1</translation>
         <translation type="obsolete">Wallet Fragments (*.frag)</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11697"/>
+        <location filename="qtdialogs.py" line="11702"/>
         <source>File Does Not Exist</source>
         <translation>File Does Not Exist</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11731"/>
+        <location filename="qtdialogs.py" line="11736"/>
         <source>Fragment Error</source>
         <translation>Fragment Error</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11764"/>
+        <location filename="qtdialogs.py" line="11769"/>
         <source>&lt;b&gt;&lt;u&gt;Wallet Being Restored:&lt;/u&gt;&lt;/b&gt;</source>
         <translation>&lt;b&gt;&lt;u&gt;Wallet Being Restored:&lt;/u&gt;&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11766"/>
+        <location filename="qtdialogs.py" line="11771"/>
         <source>&lt;b&gt;Frags Needed:&lt;/b&gt; %1</source>
         <translation>&lt;b&gt;Frags Needed:&lt;/b&gt; %1</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11767"/>
+        <location filename="qtdialogs.py" line="11772"/>
         <source>&lt;b&gt;Wallet:&lt;/b&gt; %1</source>
         <translation>&lt;b&gt;Wallet:&lt;/b&gt; %1</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11768"/>
+        <location filename="qtdialogs.py" line="11773"/>
         <source>&lt;b&gt;Fragments:&lt;/b&gt; %1</source>
         <translation>&lt;b&gt;Fragments:&lt;/b&gt; %1</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11810"/>
+        <location filename="qtdialogs.py" line="11815"/>
         <source>Mixed fragment types</source>
         <translation>Mixed fragment types</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11841"/>
+        <location filename="qtdialogs.py" line="11846"/>
         <source>Duplicate Fragment</source>
         <translation>Duplicate Fragment</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11878"/>
+        <location filename="qtdialogs.py" line="11883"/>
         <source>Invalid Target Compute Time</source>
         <translation>Invalid Target Compute Time</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11878"/>
+        <location filename="qtdialogs.py" line="11883"/>
         <source>You entered Target Compute Time incorrectly.
 
 Enter: &lt;Number&gt; (ms, s)</source>
@@ -6585,32 +6620,32 @@ Enter: &lt;Number&gt; (ms, s)</source>
 Enter: &lt;Number&gt; (ms, s)</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11882"/>
+        <location filename="qtdialogs.py" line="11887"/>
         <source>Invalid Max Memory Usage</source>
         <translation>Invalid Max Memory Usage</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11953"/>
+        <location filename="qtdialogs.py" line="11958"/>
         <source>Verify Wallet ID</source>
         <translation>Verify Wallet ID</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11969"/>
+        <location filename="qtdialogs.py" line="11974"/>
         <source>Cannot Encrypt</source>
         <translation>Cannot Encrypt</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="12011"/>
+        <location filename="qtdialogs.py" line="12016"/>
         <source>Computing New Addresses</source>
         <translation>Computing New Addresses</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11830"/>
+        <location filename="qtdialogs.py" line="11835"/>
         <source>Multiple Wallets</source>
         <translation>Multiple Wallets</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11882"/>
+        <location filename="qtdialogs.py" line="11887"/>
         <source>You entered Max Memory Usage incorrectly.
 
 Enter: &lt;Number&gt; (kB, MB)</source>
@@ -6619,62 +6654,62 @@ Enter: &lt;Number&gt; (kB, MB)</source>
 Enter: &lt;Number&gt; (kB, MB)</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11491"/>
+        <location filename="qtdialogs.py" line="11496"/>
         <source>&lt;font color=&quot;blue&quot; size=&quot;4&quot;&gt;Testing a Fragmented Backup&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11505"/>
+        <location filename="qtdialogs.py" line="11510"/>
         <source>&lt;br&gt;&lt;br&gt;&lt;b&gt;For testing purposes, you may enter more fragments than needed and Armory will test all subsets of the entered fragments to verify that each one still recovers the wallet successfully.&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11697"/>
+        <location filename="qtdialogs.py" line="11702"/>
         <source>The file you select somehow does not exist...? &lt;br&gt;&lt;br&gt;%1&lt;br&gt;&lt;br&gt; Try a different file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11731"/>
+        <location filename="qtdialogs.py" line="11736"/>
         <source>There was an unfixable error in the fragment file: &lt;br&gt;&lt;br&gt; File: %1 &lt;br&gt; Line: %2 &lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11759"/>
+        <location filename="qtdialogs.py" line="11764"/>
         <source>&lt;b&gt;Start entering fragments into the table to left...&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11810"/>
+        <location filename="qtdialogs.py" line="11815"/>
         <source>You entered a fragment for a different wallet type.  Please check that all fragments are for the same wallet, of the same version, and require the same number of fragments.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11830"/>
+        <location filename="qtdialogs.py" line="11835"/>
         <source>The fragment you just entered is actually for a different wallet than the previous fragments you entered.  Please double-check that all the fragments you are entering belong to the same wallet and have the &quot;number of needed fragments&quot; (M-value, in M-of-N).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11841"/>
+        <location filename="qtdialogs.py" line="11846"/>
         <source>You just input fragment #%1, but that fragment has already been entered!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11969"/>
+        <location filename="qtdialogs.py" line="11974"/>
         <source>You requested your restored wallet be encrypted, but no valid passphrase was supplied.  Aborting wallet recovery.</source>
         <translation type="unfinished">You requested your restored wallet be encrypted, but no valid passphrase was supplied.  Aborting wallet recovery.</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11496"/>
+        <location filename="qtdialogs.py" line="11501"/>
         <source>&lt;b&gt;&lt;u&gt;%1&lt;/u&gt;&lt;/b&gt; &lt;br&gt;&lt;br&gt;Use this form to enter all the fragments to be restored.  Fragments can be stored on a mix of paper printouts, and saved files. If any of the fragments require a SecurePrintu200bu2122 code, you will only have to enter it once, since that code is the same for all fragments of any given wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11544"/>
+        <location filename="qtdialogs.py" line="11549"/>
         <source>SecurePrintu200bu2122 Code:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11953"/>
+        <location filename="qtdialogs.py" line="11958"/>
         <source>The data you entered corresponds to a wallet with the ID:&lt;blockquote&gt;&lt;b&gt;{%1}&lt;/b&gt;&lt;/blockquote&gt;Does this ID match the &quot;Wallet Unique ID&quot; printed on your paper backup? If not, click &quot;No&quot; and reenter key and chain-code data again.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6682,87 +6717,87 @@ Enter: &lt;Number&gt; (kB, MB)</translation>
 <context>
     <name>DlgRestoreSingle</name>
     <message>
-        <location filename="qtdialogs.py" line="10940"/>
+        <location filename="qtdialogs.py" line="10945"/>
         <source>&lt;b&gt;Backup Type:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Backup Type:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10942"/>
+        <location filename="qtdialogs.py" line="10947"/>
         <source>Version 1.35 (4 lines)</source>
         <translation>Version 1.35 (4 lines)</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10943"/>
+        <location filename="qtdialogs.py" line="10948"/>
         <source>Version 1.35a (4 lines Unencrypted)</source>
         <translation>Version 1.35a (4 lines Unencrypted)</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10945"/>
+        <location filename="qtdialogs.py" line="10950"/>
         <source>Version 1.35c (2 lines Unencrypted)</source>
         <translation>Version 1.35c (2 lines Unencrypted)</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10971"/>
+        <location filename="qtdialogs.py" line="10976"/>
         <source>Root Key:</source>
         <translation>Root Key:</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10971"/>
+        <location filename="qtdialogs.py" line="10976"/>
         <source>Chaincode:</source>
         <translation>Chaincode:</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10988"/>
+        <location filename="qtdialogs.py" line="10993"/>
         <source>Test Backup</source>
         <translation>Test Backup</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10988"/>
+        <location filename="qtdialogs.py" line="10993"/>
         <source>Restore Wallet</source>
         <translation>Restore Wallet</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10991"/>
+        <location filename="qtdialogs.py" line="10996"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10998"/>
+        <location filename="qtdialogs.py" line="11003"/>
         <source>Encrypt Wallet</source>
         <translation>Encrypt Wallet</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11004"/>
+        <location filename="qtdialogs.py" line="11009"/>
         <source>Backup</source>
         <translation>Backup</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11006"/>
+        <location filename="qtdialogs.py" line="11011"/>
         <source>Advanced Options</source>
         <translation>Advanced Options</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11020"/>
+        <location filename="qtdialogs.py" line="11025"/>
         <source>Test Single-Sheet Backup</source>
         <translation>Test Single-Sheet Backup</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11022"/>
+        <location filename="qtdialogs.py" line="11027"/>
         <source>Restore Single-Sheet Backup</source>
         <translation>Restore Single-Sheet Backup</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11079"/>
+        <location filename="qtdialogs.py" line="11084"/>
         <source>Invalid Data</source>
         <translation>Invalid Data</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11092"/>
+        <location filename="qtdialogs.py" line="11097"/>
         <source>Invalid Target Compute Time</source>
         <translation>Invalid Target Compute Time</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11092"/>
+        <location filename="qtdialogs.py" line="11097"/>
         <source>You entered Target Compute Time incorrectly.
 
 Enter: &lt;Number&gt; (ms, s)</source>
@@ -6771,37 +6806,37 @@ Enter: &lt;Number&gt; (ms, s)</source>
 Enter: &lt;Number&gt; (ms, s)</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11096"/>
+        <location filename="qtdialogs.py" line="11101"/>
         <source>Invalid Max Memory Usage</source>
         <translation>Invalid Max Memory Usage</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11108"/>
+        <location filename="qtdialogs.py" line="11113"/>
         <source>Errors Corrected</source>
         <translation>Errors Corrected</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11157"/>
+        <location filename="qtdialogs.py" line="11162"/>
         <source>Verify Wallet ID</source>
         <translation>Verify Wallet ID</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11172"/>
+        <location filename="qtdialogs.py" line="11177"/>
         <source>Cannot Encrypt</source>
         <translation>Cannot Encrypt</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11172"/>
+        <location filename="qtdialogs.py" line="11177"/>
         <source>You requested your restored wallet be encrypted, but no valid passphrase was supplied.  Aborting wallet recovery.</source>
         <translation>You requested your restored wallet be encrypted, but no valid passphrase was supplied.  Aborting wallet recovery.</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11216"/>
+        <location filename="qtdialogs.py" line="11221"/>
         <source>Computing New Addresses</source>
         <translation>Computing New Addresses</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11096"/>
+        <location filename="qtdialogs.py" line="11101"/>
         <source>You entered Max Memory Usage incorrectly.
 
 Enter: &lt;Number&gt; (kB, MB)</source>
@@ -6810,7 +6845,7 @@ Enter: &lt;Number&gt; (kB, MB)</source>
 Enter: &lt;Number&gt; (kB, MB)</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11157"/>
+        <location filename="qtdialogs.py" line="11162"/>
         <source>The data you entered corresponds to a wallet with a wallet ID: 
 
 %1
@@ -6819,37 +6854,37 @@ Does this ID match the &quot;Wallet Unique ID&quot; printed on your paper backup
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10924"/>
+        <location filename="qtdialogs.py" line="10929"/>
         <source>&lt;b&gt;&lt;u&gt;&lt;font color=&quot;blue&quot; size=&quot;4&quot;&gt;Test a Paper Backup&lt;/font&gt;&lt;/u&gt;&lt;/b&gt; &lt;br&gt;&lt;br&gt;Use this window to test a single-sheet paper backup.  If your backup includes imported keys, those will not be covered by this test.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10930"/>
+        <location filename="qtdialogs.py" line="10935"/>
         <source>&lt;b&gt;&lt;u&gt;Restore a Wallet from Paper Backup&lt;/u&gt;&lt;/b&gt; &lt;br&gt;&lt;br&gt;Use this window to restore a single-sheet paper backup. If your backup includes extra pages with imported keys, please restore the base wallet first, then double-click the restored wallet and select &quot;Import Private Keys&quot; from the right-hand menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11079"/>
+        <location filename="qtdialogs.py" line="11084"/>
         <source>There is an error in the data you entered that could not be fixed automatically.  Please double-check that you entered the text exactly as it appears on the wallet-backup page.  &lt;br&gt;&lt;br&gt; The error occured on &lt;font color=&quot;red&quot;&gt;line #%1&lt;/font&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11102"/>
+        <location filename="qtdialogs.py" line="11107"/>
         <source>Detected errors in the data you entered. Armory attempted to fix the errors but it is not always right.  Be sure to verify the &quot;Wallet Unique ID&quot; closely on the next window.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10946"/>
+        <location filename="qtdialogs.py" line="10951"/>
         <source>Version 1.35c (2 lines + SecurePrintu200bu2122)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10969"/>
+        <location filename="qtdialogs.py" line="10974"/>
         <source>SecurePrintu200bu2122 Code:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10944"/>
+        <location filename="qtdialogs.py" line="10949"/>
         <source>Version 1.35a (4 lines + SecurePrintu200bu2122)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6857,72 +6892,72 @@ Does this ID match the &quot;Wallet Unique ID&quot; printed on your paper backup
 <context>
     <name>DlgRestoreWOData</name>
     <message>
-        <location filename="qtdialogs.py" line="11267"/>
+        <location filename="qtdialogs.py" line="11272"/>
         <source>Watch-Only Root ID:</source>
         <translation>Watch-Only Root ID:</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11275"/>
+        <location filename="qtdialogs.py" line="11280"/>
         <source>Data:</source>
         <translation>Data:</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11294"/>
+        <location filename="qtdialogs.py" line="11299"/>
         <source>Test Backup</source>
         <translation>Test Backup</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11294"/>
+        <location filename="qtdialogs.py" line="11299"/>
         <source>Restore Wallet</source>
         <translation>Restore Wallet</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11295"/>
+        <location filename="qtdialogs.py" line="11300"/>
         <source>Load From Text File</source>
         <translation>Load From Text File</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11297"/>
+        <location filename="qtdialogs.py" line="11302"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11324"/>
+        <location filename="qtdialogs.py" line="11329"/>
         <source>Test Watch-Only Wallet Backup</source>
         <translation>Test Watch-Only Wallet Backup</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11326"/>
+        <location filename="qtdialogs.py" line="11331"/>
         <source>Restore Watch-Only Wallet Backup</source>
         <translation>Restore Watch-Only Wallet Backup</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11336"/>
+        <location filename="qtdialogs.py" line="11341"/>
         <source>Import Wallet File</source>
         <translation>Import Wallet File</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11336"/>
+        <location filename="qtdialogs.py" line="11341"/>
         <source>Root Pubkey Text Files (*.rootpubkey)</source>
         <translation>Root Pubkey Text Files (*.rootpubkey)</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11419"/>
+        <location filename="qtdialogs.py" line="11424"/>
         <source>Invalid Data</source>
         <translation>Invalid Data</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11452"/>
+        <location filename="qtdialogs.py" line="11457"/>
         <source>Wallet Already Exists</source>
         <translation>Wallet Already Exists</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11459"/>
+        <location filename="qtdialogs.py" line="11464"/>
         <source>Verify Wallet ID</source>
         <translation>Verify Wallet ID</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11459"/>
+        <location filename="qtdialogs.py" line="11464"/>
         <source>The data you entered corresponds to a wallet with a wallet ID: 
 
 <byte value="x9"/>%1
@@ -6935,32 +6970,32 @@ Does this ID match the &quot;Wallet Unique ID&quot; you intend to restore? If no
 Does this ID match the &quot;Wallet Unique ID&quot; you intend to restore? If not, click &quot;No&quot; and enter the key and chain-code data again.</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11474"/>
+        <location filename="qtdialogs.py" line="11479"/>
         <source>Computing New Addresses</source>
         <translation>Computing New Addresses</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11252"/>
+        <location filename="qtdialogs.py" line="11257"/>
         <source>&lt;b&gt;&lt;u&gt;&lt;font color=&quot;blue&quot; size=&quot;4&quot;&gt;Test a Watch-Only Wallet Restore &lt;/font&gt;&lt;/u&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Use this window to test the restoration of a watch-only wallet using the wallet&apos;s data. You can either type the data on a root data printout or import the data from a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11259"/>
+        <location filename="qtdialogs.py" line="11264"/>
         <source>&lt;b&gt;&lt;u&gt;&lt;font color=&quot;blue&quot; size=&quot;4&quot;&gt;Restore a Watch-Only Wallet &lt;/font&gt;&lt;/u&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt;Use this window to restore a watch-only wallet using the wallet&apos;s data. You can either type the data on a root data printout or import the data from a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11389"/>
+        <location filename="qtdialogs.py" line="11394"/>
         <source>There is an error in the root ID you entered that could not be fixed automatically.  Please double-check that you entered the text exactly as it appears on the wallet-backup page.&lt;br&gt;&lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11419"/>
+        <location filename="qtdialogs.py" line="11424"/>
         <source>There is an error in the root data you entered that could not be fixed automatically.  Please double-check that you entered the text exactly as it appears on the wallet-backup page.  &lt;br&gt;&lt;br&gt;The error occured on &lt;font color=&quot;red&quot;&gt;line #%1&lt;/font&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="11452"/>
+        <location filename="qtdialogs.py" line="11457"/>
         <source>The wallet already exists and will not be replaced.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6968,52 +7003,52 @@ Does this ID match the &quot;Wallet Unique ID&quot; you intend to restore? If no
 <context>
     <name>DlgSelectMultiSigOption</name>
     <message>
-        <location filename="MultiSigDialogs.py" line="3842"/>
+        <location filename="MultiSigDialogs.py" line="3837"/>
         <source>Create/Manage lockboxes</source>
         <translation>Create/Manage lockboxes</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3844"/>
+        <location filename="MultiSigDialogs.py" line="3839"/>
         <source>Fund a lockbox</source>
         <translation>Fund a lockbox</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3845"/>
+        <location filename="MultiSigDialogs.py" line="3840"/>
         <source>Spend from a lockbox</source>
         <translation>Spend from a lockbox</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3932"/>
+        <location filename="MultiSigDialogs.py" line="3927"/>
         <source>Done</source>
         <translation>Done</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3943"/>
+        <location filename="MultiSigDialogs.py" line="3938"/>
         <source>Multi-Sig Lockboxes</source>
         <translation>Multi-Sig Lockboxes</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3847"/>
+        <location filename="MultiSigDialogs.py" line="3842"/>
         <source>&lt;font color=&quot;%1&quot; size=5&gt;&lt;b&gt;Multi-Sig Lockboxes [EXPERIMENTAL]&lt;/b&gt;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3852"/>
+        <location filename="MultiSigDialogs.py" line="3847"/>
         <source>The buttons below link you to all the functionality needed to create, fund and spend from multi-sig &quot;lockboxes.&quot;  This includes turning multiple wallets into a multi-factor lock-box for your personal coins, or can be used for escrow between multiple parties, using the Bitcoin network itself to hold the escrow.&lt;br&gt;&lt;br&gt;&lt;b&gt;&lt;u&gt;IMPORTANT:&lt;/u&gt;&lt;/b&gt;  If you are using an lockbox that requires being funded by multiple parties simultaneously, you should &lt;b&gt;&lt;u&gt;not&lt;/u&gt; &lt;/b&gt; use regular transactions to do the funding. You should use the third button labeled &quot;Fund a multi-sig lockbox&quot; to collect funding promises into a single transaction, to limit the ability of any party to scam you.  Read more about it by clicking [NO LINK YET]  (if the above doesn&apos;t hold, you can use the regular &quot;Send Bitcoins&quot; dialog to fund the lockbox).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3870"/>
+        <location filename="MultiSigDialogs.py" line="3865"/>
         <source>Collect public keys to create an &quot;address&quot; that can be used to send funds to the multi-sig container</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3876"/>
+        <location filename="MultiSigDialogs.py" line="3871"/>
         <source>Send money to an lockbox simultaneously with other parties involved in the lockbox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3879"/>
+        <location filename="MultiSigDialogs.py" line="3874"/>
         <source>Collect signatures to authorize transferring money out of a multi-sig lockbox</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7021,57 +7056,57 @@ Does this ID match the &quot;Wallet Unique ID&quot; you intend to restore? If no
 <context>
     <name>DlgSelectPublicKey</name>
     <message>
-        <location filename="MultiSigDialogs.py" line="2171"/>
+        <location filename="MultiSigDialogs.py" line="2166"/>
         <source>Select Public Key:</source>
         <translation>Select Public Key:</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="2172"/>
+        <location filename="MultiSigDialogs.py" line="2167"/>
         <source>Notes or Contact Info:</source>
         <translation>Notes or Contact Info:</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="2218"/>
+        <location filename="MultiSigDialogs.py" line="2213"/>
         <source>Continue</source>
         <translation>Continue</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="2219"/>
+        <location filename="MultiSigDialogs.py" line="2214"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="2233"/>
+        <location filename="MultiSigDialogs.py" line="2228"/>
         <source>Select Public Key for Lockbox</source>
         <translation>Select Public Key for Lockbox</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="2251"/>
+        <location filename="MultiSigDialogs.py" line="2246"/>
         <source>Invalid Public Key</source>
         <translation>Invalid Public Key</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="2272"/>
+        <location filename="MultiSigDialogs.py" line="2267"/>
         <source>Export Public Key for Lockbox</source>
         <translation>Export Public Key for Lockbox</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="2144"/>
+        <location filename="MultiSigDialogs.py" line="2139"/>
         <source>&lt;center&gt;&lt;font size=4&gt;&lt;b&gt;&lt;u&gt;Select Public Key for Lockbox Creation&lt;/u&gt;&lt;/b&gt;&lt;/font&gt;&lt;/center&gt; &lt;br&gt;Lockbox creation requires &lt;b&gt;public keys&lt;/b&gt; not the regular Bitcoin addresses most users are accustomed to.  A public key is much longer than a regular bitcoin address, usually starting with &quot;02&quot;, &quot;03&quot; or &quot;04&quot;.  Once you have selected a public key, send it to the lockbox organizer (person or device).  The organizer will create the lockbox which then must be imported by all devices that will track the funds and/or sign transactions. &lt;br&gt;&lt;br&gt;It is recommended that you select a &lt;i&gt;new&lt;/i&gt; key from one of your wallets that will not be used for any other purpose. You &lt;u&gt;can&lt;/u&gt; use a public key from a watching-only wallet (for an offline wallet), but you will have to sign the transactions the same way you would a regular offline transaction.  Additionally the offline computer will need to have Armory version 0.92 or later. &lt;br&gt;&lt;br&gt;&lt;b&gt;&lt;font color=&quot;%1&quot;&gt;BACKUP WARNING&lt;/font&gt;&lt;/b&gt;: It is highly recommended that you select a public key from a wallet for which you have good backups!  If you are creating a lockbox requiring the same number of signatures as there are authorities (such as 2-of-2 or 3-of-3), the loss of the wallet &lt;u&gt;will&lt;/u&gt; lead to loss of lockbox funds!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="2173"/>
+        <location filename="MultiSigDialogs.py" line="2168"/>
         <source>If multiple people will be part of this lockbox, you should specify name and contact info in the box below, which will be available to all parties that import the finalized lockbox. &lt;br&gt;&lt;br&gt;If this lockbox will be shared among devices you own (such as for personal savings), specify information that helps you identify which device is associated with this public key.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="2251"/>
+        <location filename="MultiSigDialogs.py" line="2246"/>
         <source>You must enter a public key into the box, &lt;b&gt;not&lt;/b&gt; a regular Bitcoin address that most users are accustomed to.  A public key is much longer than a Bitcoin address, and always starts with &quot;02&quot;, &quot;03&quot; or &quot;04&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="2273"/>
+        <location filename="MultiSigDialogs.py" line="2268"/>
         <source>The text below includes both the public key and the notes/contact info you entered.  Please send this text to the organizer (person or device) to be used to create the lockbox.  This data is &lt;u&gt;not&lt;/u&gt; sensitive and it is appropriate be sent via email or transferred via USB storage. </source>
         <translation type="unfinished"></translation>
     </message>
@@ -7079,7 +7114,7 @@ Does this ID match the &quot;Wallet Unique ID&quot; you intend to restore? If no
 <context>
     <name>DlgSendBitcoins</name>
     <message>
-        <location filename="qtdialogs.py" line="4568"/>
+        <location filename="qtdialogs.py" line="4573"/>
         <source>Send Bitcoins</source>
         <translation>Send Bitcoins</translation>
     </message>
@@ -7087,7 +7122,7 @@ Does this ID match the &quot;Wallet Unique ID&quot; you intend to restore? If no
 <context>
     <name>DlgSetComment</name>
     <message>
-        <location filename="qtdialogs.py" line="3867"/>
+        <location filename="qtdialogs.py" line="3872"/>
         <source>Modify Comment</source>
         <translation>Modify Comment</translation>
     </message>
@@ -7178,32 +7213,32 @@ Does this ID match the &quot;Wallet Unique ID&quot; you intend to restore? If no
 <context>
     <name>DlgSettings</name>
     <message>
-        <location filename="qtdialogs.py" line="8309"/>
+        <location filename="qtdialogs.py" line="8314"/>
         <source>Bitcoin Core/bitcoind management is not available on Mac/OSX</source>
         <translation>Bitcoin Core/bitcoind management is not available on Mac/OSX</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8319"/>
+        <location filename="qtdialogs.py" line="8324"/>
         <source>&lt;b&gt;Bitcoin Software Management&lt;/b&gt;&lt;br&gt;&lt;br&gt;By default, Armory will manage the Bitcoin engine/software in the background.  You can choose to manage it yourself, or tell Armory about non-standard installation configuration.</source>
         <translation>&lt;b&gt;Bitcoin Software Management&lt;/b&gt;&lt;br&gt;&lt;br&gt;By default, Armory will manage the Bitcoin engine/software in the background.  You can choose to manage it yourself, or tell Armory about non-standard installation configuration.</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8332"/>
+        <location filename="qtdialogs.py" line="8337"/>
         <source>Bitcoin Install Dir:</source>
         <translation>Bitcoin Install Dir:</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8333"/>
+        <location filename="qtdialogs.py" line="8338"/>
         <source>Bitcoin Home Dir:</source>
         <translation>Bitcoin Home Dir:</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8334"/>
+        <location filename="qtdialogs.py" line="8339"/>
         <source>Leave blank to have Armory search default locations for your OS</source>
         <translation>Leave blank to have Armory search default locations for your OS</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8336"/>
+        <location filename="qtdialogs.py" line="8341"/>
         <source>Leave blank to use default datadir (%1)</source>
         <translation>Leave blank to use default datadir (%1)</translation>
     </message>
@@ -7213,142 +7248,142 @@ Does this ID match the &quot;Wallet Unique ID&quot; you intend to restore? If no
         <translation type="obsolete">&lt;b&gt;Privacy Settings&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8368"/>
+        <location filename="qtdialogs.py" line="8373"/>
         <source>Set Armory as Default</source>
         <translation>Set Armory as Default</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8378"/>
+        <location filename="qtdialogs.py" line="8383"/>
         <source>Registered</source>
         <translation>Registered</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8399"/>
+        <location filename="qtdialogs.py" line="8404"/>
         <source>Minimize to system tray on open</source>
         <translation>Minimize to system tray on open</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8404"/>
+        <location filename="qtdialogs.py" line="8409"/>
         <source>Minimize to system tray on close</source>
         <translation>Minimize to system tray on close</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8417"/>
+        <location filename="qtdialogs.py" line="8422"/>
         <source>&lt;b&gt;Enable notifications from the system-tray:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Enable notifications from the system-tray:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8418"/>
+        <location filename="qtdialogs.py" line="8423"/>
         <source>Bitcoins Received</source>
         <translation>Bitcoins Received</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8419"/>
+        <location filename="qtdialogs.py" line="8424"/>
         <source>Bitcoins Sent</source>
         <translation>Bitcoins Sent</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8420"/>
+        <location filename="qtdialogs.py" line="8425"/>
         <source>Bitcoin Core/bitcoind disconnected</source>
         <translation>Bitcoin Core/bitcoind disconnected</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8421"/>
+        <location filename="qtdialogs.py" line="8426"/>
         <source>Bitcoin Core/bitcoind reconnected</source>
         <translation>Bitcoin Core/bitcoind reconnected</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8425"/>
+        <location filename="qtdialogs.py" line="8430"/>
         <source>&lt;b&gt;Sorry!  Notifications are not available on your version of OS X.&lt;/b&gt;</source>
         <translation>&lt;b&gt;Sorry!  Notifications are not available on your version of OS X.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8450"/>
+        <location filename="qtdialogs.py" line="8455"/>
         <source>&lt;b&gt;Preferred Date Format&lt;b&gt;:&lt;br&gt;</source>
         <translation>&lt;b&gt;Preferred Date Format&lt;b&gt;:&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8451"/>
+        <location filename="qtdialogs.py" line="8456"/>
         <source>You can specify how you would like dates to be displayed using percent-codes to represent components of the date.  The mouseover text of the &quot;(?)&quot; icon shows the most commonly used codes/symbols.  The text next to it shows how &quot;%1&quot; would be shown with the specified format.</source>
         <translation>You can specify how you would like dates to be displayed using percent-codes to represent components of the date.  The mouseover text of the &quot;(?)&quot; icon shows the most commonly used codes/symbols.  The text next to it shows how &quot;%1&quot; would be shown with the specified format.</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8462"/>
+        <location filename="qtdialogs.py" line="8467"/>
         <source>Use any of the following symbols:&lt;br&gt;</source>
         <translation>Use any of the following symbols:&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8476"/>
+        <location filename="qtdialogs.py" line="8481"/>
         <source>Reset to Default</source>
         <translation>Reset to Default</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8494"/>
+        <location filename="qtdialogs.py" line="8499"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8495"/>
+        <location filename="qtdialogs.py" line="8500"/>
         <source>Save</source>
         <translation>Save</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8516"/>
+        <location filename="qtdialogs.py" line="8521"/>
         <source>&lt;b&gt;Armory user mode:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Armory user mode:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8524"/>
+        <location filename="qtdialogs.py" line="8529"/>
         <source>&lt;b&gt;Preferred Language&lt;b&gt;:&lt;br&gt;</source>
         <translation>&lt;b&gt;Preferred Language&lt;b&gt;:&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8525"/>
+        <location filename="qtdialogs.py" line="8530"/>
         <source>Specify which language you would like Armory to be displayed in.</source>
         <translation>Specify which language you would like Armory to be displayed in.</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8620"/>
+        <location filename="qtdialogs.py" line="8625"/>
         <source>General</source>
         <translation>General</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8641"/>
+        <location filename="qtdialogs.py" line="8646"/>
         <source>Armory Settings</source>
         <translation>Armory Settings</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8680"/>
+        <location filename="qtdialogs.py" line="8685"/>
         <source>&lt;b&gt;Fee&lt;br&gt;&lt;/b&gt;</source>
         <translation>&lt;b&gt;Fee&lt;br&gt;&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8682"/>
+        <location filename="qtdialogs.py" line="8687"/>
         <source>Auto fee/byte</source>
         <translation>Auto fee/byte</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8704"/>
+        <location filename="qtdialogs.py" line="8709"/>
         <source>Manual fee/byte</source>
         <translation>Manual fee/byte</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8709"/>
+        <location filename="qtdialogs.py" line="8714"/>
         <source>Flat fee</source>
         <translation>Flat fee</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8714"/>
+        <location filename="qtdialogs.py" line="8719"/>
         <source>Auto-adjust fee/byte for better privacy</source>
         <translation>Auto-adjust fee/byte for better privacy</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8785"/>
+        <location filename="qtdialogs.py" line="8790"/>
         <source>&lt;b&gt;Change Address Type&lt;br&gt;&lt;/b&gt;</source>
         <translation>&lt;b&gt;Change Address Type&lt;br&gt;&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8787"/>
+        <location filename="qtdialogs.py" line="8792"/>
         <source>Auto change</source>
         <translation>Auto change</translation>
     </message>
@@ -7368,17 +7403,17 @@ Does this ID match the &quot;Wallet Unique ID&quot; you intend to restore? If no
         <translation type="obsolete">Force P2SH-P2WPKH</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8869"/>
+        <location filename="qtdialogs.py" line="8874"/>
         <source>Invalid Path</source>
         <translation>Invalid Path</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8852"/>
+        <location filename="qtdialogs.py" line="8857"/>
         <source>The path you specified for the Bitcoin software installation does not exist.  Please select the directory that contains %1 or leave it blank to have Armory search the default location for your operating system</source>
         <translation>The path you specified for the Bitcoin software installation does not exist.  Please select the directory that contains %1 or leave it blank to have Armory search the default location for your operating system</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8869"/>
+        <location filename="qtdialogs.py" line="8874"/>
         <source>The path you specified for the Bitcoin software home directory does not exist.  Only specify this directory if you use a non-standard &quot;-datadir=&quot; option when running Bitcoin Core or bitcoind.  If you leave this field blank, the following path will be used: &lt;br&gt;&lt;br&gt; %1</source>
         <translation>The path you specified for the Bitcoin software home directory does not exist.  Only specify this directory if you use a non-standard &quot;-datadir=&quot; option when running Bitcoin Core or bitcoind.  If you leave this field blank, the following path will be used: &lt;br&gt;&lt;br&gt; %1</translation>
     </message>
@@ -7393,27 +7428,27 @@ Does this ID match the &quot;Wallet Unique ID&quot; you intend to restore? If no
         <translation type="obsolete">The default fee specified could not be understood.  Please specify in BTC with no more than 8 decimal places.</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8937"/>
+        <location filename="qtdialogs.py" line="8942"/>
         <source>&quot;Standard&quot; is for users that only need the core set of features to send and receive bitcoins.  This includes maintaining multiple wallets, wallet encryption, and the ability to make backups of your wallets.</source>
         <translation>&quot;Standard&quot; is for users that only need the core set of features to send and receive bitcoins.  This includes maintaining multiple wallets, wallet encryption, and the ability to make backups of your wallets.</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8943"/>
+        <location filename="qtdialogs.py" line="8948"/>
         <source>&quot;Advanced&quot; mode provides extra Armory features such as private key importing &amp; sweeping, message signing, and the offline wallet interface.  But, with advanced features come advanced risks...</source>
         <translation>&quot;Advanced&quot; mode provides extra Armory features such as private key importing &amp; sweeping, message signing, and the offline wallet interface.  But, with advanced features come advanced risks...</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8949"/>
+        <location filename="qtdialogs.py" line="8954"/>
         <source>&quot;Expert&quot; mode is similar to &quot;Advanced&quot; but includes access to lower-level info about transactions, scripts, keys and network protocol.  Most extra functionality is geared towards Bitcoin software developers.</source>
         <translation>&quot;Expert&quot; mode is similar to &quot;Advanced&quot; but includes access to lower-level info about transactions, scripts, keys and network protocol.  Most extra functionality is geared towards Bitcoin software developers.</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8960"/>
+        <location filename="qtdialogs.py" line="8965"/>
         <source>Sample: </source>
         <translation>Sample: </translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8963"/>
+        <location filename="qtdialogs.py" line="8968"/>
         <source>Sample: [[invalid date format]]</source>
         <translation>Sample: [[invalid date format]]</translation>
     </message>
@@ -7428,27 +7463,27 @@ Does this ID match the &quot;Wallet Unique ID&quot; you intend to restore? If no
         <translation type="obsolete">Fee and Change Settings</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8692"/>
+        <location filename="qtdialogs.py" line="8697"/>
         <source>Blocks to confirm: %1</source>
         <translation>Blocks to confirm: %1</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8503"/>
+        <location filename="qtdialogs.py" line="8508"/>
         <source>Standard</source>
         <translation>Standard</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8504"/>
+        <location filename="qtdialogs.py" line="8509"/>
         <source>Advanced</source>
         <translation>Advanced</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8505"/>
+        <location filename="qtdialogs.py" line="8510"/>
         <source>Expert</source>
         <translation>Expert</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8789"/>
+        <location filename="qtdialogs.py" line="8794"/>
         <source>Change address type will match the address type of recipient addresses. &lt;br&gt;Favors P2SH when recipients are heterogenous. &lt;br&gt;Will create nested SegWit change if inputs are SegWit and recipient are P2SH. &lt;br&gt;&lt;br&gt;&lt;b&gt;Pre 0.96 Armory cannot spend from P2SH address types&lt;/b&gt;</source>
         <translation>Change address type will match the address type of recipient addresses. &lt;br&gt;Favors P2SH when recipients are heterogenous. &lt;br&gt;Will create nested SegWit change if inputs are SegWit and recipient are P2SH. &lt;br&gt;&lt;br&gt;&lt;b&gt;Pre 0.96 Armory cannot spend from P2SH address types&lt;/b&gt;</translation>
     </message>
@@ -7458,67 +7493,67 @@ Does this ID match the &quot;Wallet Unique ID&quot; you intend to restore? If no
         <translation type="obsolete">Defaults back to P2SH-P2PK if SegWit is not enabled</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8298"/>
+        <location filename="qtdialogs.py" line="8303"/>
         <source>Let Armory run Bitcoin Core/bitcoind in the background</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8362"/>
+        <location filename="qtdialogs.py" line="8367"/>
         <source>&lt;b&gt;Set Armory as default URL handler&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8363"/>
+        <location filename="qtdialogs.py" line="8368"/>
         <source>Set Armory to be the default when you click on &quot;bitcoin:&quot; links in your browser or in emails. You can test if your operating system is supported by clicking on a &quot;bitcoin:&quot; link right after clicking this button.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8371"/>
+        <location filename="qtdialogs.py" line="8376"/>
         <source>Check whether Armory is the default handler at startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8378"/>
+        <location filename="qtdialogs.py" line="8383"/>
         <source>Armory just attempted to register itself to handle &quot;bitcoin:&quot; links, but this does not work on all operating systems.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8386"/>
+        <location filename="qtdialogs.py" line="8391"/>
         <source>&lt;b&gt;Minimize to System Tray&lt;/b&gt; &lt;br&gt;You can have Armory automatically minimize itself to your system tray on open or close.  Armory will stay open but run in the background, and you will still receive notifications.  Access Armory through the icon on your system tray. &lt;br&gt;&lt;br&gt;If you select &quot;Minimize on close&quot;, the &apos;x&apos; on the top window bar will minimize Armory instead of exiting the application.  You can always use &lt;i&gt;&quot;File&quot;&lt;/i&gt; -&gt; &lt;i&gt;&quot;Quit Armory&quot;&lt;/i&gt; to actually close it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8700"/>
+        <location filename="qtdialogs.py" line="8705"/>
         <source>Fetch fee/byte from local Bitcoin node. Defaults to manual fee/byte on failure.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8707"/>
+        <location filename="qtdialogs.py" line="8712"/>
         <source>Values in satoshis/byte</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8712"/>
+        <location filename="qtdialogs.py" line="8717"/>
         <source>Values in BTC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8716"/>
+        <location filename="qtdialogs.py" line="8721"/>
         <source>Auto-adjust fee may increase your total fee using the selected fee/byte rate as its basis in an attempt to align the amount of digits after the decimal point between your spend values and change value.&lt;br&gt;&lt;br&gt;The purpose of this obfuscation technique is to make the change output less obvious. &lt;br&gt;&lt;br&gt;The auto-adjust fee feature only applies to fee/byte options and does not inflate your fee by more that 10% of its original value.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8627"/>
+        <location filename="qtdialogs.py" line="8632"/>
         <source>Fee and Address Types</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8801"/>
+        <location filename="qtdialogs.py" line="8806"/>
         <source>Force a script type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8823"/>
+        <location filename="qtdialogs.py" line="8828"/>
         <source>&lt;b&gt;Preferred Receive Address Type&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7526,112 +7561,112 @@ Does this ID match the &quot;Wallet Unique ID&quot; you intend to restore? If no
 <context>
     <name>DlgShowKeyList</name>
     <message>
-        <location filename="qtdialogs.py" line="4852"/>
+        <location filename="qtdialogs.py" line="4857"/>
         <source>Address String</source>
         <translation>Address String</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4853"/>
+        <location filename="qtdialogs.py" line="4858"/>
         <source>Hash160</source>
         <translation>Hash160</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4854"/>
+        <location filename="qtdialogs.py" line="4859"/>
         <source>Private Key (Encrypted)</source>
         <translation>Private Key (Encrypted)</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4855"/>
+        <location filename="qtdialogs.py" line="4860"/>
         <source>Private Key (Plain Hex)</source>
         <translation>Private Key (Plain Hex)</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4856"/>
+        <location filename="qtdialogs.py" line="4861"/>
         <source>Private Key (Plain Base58)</source>
         <translation>Private Key (Plain Base58)</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4857"/>
+        <location filename="qtdialogs.py" line="4862"/>
         <source>Public Key (BE)</source>
         <translation>Public Key (BE)</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4858"/>
+        <location filename="qtdialogs.py" line="4863"/>
         <source>Chain Index</source>
         <translation>Chain Index</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4876"/>
+        <location filename="qtdialogs.py" line="4881"/>
         <source>Imported Addresses Only</source>
         <translation>Imported Addresses Only</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4877"/>
+        <location filename="qtdialogs.py" line="4882"/>
         <source>Include Unused (Address Pool)</source>
         <translation>Include Unused (Address Pool)</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4878"/>
+        <location filename="qtdialogs.py" line="4883"/>
         <source>Include Paper Backup Root</source>
         <translation>Include Paper Backup Root</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4879"/>
+        <location filename="qtdialogs.py" line="4884"/>
         <source>Omit spaces in key data</source>
         <translation>Omit spaces in key data</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4917"/>
+        <location filename="qtdialogs.py" line="4922"/>
         <source>&lt;&lt;&lt; Go Back</source>
         <translation>&lt;&lt;&lt; Go Back</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4918"/>
+        <location filename="qtdialogs.py" line="4923"/>
         <source>Save to File...</source>
         <translation>Save to File...</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4919"/>
+        <location filename="qtdialogs.py" line="4924"/>
         <source>Copy to Clipboard</source>
         <translation>Copy to Clipboard</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4952"/>
+        <location filename="qtdialogs.py" line="4957"/>
         <source>All Wallet Keys</source>
         <translation>All Wallet Keys</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5057"/>
+        <location filename="qtdialogs.py" line="5062"/>
         <source>Plaintext Private Keys</source>
         <translation>Plaintext Private Keys</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5068"/>
+        <location filename="qtdialogs.py" line="5073"/>
         <source>Save Key List</source>
         <translation>Save Key List</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5068"/>
+        <location filename="qtdialogs.py" line="5073"/>
         <source>Text Files (*.txt)</source>
         <translation>Text Files (*.txt)</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5082"/>
+        <location filename="qtdialogs.py" line="5087"/>
         <source>&lt;i&gt;Copied!&lt;/i&gt;</source>
         <translation>&lt;i&gt;Copied!&lt;/i&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4816"/>
+        <location filename="qtdialogs.py" line="4821"/>
         <source>The textbox below shows all keys that are part of this wallet, which includes both permanent keys and imported keys.  If you simply want to backup your wallet and you have no imported keys then all data below is reproducible from a plain paper backup. &lt;br&gt;&lt;br&gt; If you have imported addresses to backup, and/or you would like to export your private keys to another wallet service or application, then you can save this data to disk, or copy&amp;paste it into the other application.</source>
         <translation>The textbox below shows all keys that are part of this wallet, which includes both permanent keys and imported keys.  If you simply want to backup your wallet and you have no imported keys then all data below is reproducible from a plain paper backup. &lt;br&gt;&lt;br&gt; If you have imported addresses to backup, and/or you would like to export your private keys to another wallet service or application, then you can save this data to disk, or copy&amp;paste it into the other application.</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4826"/>
+        <location filename="qtdialogs.py" line="4831"/>
         <source>&lt;br&gt;&lt;br&gt;&lt;font color=&quot;red&quot;&gt;Warning:&lt;/font&gt; The text box below contains the plaintext (unencrypted) private keys for each of the addresses in this wallet.  This information can be used to spend the money associated with those addresses, so please protect it like you protect the rest of your wallet. </source>
         <translation>&lt;br&gt;&lt;br&gt;&lt;font color=&quot;red&quot;&gt;Warning:&lt;/font&gt; The text box below contains the plaintext (unencrypted) private keys for each of the addresses in this wallet.  This information can be used to spend the money associated with those addresses, so please protect it like you protect the rest of your wallet. </translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="5057"/>
+        <location filename="qtdialogs.py" line="5062"/>
         <source>&lt;font color=&quot;red&quot;&gt;&lt;b&gt;REMEMBER:&lt;/b&gt;&lt;/font&gt; The data you are about to save contains private keys.  Please make sure that only trusted persons will have access to this file. &lt;br&gt;&lt;br&gt;Are you sure you want to continue?</source>
         <translation>&lt;font color=&quot;red&quot;&gt;&lt;b&gt;REMEMBER:&lt;/b&gt;&lt;/font&gt; The data you are about to save contains private keys.  Please make sure that only trusted persons will have access to this file. &lt;br&gt;&lt;br&gt;Are you sure you want to continue?</translation>
     </message>
@@ -7639,82 +7674,82 @@ Does this ID match the &quot;Wallet Unique ID&quot; you intend to restore? If no
 <context>
     <name>DlgShowKeys</name>
     <message>
-        <location filename="qtdialogs.py" line="3419"/>
+        <location filename="qtdialogs.py" line="3424"/>
         <source>Key Data for address: &lt;b&gt;%1&lt;/b&gt;</source>
         <translation>Key Data for address: &lt;b&gt;%1&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3428"/>
+        <location filename="qtdialogs.py" line="3433"/>
         <source>Private Key (hex,%1):</source>
         <translation>Private Key (hex,%1):</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3430"/>
+        <location filename="qtdialogs.py" line="3435"/>
         <source>&lt;i&gt;[[ No Private Key in Watching-Only Wallet ]]&lt;/i&gt;</source>
         <translation>&lt;i&gt;[[ No Private Key in Watching-Only Wallet ]]&lt;/i&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3434"/>
+        <location filename="qtdialogs.py" line="3439"/>
         <source>&lt;i&gt;[[ ENCRYPTED ]]&lt;/i&gt;</source>
         <translation>&lt;i&gt;[[ ENCRYPTED ]]&lt;/i&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3441"/>
+        <location filename="qtdialogs.py" line="3446"/>
         <source>Private Key (Base58):</source>
         <translation>Private Key (Base58):</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3451"/>
+        <location filename="qtdialogs.py" line="3456"/>
         <source>Public Key X (%1):</source>
         <translation>Public Key X (%1):</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3459"/>
+        <location filename="qtdialogs.py" line="3464"/>
         <source>Public Key Y (%1):</source>
         <translation>Public Key Y (%1):</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3467"/>
+        <location filename="qtdialogs.py" line="3472"/>
         <source>%1 (Network: %2 / Checksum: %3)</source>
         <translation>%1 (Network: %2 / Checksum: %3)</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3470"/>
+        <location filename="qtdialogs.py" line="3475"/>
         <source>This is the hexadecimal version if the address string</source>
         <translation>This is the hexadecimal version if the address string</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3472"/>
+        <location filename="qtdialogs.py" line="3477"/>
         <source>Public Key Hash:</source>
         <translation>Public Key Hash:</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3506"/>
+        <location filename="qtdialogs.py" line="3511"/>
         <source>Address Key Information</source>
         <translation>Address Key Information</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3401"/>
+        <location filename="qtdialogs.py" line="3406"/>
         <source>&lt;font color=%1&gt;&lt;b&gt;Warning:&lt;/b&gt; the unencrypted private keys for this address are shown below.  They are &quot;private&quot; because anyone who obtains them can spend the money held by this address.  Please protect this information the same as you protect your wallet.&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3425"/>
+        <location filename="qtdialogs.py" line="3430"/>
         <source>The raw form of the private key for this address.  It is 32-bytes of randomly generated data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3438"/>
+        <location filename="qtdialogs.py" line="3443"/>
         <source>This is a more compact form of the private key, and includes a checksum for error detection.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3448"/>
+        <location filename="qtdialogs.py" line="3453"/>
         <source>The raw public key data.  This is the X-coordinate of the Elliptic-curve public key point.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3456"/>
+        <location filename="qtdialogs.py" line="3461"/>
         <source>The raw public key data.  This is the Y-coordinate of the Elliptic-curve public key point.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7722,32 +7757,32 @@ Does this ID match the &quot;Wallet Unique ID&quot; you intend to restore? If no
 <context>
     <name>DlgShowTestResults</name>
     <message>
-        <location filename="qtdialogs.py" line="12127"/>
+        <location filename="qtdialogs.py" line="12132"/>
         <source>Ok</source>
         <translation>Ok</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="12139"/>
+        <location filename="qtdialogs.py" line="12144"/>
         <source>Fragment Test Results</source>
         <translation>Fragment Test Results</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="12080"/>
+        <location filename="qtdialogs.py" line="12085"/>
         <source>The total number of fragment subsets (%1) is too high to test and display.  Instead, %2 subsets were tested at random.  The results are below </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="12085"/>
+        <location filename="qtdialogs.py" line="12090"/>
         <source>For the fragments you entered, there are a total of %1 possible subsets that can restore your wallet. The test results for all subsets are shown below</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="12092"/>
+        <location filename="qtdialogs.py" line="12097"/>
         <source>The wallet ID is computed from the first address in your wallet based on the root key data (and the &quot;chain code&quot;).  Therefore, a matching wallet ID proves that the wallet will produce identical addresses.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="12105"/>
+        <location filename="qtdialogs.py" line="12110"/>
         <source>Fragments &lt;b&gt;%1&lt;/b&gt; and &lt;b&gt;%2&lt;/b&gt; produce a wallet with ID &quot;&lt;b&gt;%3&lt;/b&gt;&quot;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7755,17 +7790,17 @@ Does this ID match the &quot;Wallet Unique ID&quot; you intend to restore? If no
 <context>
     <name>DlgSignBroadcastOfflineTx</name>
     <message>
-        <location filename="qtdialogs.py" line="4769"/>
+        <location filename="qtdialogs.py" line="4774"/>
         <source>Review Offline Transaction</source>
         <translation>Review Offline Transaction</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4772"/>
+        <location filename="qtdialogs.py" line="4777"/>
         <source>Sign or Broadcast Transaction</source>
         <translation>Sign or Broadcast Transaction</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4775"/>
+        <location filename="qtdialogs.py" line="4780"/>
         <source>Done</source>
         <translation>Done</translation>
     </message>
@@ -7773,47 +7808,47 @@ Does this ID match the &quot;Wallet Unique ID&quot; you intend to restore? If no
 <context>
     <name>DlgSimpleBackup</name>
     <message>
-        <location filename="qtdialogs.py" line="9936"/>
+        <location filename="qtdialogs.py" line="9941"/>
         <source>Make Paper Backup</source>
         <translation>Make Paper Backup</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9942"/>
+        <location filename="qtdialogs.py" line="9947"/>
         <source>Make Digital Backup</source>
         <translation>Make Digital Backup</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9945"/>
+        <location filename="qtdialogs.py" line="9950"/>
         <source>See Other Backup Options</source>
         <translation>See Other Backup Options</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9988"/>
+        <location filename="qtdialogs.py" line="9993"/>
         <source>Done</source>
         <translation>Done</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9998"/>
+        <location filename="qtdialogs.py" line="10003"/>
         <source>Backup Options</source>
         <translation>Backup Options</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9923"/>
+        <location filename="qtdialogs.py" line="9928"/>
         <source>&lt;b&gt;Protect Your Bitcoins -- Make a Wallet Backup!&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9926"/>
+        <location filename="qtdialogs.py" line="9931"/>
         <source>A failed hard-drive or forgotten passphrase will lead to &lt;u&gt;permanent loss of bitcoins&lt;/u&gt;!  Luckily, Armory wallets only need to be backed up &lt;u&gt;one time&lt;/u&gt;, and protect you in both of these events.   If you&apos;ve ever forgotten a password or had a hardware failure, make a backup!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9934"/>
+        <location filename="qtdialogs.py" line="9939"/>
         <source>Use a printer or pen-and-paper to write down your wallet &quot;seed.&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9939"/>
+        <location filename="qtdialogs.py" line="9944"/>
         <source>Create an unencrypted copy of your wallet file, including imported addresses.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7821,52 +7856,52 @@ Does this ID match the &quot;Wallet Unique ID&quot; you intend to restore? If no
 <context>
     <name>DlgSimulfundSelect</name>
     <message>
-        <location filename="MultiSigDialogs.py" line="2011"/>
+        <location filename="MultiSigDialogs.py" line="2006"/>
         <source>Create Promissory Note</source>
         <translation>Create Promissory Note</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="2012"/>
+        <location filename="MultiSigDialogs.py" line="2007"/>
         <source>Collect and Merge Notes</source>
         <translation>Collect and Merge Notes</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="2013"/>
+        <location filename="MultiSigDialogs.py" line="2008"/>
         <source>Sign Simulfunding Transaction</source>
         <translation>Sign Simulfunding Transaction</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="2014"/>
+        <location filename="MultiSigDialogs.py" line="2009"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1986"/>
+        <location filename="MultiSigDialogs.py" line="1981"/>
         <source>&lt;font color=&quot;%1&quot; size=4&gt;&lt;b&gt;Simultaneous Lockbox Funding&lt;/b&gt;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="2020"/>
+        <location filename="MultiSigDialogs.py" line="2015"/>
         <source>Note creation is not available when offline.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1990"/>
+        <location filename="MultiSigDialogs.py" line="1985"/>
         <source>To have multiple parties simultaneously fund a lockbox, each party will need to create a &quot;promissory note,&quot; and any other party will collect all of them to create a single Simulfunding transaction. This transaction will be signed by all parties after reviewing that it meets their expectations.  This process guarantees that either all parties commit funds simultaneously, or no one does.  The signature that you provide using this interface is only valid if all the other funding commitments are also signed.&lt;br&gt;&lt;br&gt;If you are both creating a promissory note and merging all the notes together, you should first create the promissory note and save it to disk or copy it to your clipboard.  Once all other funding commitments have been received, open this dialog again and load all of them at once.  Sign for your contribution and send the result to all the other parties. &lt;br&gt;&lt;br&gt;You are currently handling a Simulfunding operation for lockbox: &lt;br&gt;%1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="2017"/>
+        <location filename="MultiSigDialogs.py" line="2012"/>
         <source>Create a commitment to a Simulfunding transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="2022"/>
+        <location filename="MultiSigDialogs.py" line="2017"/>
         <source>Collect multiple promissory notes into a single Simulfunding transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="2024"/>
+        <location filename="MultiSigDialogs.py" line="2019"/>
         <source>Review and sign a Simulfunding transaction (after all promissory notes have been collected)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7874,37 +7909,37 @@ Does this ID match the &quot;Wallet Unique ID&quot; you intend to restore? If no
 <context>
     <name>DlgSpendFromLockbox</name>
     <message>
-        <location filename="MultiSigDialogs.py" line="1919"/>
+        <location filename="MultiSigDialogs.py" line="1914"/>
         <source>Create Transaction</source>
         <translation>Create Transaction</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1920"/>
+        <location filename="MultiSigDialogs.py" line="1915"/>
         <source>Review and Sign</source>
         <translation>Review and Sign</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1921"/>
+        <location filename="MultiSigDialogs.py" line="1916"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1913"/>
+        <location filename="MultiSigDialogs.py" line="1908"/>
         <source>To spend from a multi-sig lockbox, one party/device must create a proposed spending transaction, then all parties/devices must review and sign that transaction.  Once it has enough signatures, any device, can broadcast the transaction to the network.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1924"/>
+        <location filename="MultiSigDialogs.py" line="1919"/>
         <source>I am creating a new proposed spending transaction and will pass it to each party or device that needs to sign it</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1929"/>
+        <location filename="MultiSigDialogs.py" line="1924"/>
         <source>Transaction creation is not available when offline.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="1931"/>
+        <location filename="MultiSigDialogs.py" line="1926"/>
         <source>Another party or device created the transaction, I just need to review and sign it.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7912,47 +7947,47 @@ Does this ID match the &quot;Wallet Unique ID&quot; you intend to restore? If no
 <context>
     <name>DlgUniversalRestoreSelect</name>
     <message>
-        <location filename="qtdialogs.py" line="10794"/>
+        <location filename="qtdialogs.py" line="10799"/>
         <source>Single-Sheet Backup (printed)</source>
         <translation>Single-Sheet Backup (printed)</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10795"/>
+        <location filename="qtdialogs.py" line="10800"/>
         <source>Fragmented Backup (incl. mix of paper and files)</source>
         <translation>Fragmented Backup (incl. mix of paper and files)</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10796"/>
+        <location filename="qtdialogs.py" line="10801"/>
         <source>Import digital backup or watching-only wallet</source>
         <translation>Import digital backup or watching-only wallet</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10797"/>
+        <location filename="qtdialogs.py" line="10802"/>
         <source>Import watching-only wallet data</source>
         <translation>Import watching-only wallet data</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10798"/>
+        <location filename="qtdialogs.py" line="10803"/>
         <source>This is a test recovery to make sure my backup works</source>
         <translation>This is a test recovery to make sure my backup works</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10812"/>
+        <location filename="qtdialogs.py" line="10817"/>
         <source>Continue</source>
         <translation>Continue</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10813"/>
+        <location filename="qtdialogs.py" line="10818"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10788"/>
+        <location filename="qtdialogs.py" line="10793"/>
         <source>&lt;b&gt;&lt;u&gt;Restore Wallet from Backup&lt;/u&gt;&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10789"/>
+        <location filename="qtdialogs.py" line="10794"/>
         <source>You can restore any kind of backup ever created by Armory using one of the options below.  If you have a list of private keys you should open the target wallet and select &quot;Import/Sweep Private Keys.&quot;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8043,17 +8078,17 @@ Does this ID match the &quot;Wallet Unique ID&quot; you intend to restore? If no
 <context>
     <name>DlgUriCopyAndPaste</name>
     <message>
-        <location filename="qtdialogs.py" line="9720"/>
+        <location filename="qtdialogs.py" line="9725"/>
         <source>Copy and paste a raw bitcoin URL string here.  A valid string starts with &quot;bitcoin:&quot; followed by a bitcoin address.&lt;br&gt;&lt;br&gt;You should use this feature if there is a &quot;bitcoin:&quot; link in a webpage or email that does not load Armory when you click on it.  Instead, right-click on the link and select &quot;Copy Link Location&quot; then paste it into the box below. </source>
         <translation>Copy and paste a raw bitcoin URL string here.  A valid string starts with &quot;bitcoin:&quot; followed by a bitcoin address.&lt;br&gt;&lt;br&gt;You should use this feature if there is a &quot;bitcoin:&quot; link in a webpage or email that does not load Armory when you click on it.  Instead, right-click on the link and select &quot;Copy Link Location&quot; then paste it into the box below. </translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9736"/>
+        <location filename="qtdialogs.py" line="9741"/>
         <source>Done</source>
         <translation>Done</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="9737"/>
+        <location filename="qtdialogs.py" line="9742"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
@@ -8061,37 +8096,37 @@ Does this ID match the &quot;Wallet Unique ID&quot; you intend to restore? If no
 <context>
     <name>DlgVerifySweep</name>
     <message>
-        <location filename="qtdialogs.py" line="2982"/>
+        <location filename="qtdialogs.py" line="2984"/>
         <source>(Fee: %1)</source>
         <translation>(Fee: %1)</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2988"/>
+        <location filename="qtdialogs.py" line="2990"/>
         <source>      From %1</source>
         <translation>      From %1</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2989"/>
+        <location filename="qtdialogs.py" line="2991"/>
         <source>      To %1</source>
         <translation>      To %1</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2990"/>
+        <location filename="qtdialogs.py" line="2992"/>
         <source>      Total &lt;b&gt;%1&lt;/b&gt; BTC %2</source>
         <translation>      Total &lt;b&gt;%1&lt;/b&gt; BTC %2</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2993"/>
+        <location filename="qtdialogs.py" line="2995"/>
         <source>Are you sure you want to execute this transaction?</source>
         <translation>Are you sure you want to execute this transaction?</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="3009"/>
+        <location filename="qtdialogs.py" line="3011"/>
         <source>Confirm Sweep</source>
         <translation>Confirm Sweep</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2976"/>
+        <location filename="qtdialogs.py" line="2978"/>
         <source>You are about to &lt;i&gt;sweep&lt;/i&gt; all funds from the specified address to your wallet.  Please confirm the action:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8099,22 +8134,22 @@ Does this ID match the &quot;Wallet Unique ID&quot; you intend to restore? If no
 <context>
     <name>DlgWODataPrintBackup</name>
     <message>
-        <location filename="qtdialogs.py" line="10272"/>
+        <location filename="qtdialogs.py" line="10277"/>
         <source>&lt;b&gt;&lt;font size=4&gt;&lt;font color=&quot;#aa0000&quot;&gt;WARNING:&lt;/font&gt;  &lt;u&gt;This is not a wallet backup!&lt;/u&gt;&lt;/font&gt;&lt;/b&gt; &lt;br&gt;&lt;br&gt;Please make a regular digital or paper backup of your wallet to keep it protected!  This data simply lets you monitor the funds in this wallet but gives you no ability to move any funds.</source>
         <translation>&lt;b&gt;&lt;font size=4&gt;&lt;font color=&quot;#aa0000&quot;&gt;WARNING:&lt;/font&gt;  &lt;u&gt;This is not a wallet backup!&lt;/u&gt;&lt;/font&gt;&lt;/b&gt; &lt;br&gt;&lt;br&gt;Please make a regular digital or paper backup of your wallet to keep it protected!  This data simply lets you monitor the funds in this wallet but gives you no ability to move any funds.</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10189"/>
+        <location filename="qtdialogs.py" line="10194"/>
         <source>&lt;b&gt;&lt;u&gt;Print Watch-Only Wallet Root&lt;/u&gt;&lt;/b&gt;&lt;br&gt;&lt;br&gt; The lines below are sufficient to calculate public keys for every private key ever produced by the full wallet. Importing this data to an online computer is sufficient to receive and verify transactions, and monitor balances, but without the ability to spend the funds.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10302"/>
+        <location filename="qtdialogs.py" line="10307"/>
         <source>The following five lines are sufficient to reproduce all public keys matching the private keys produced by the full wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10341"/>
+        <location filename="qtdialogs.py" line="10346"/>
         <source>The following QR code is for convenience only.  It contains the exact same data as the five lines above.  If you copy this data by hand, you can safely ignore this QR code.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8307,122 +8342,122 @@ Does this ID match the &quot;Wallet Unique ID&quot; you intend to restore? If no
         <translation>Armory Not Ready</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="1592"/>
+        <location filename="qtdialogs.py" line="1594"/>
         <source>Create Paper Backup</source>
         <translation>Create Paper Backup</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="1597"/>
+        <location filename="qtdialogs.py" line="1599"/>
         <source>Move along...</source>
         <translation>Move along...</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="1597"/>
+        <location filename="qtdialogs.py" line="1599"/>
         <source>This wallet does not contain any private keys.  Nothing to backup!</source>
         <translation>This wallet does not contain any private keys.  Nothing to backup!</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="1611"/>
+        <location filename="qtdialogs.py" line="1613"/>
         <source>Unlock Private Keys</source>
         <translation>Unlock Private Keys</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="1620"/>
+        <location filename="qtdialogs.py" line="1622"/>
         <source>Unlock Failed</source>
         <translation>Unlock Failed</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="1631"/>
+        <location filename="qtdialogs.py" line="1633"/>
         <source>No Selection</source>
         <translation>No Selection</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="1631"/>
+        <location filename="qtdialogs.py" line="1633"/>
         <source>You must select an address to remove!</source>
         <translation>You must select an address to remove!</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="1648"/>
+        <location filename="qtdialogs.py" line="1650"/>
         <source>Invalid Selection</source>
         <translation>Invalid Selection</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="1657"/>
+        <location filename="qtdialogs.py" line="1659"/>
         <source>Imported Address Warning</source>
         <translation>Imported Address Warning</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="1784"/>
+        <location filename="qtdialogs.py" line="1786"/>
         <source>Wallet Name:</source>
         <translation>Wallet Name:</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="1785"/>
+        <location filename="qtdialogs.py" line="1787"/>
         <source>Description:</source>
         <translation>Description:</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="1787"/>
+        <location filename="qtdialogs.py" line="1789"/>
         <source>Wallet ID:</source>
         <translation>Wallet ID:</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="1788"/>
+        <location filename="qtdialogs.py" line="1790"/>
         <source>Addresses Used:</source>
         <translation>Addresses Used:</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="1789"/>
+        <location filename="qtdialogs.py" line="1791"/>
         <source>Security:</source>
         <translation>Security:</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="1790"/>
+        <location filename="qtdialogs.py" line="1792"/>
         <source>Version:</source>
         <translation>Version:</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="1792"/>
+        <location filename="qtdialogs.py" line="1794"/>
         <source>Belongs to:</source>
         <translation>Belongs to:</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="1798"/>
+        <location filename="qtdialogs.py" line="1800"/>
         <source>Unlock Time:</source>
         <translation>Unlock Time:</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="1799"/>
+        <location filename="qtdialogs.py" line="1801"/>
         <source>Unlock Memory:</source>
         <translation>Unlock Memory:</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="1947"/>
+        <location filename="qtdialogs.py" line="1949"/>
         <source>You own this wallet</source>
         <translation>You own this wallet</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="1825"/>
+        <location filename="qtdialogs.py" line="1827"/>
         <source>Someone else...</source>
         <translation>Someone else...</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="1835"/>
+        <location filename="qtdialogs.py" line="1837"/>
         <source>Click to Test</source>
         <translation>Click to Test</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="1949"/>
+        <location filename="qtdialogs.py" line="1951"/>
         <source>&lt;i&gt;Offline&lt;/i&gt;</source>
         <translation>&lt;i&gt;Offline&lt;/i&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="1958"/>
+        <location filename="qtdialogs.py" line="1960"/>
         <source>Someone else</source>
         <translation>Someone else</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="1959"/>
+        <location filename="qtdialogs.py" line="1961"/>
         <source>&lt;i&gt;Watching-Only&lt;/i&gt;</source>
         <translation>&lt;i&gt;Watching-Only&lt;/i&gt;</translation>
     </message>
@@ -8457,7 +8492,7 @@ Does this ID match the &quot;Wallet Unique ID&quot; you intend to restore? If no
         <translation>Armory is currently scanning the blockchain to collect the information needed to create transactions.  This typically takes between one and five minutes.  Please wait until your balance appears on the main window, then try again.</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="1657"/>
+        <location filename="qtdialogs.py" line="1659"/>
         <source>Armory supports importing of external private keys into your wallet but imported addresses are &lt;u&gt;not&lt;/u&gt; automatically protected by your backups.  If you do not plan to use the address again, it is recommended that you &quot;Sweep&quot; the private key instead of importing it. &lt;br&gt;&lt;br&gt; Individual private keys, including imported ones, can be backed up using the &quot;Export Key Lists&quot; option in the wallet backup window.</source>
         <translation>Armory supports importing of external private keys into your wallet but imported addresses are &lt;u&gt;not&lt;/u&gt; automatically protected by your backups.  If you do not plan to use the address again, it is recommended that you &quot;Sweep&quot; the private key instead of importing it. &lt;br&gt;&lt;br&gt; Individual private keys, including imported ones, can be backed up using the &quot;Export Key Lists&quot; option in the wallet backup window.</translation>
     </message>
@@ -8507,82 +8542,82 @@ Does this ID match the &quot;Wallet Unique ID&quot; you intend to restore? If no
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="1620"/>
+        <location filename="qtdialogs.py" line="1622"/>
         <source>Wallet could not be unlocked to display individual keys.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="1648"/>
+        <location filename="qtdialogs.py" line="1650"/>
         <source>You cannot delete addresses generated by your wallet. Only imported addresses can be deleted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="1689"/>
+        <location filename="qtdialogs.py" line="1691"/>
         <source>Move along... This wallet does not have a chain code. Backups are pointless!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="1714"/>
+        <location filename="qtdialogs.py" line="1716"/>
         <source>This is the name stored with the wallet file.  Click on the &quot;Change Labels&quot; button on the right side of this window to change this field</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="1719"/>
+        <location filename="qtdialogs.py" line="1721"/>
         <source>This is the description of the wallet stored in the wallet file. Press the &quot;Change Labels&quot; button on the right side of this window to change this field</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="1724"/>
+        <location filename="qtdialogs.py" line="1726"/>
         <source>This is a unique identifier for this wallet, based on the root key. No other wallet can have the same ID unless it is a copy of this one, regardless of whether the name and description match.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="1730"/>
+        <location filename="qtdialogs.py" line="1732"/>
         <source>This is the number of addresses *used* by this wallet so far. If you recently restored this wallet and you do not see all the funds you were expecting, click on this field to increase it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="1736"/>
+        <location filename="qtdialogs.py" line="1738"/>
         <source>Offline:  This is a &quot;Watching-Only&quot; wallet that you have identified belongs to you, but you cannot spend any of the wallet funds using this wallet.  This kind of wallet is usually stored on an internet-connected computer, to manage incoming transactions, but the private keys needed to spend the money are stored on an offline computer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="1744"/>
+        <location filename="qtdialogs.py" line="1746"/>
         <source>Watching-Only:  You can only watch addresses in this wallet but cannot spend any of the funds.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="1748"/>
+        <location filename="qtdialogs.py" line="1750"/>
         <source>No Encryption: This wallet contains private keys, and does not require a passphrase to spend funds available to this wallet.  If someone else obtains a copy of this wallet, they can also spend your funds! (You can click the &quot;Change Encryption&quot; button on the right side of this window to enabled encryption)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="1755"/>
+        <location filename="qtdialogs.py" line="1757"/>
         <source>This wallet contains the private keys needed to spend this wallet&apos;s funds, but they are encrypted on your harddrive.  The wallet must be &quot;unlocked&quot; with the correct passphrase before you can spend any of the funds.  You can still generate new addresses and monitor incoming transactions, even with a locked wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="1762"/>
+        <location filename="qtdialogs.py" line="1764"/>
         <source>Declare who owns this wallet.  If you click on the field and select &quot;This wallet is mine&quot;, it&apos;s balance will be included in your total Armory Balance in the main window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="1767"/>
+        <location filename="qtdialogs.py" line="1769"/>
         <source>This is exactly how long it takes your computer to unlock your wallet after you have entered your passphrase.  If someone got ahold of your wallet, this is approximately how long it would take them to for each guess of your passphrase.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="1773"/>
+        <location filename="qtdialogs.py" line="1775"/>
         <source>This is the amount of memory required to unlock your wallet. Memory values above 64 kB pretty much guarantee that GPU-acceleration will be useless for guessing your passphrase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="1778"/>
+        <location filename="qtdialogs.py" line="1780"/>
         <source>Wallets created with different versions of Armory, may have different wallet versions.  Not all functionality may be available with all wallet versions.  Creating a new wallet will always create the latest version.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="1614"/>
+        <location filename="qtdialogs.py" line="1616"/>
         <source>Wallet was not unlocked.  The public keys and addresses will still be shown, but private keys will not be available unless you reopen the dialog with the correct passphrase</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8590,17 +8625,17 @@ Does this ID match the &quot;Wallet Unique ID&quot; you intend to restore? If no
 <context>
     <name>DlgWalletSelect</name>
     <message>
-        <location filename="qtdialogs.py" line="4309"/>
+        <location filename="qtdialogs.py" line="4314"/>
         <source>No Wallets!</source>
         <translation>No Wallets!</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4338"/>
+        <location filename="qtdialogs.py" line="4343"/>
         <source>Select Wallet</source>
         <translation>Select Wallet</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="4309"/>
+        <location filename="qtdialogs.py" line="4314"/>
         <source>There are no wallets to select from.  Please create or import a wallet first.</source>
         <translation type="unfinished">There are no wallets to select from.  Please create or import a wallet first.</translation>
     </message>
@@ -8608,77 +8643,77 @@ Does this ID match the &quot;Wallet Unique ID&quot; you intend to restore? If no
 <context>
     <name>DlgWltRecoverWallet</name>
     <message>
-        <location filename="qtdialogs.py" line="12570"/>
+        <location filename="qtdialogs.py" line="12575"/>
         <source>Browse File System</source>
         <translation>Browse File System</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="12586"/>
+        <location filename="qtdialogs.py" line="12591"/>
         <source>Wallet Path:</source>
         <translation>Wallet Path:</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="12591"/>
+        <location filename="qtdialogs.py" line="12596"/>
         <source>Select Wallet...</source>
         <translation>Select Wallet...</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="12597"/>
+        <location filename="qtdialogs.py" line="12602"/>
         <source>Select Loaded Wallet</source>
         <translation>Select Loaded Wallet</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="12621"/>
+        <location filename="qtdialogs.py" line="12626"/>
         <source>&lt;b&gt;Stripped Recovery&lt;/b&gt;&lt;br&gt;Only attempts to                             recover the wallet&apos;s rootkey and chaincode</source>
         <translation>&lt;b&gt;Stripped Recovery&lt;/b&gt;&lt;br&gt;Only attempts to                             recover the wallet&apos;s rootkey and chaincode</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="12628"/>
+        <location filename="qtdialogs.py" line="12633"/>
         <source>&lt;b&gt;Bare Recovery&lt;/b&gt;&lt;br&gt;Attempts to recover all private key related data</source>
         <translation>&lt;b&gt;Bare Recovery&lt;/b&gt;&lt;br&gt;Attempts to recover all private key related data</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="12635"/>
+        <location filename="qtdialogs.py" line="12640"/>
         <source>&lt;b&gt;Full Recovery&lt;/b&gt;&lt;br&gt;Attempts to recover as much data as possible</source>
         <translation>&lt;b&gt;Full Recovery&lt;/b&gt;&lt;br&gt;Attempts to recover as much data as possible</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="12641"/>
+        <location filename="qtdialogs.py" line="12646"/>
         <source>&lt;b&gt;Consistency Check&lt;/b&gt;&lt;br&gt;Checks wallet consistency. Works with both full and watch only&lt;br&gt; wallets. Unlocking of encrypted wallets is not mandatory</source>
         <translation>&lt;b&gt;Consistency Check&lt;/b&gt;&lt;br&gt;Checks wallet consistency. Works with both full and watch only&lt;br&gt; wallets. Unlocking of encrypted wallets is not mandatory</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="12685"/>
+        <location filename="qtdialogs.py" line="12690"/>
         <source>Recover</source>
         <translation>Recover</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="12686"/>
+        <location filename="qtdialogs.py" line="12691"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="12697"/>
+        <location filename="qtdialogs.py" line="12702"/>
         <source>The entered path does not exist</source>
         <translation>The entered path does not exist</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="12710"/>
+        <location filename="qtdialogs.py" line="12715"/>
         <source>Wallet Recovery Tool</source>
         <translation>Wallet Recovery Tool</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="12754"/>
+        <location filename="qtdialogs.py" line="12759"/>
         <source>Wallet files (*.wallet);; All files (*)</source>
         <translation>Wallet files (*.wallet);; All files (*)</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="12761"/>
+        <location filename="qtdialogs.py" line="12766"/>
         <source>Recover Wallet</source>
         <translation>Recover Wallet</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="12574"/>
+        <location filename="qtdialogs.py" line="12579"/>
         <source>&lt;b&gt;Wallet Recovery Tool: &lt;/b&gt;&lt;br&gt;This tool will recover data from damaged or inconsistent wallets.  Specify a wallet file and Armory will analyze the wallet and fix any errors with it. &lt;br&gt;&lt;br&gt;&lt;font color=&quot;%1&quot;&gt;If any problems are found with the specified wallet, Armory will provide explanation and instructions to transition to a new wallet.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8729,7 +8764,7 @@ Does this ID match the &quot;Wallet Unique ID&quot; you intend to restore? If no
 <context>
     <name>LedgerDispModelSimple</name>
     <message>
-        <location filename="armorymodels.py" line="273"/>
+        <location filename="armorymodels.py" line="275"/>
         <source>
 
 This is a &quot;generation&quot; transaction from
@@ -8744,7 +8779,7 @@ Bitcoin mining.  These transactions take
 before they are available to be spent.</translation>
     </message>
     <message>
-        <location filename="armorymodels.py" line="297"/>
+        <location filename="armorymodels.py" line="299"/>
         <source>
 
 For small transactions, 2 or 3 confirmations is usually acceptable. For larger transactions, you should wait for 6 confirmations before trusting that the transaction is valid.</source>
@@ -8753,104 +8788,104 @@ For small transactions, 2 or 3 confirmations is usually acceptable. For larger t
 For small transactions, 2 or 3 confirmations is usually acceptable. For larger transactions, you should wait for 6 confirmations before trusting that the transaction is valid.</translation>
     </message>
     <message>
-        <location filename="armorymodels.py" line="307"/>
+        <location filename="armorymodels.py" line="309"/>
         <source>Bitcoins sent and received by the same wallet</source>
         <translation>Bitcoins sent and received by the same wallet</translation>
     </message>
     <message>
-        <location filename="armorymodels.py" line="312"/>
+        <location filename="armorymodels.py" line="314"/>
         <source>You mined these Bitcoins!</source>
         <translation>You mined these Bitcoins!</translation>
     </message>
     <message>
-        <location filename="armorymodels.py" line="314"/>
+        <location filename="armorymodels.py" line="316"/>
         <source>Bitcoins sent</source>
         <translation>Bitcoins sent</translation>
     </message>
     <message>
-        <location filename="armorymodels.py" line="316"/>
+        <location filename="armorymodels.py" line="318"/>
         <source>Bitcoins received</source>
         <translation>Bitcoins received</translation>
     </message>
     <message>
-        <location filename="armorymodels.py" line="319"/>
+        <location filename="armorymodels.py" line="321"/>
         <source>The net effect on the balance of this wallet &lt;b&gt;not including transaction fees.&lt;/b&gt;  You can change this behavior in the Armory preferences window.</source>
         <translation>The net effect on the balance of this wallet &lt;b&gt;not including transaction fees.&lt;/b&gt;  You can change this behavior in the Armory preferences window.</translation>
     </message>
     <message>
-        <location filename="armorymodels.py" line="324"/>
+        <location filename="armorymodels.py" line="326"/>
         <source>The net effect on the balance of this wallet, including transaction fees.</source>
         <translation>The net effect on the balance of this wallet, including transaction fees.</translation>
     </message>
     <message>
-        <location filename="armorymodels.py" line="334"/>
+        <location filename="armorymodels.py" line="336"/>
         <source>Date</source>
         <translation>Date</translation>
     </message>
     <message>
-        <location filename="armorymodels.py" line="335"/>
+        <location filename="armorymodels.py" line="337"/>
         <source>Lockbox</source>
         <translation>Lockbox</translation>
     </message>
     <message>
-        <location filename="armorymodels.py" line="335"/>
+        <location filename="armorymodels.py" line="337"/>
         <source>Wallet</source>
         <translation>Wallet</translation>
     </message>
     <message>
-        <location filename="armorymodels.py" line="336"/>
+        <location filename="armorymodels.py" line="338"/>
         <source>Comments</source>
         <translation>Comments</translation>
     </message>
     <message>
-        <location filename="armorymodels.py" line="338"/>
+        <location filename="armorymodels.py" line="340"/>
         <source>Amount</source>
         <translation>Amount</translation>
     </message>
     <message>
-        <location filename="armorymodels.py" line="339"/>
+        <location filename="armorymodels.py" line="341"/>
         <source>Other Owner</source>
         <translation>Other Owner</translation>
     </message>
     <message>
-        <location filename="armorymodels.py" line="340"/>
+        <location filename="armorymodels.py" line="342"/>
         <source>Wallet ID</source>
         <translation>Wallet ID</translation>
     </message>
     <message>
-        <location filename="armorymodels.py" line="341"/>
+        <location filename="armorymodels.py" line="343"/>
         <source>Tx Hash (LE)</source>
         <translation>Tx Hash (LE)</translation>
     </message>
     <message>
-        <location filename="armorymodels.py" line="267"/>
+        <location filename="armorymodels.py" line="269"/>
         <source>Transaction confirmed!
 (%1 confirmations)</source>
         <translation>Transaction confirmed!
 (%1 confirmations)</translation>
     </message>
     <message>
-        <location filename="armorymodels.py" line="272"/>
+        <location filename="armorymodels.py" line="274"/>
         <source>%1/120 confirmations</source>
         <translation>%1/120 confirmations</translation>
     </message>
     <message>
-        <location filename="armorymodels.py" line="296"/>
+        <location filename="armorymodels.py" line="298"/>
         <source>%1/6 confirmations</source>
         <translation>%1/6 confirmations</translation>
     </message>
     <message>
-        <location filename="armorymodels.py" line="283"/>
+        <location filename="armorymodels.py" line="285"/>
         <source>This transaction has been RBF flagged (Replaceable By Fee)&lt;br&gt;&lt;br&gt;It means the network will accept and broadcast a double spend of the underlying outputs as long as the double spend pays a higher fee.&lt;br&gt;&lt;br&gt;Do not consider a RBF transaction as a valid payment until it receives at least 1 confirmation.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="armorymodels.py" line="289"/>
+        <location filename="armorymodels.py" line="291"/>
         <source>This transaction spends ZC (zero confirmation) outputs&lt;br&gt;&lt;br&gt;Transactions built on top of yet to confirm transactions are at risk of being invalidated for as long as the parent transaction remains unconfirmed.&lt;br&gt;&lt;br&gt;It is recommended to wait for at least 1 confirmation before accepting these as valid payment.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="armorymodels.py" line="278"/>
+        <location filename="armorymodels.py" line="280"/>
         <source>You have create this transaction as RBF (Replaceable By Fee).&lt;br&gt;&lt;br&gt;This means you have the opportunity to bump the fee on this transaction if it fails to confirm quickly enough.&lt;br&gt;&lt;br&gt;To bump the fee, right click on the ledger entry and pick &lt;u&gt;&quot;Bump the fee&quot;&lt;/u&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8876,7 +8911,7 @@ For small transactions, 2 or 3 confirmations is usually acceptable. For larger t
 <context>
     <name>LockboxDisplayModel</name>
     <message>
-        <location filename="MultiSigModels.py" line="90"/>
+        <location filename="MultiSigModels.py" line="94"/>
         <source>Scanning: %1%%</source>
         <translation>Scanning: %1%%</translation>
     </message>
@@ -9079,132 +9114,132 @@ For small transactions, 2 or 3 confirmations is usually acceptable. For larger t
 <context>
     <name>OutputBundle</name>
     <message>
-        <location filename="MultiSigDialogs.py" line="2626"/>
+        <location filename="MultiSigDialogs.py" line="2621"/>
         <source>Unrelated Multi-Spend</source>
         <translation>Unrelated Multi-Spend</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="2634"/>
+        <location filename="MultiSigDialogs.py" line="2629"/>
         <source>Cannot Sign</source>
         <translation>Cannot Sign</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="2751"/>
+        <location filename="MultiSigDialogs.py" line="2746"/>
         <source>[[Unknown Signer]]</source>
         <translation>[[Unknown Signer]]</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="2852"/>
+        <location filename="MultiSigDialogs.py" line="2847"/>
         <source>Import/Merge</source>
         <translation>Import/Merge</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="2855"/>
+        <location filename="MultiSigDialogs.py" line="2850"/>
         <source>Broadcast</source>
         <translation>Broadcast</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="2856"/>
+        <location filename="MultiSigDialogs.py" line="2851"/>
         <source>Export</source>
         <translation>Export</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="2857"/>
+        <location filename="MultiSigDialogs.py" line="2852"/>
         <source>Done</source>
         <translation>Done</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="2894"/>
+        <location filename="MultiSigDialogs.py" line="2889"/>
         <source>Review and Sign</source>
         <translation>Review and Sign</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="2913"/>
+        <location filename="MultiSigDialogs.py" line="2908"/>
         <source>Sign Lockbox</source>
         <translation>Sign Lockbox</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="2915"/>
+        <location filename="MultiSigDialogs.py" line="2910"/>
         <source>Wallet is locked</source>
         <translation>Wallet is locked</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="2915"/>
+        <location filename="MultiSigDialogs.py" line="2910"/>
         <source>Cannot sign without unlocking wallet!</source>
         <translation>Cannot sign without unlocking wallet!</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="2968"/>
+        <location filename="MultiSigDialogs.py" line="2963"/>
         <source>Done!</source>
         <translation>Done!</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3036"/>
+        <location filename="MultiSigDialogs.py" line="3031"/>
         <source>Export Signature Collector</source>
         <translation>Export Signature Collector</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3054"/>
+        <location filename="MultiSigDialogs.py" line="3049"/>
         <source>Import Signature Collector</source>
         <translation>Import Signature Collector</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3086"/>
+        <location filename="MultiSigDialogs.py" line="3081"/>
         <source>Invalid Signatures</source>
         <translation>Invalid Signatures</translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="2626"/>
+        <location filename="MultiSigDialogs.py" line="2621"/>
         <source>The signature-collector you loaded appears to be unrelated to any of the wallets or lockboxes that you have available.  If you were expecting to be able to sign for a lockbox input, you need to import the lockbox definition first.  Any other person or device with the lockbox loaded can export it to be imported by this device.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="2634"/>
+        <location filename="MultiSigDialogs.py" line="2629"/>
         <source>The signature-collector you loaded is sending money to one of your wallets or lockboxes, but does not have any inputs for which you can sign. If you were expecting to be able to sign for a lockbox input, you need to import the lockbox definition first.  Any other person or device with the lockbox loaded can export it to be imported by this device.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="2672"/>
+        <location filename="MultiSigDialogs.py" line="2667"/>
         <source>&lt;b&gt;&lt;u&gt;Spending:&lt;/u&gt; &lt;font color=&quot;%1&quot;&gt;%2&lt;/b&gt;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="2676"/>
+        <location filename="MultiSigDialogs.py" line="2671"/>
         <source>&lt;b&gt;&lt;u&gt;Contributor:&lt;/u&gt; &lt;font color=&quot;%1&quot;&gt;%2&lt;/b&gt;%3&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="2804"/>
+        <location filename="MultiSigDialogs.py" line="2799"/>
         <source>&lt;b&gt;&lt;u&gt;Receiving:&lt;/u&gt;  &lt;font color=&quot;%1&quot;&gt;%2&lt;/font&gt;&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3021"/>
+        <location filename="MultiSigDialogs.py" line="3016"/>
         <source>&lt;font color=&quot;%1&quot;&gt;This transaction is incomplete.  You can add signatures then export and give to other parties or devices to sign.&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3037"/>
+        <location filename="MultiSigDialogs.py" line="3032"/>
         <source>The text below includes all data about this multi-sig transaction, including all the signatures already made to it.  It contains everything needed to securely review and sign it, including offline devices/wallets.&lt;br&gt;&lt;br&gt;If this transaction requires signatures from multiple parties, it is safe to send this data via email or USB key.  No data is included that would compromise the security of any of the signing devices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3055"/>
+        <location filename="MultiSigDialogs.py" line="3050"/>
         <source>Load a multi-sig transaction for review, signing and/or broadcast. If any of your loaded wallets can sign for any transaction inputs, you will be able to execute the signing for each one.  If your signature completes the transaction, you can then broadcast it to finalize it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3086"/>
+        <location filename="MultiSigDialogs.py" line="3081"/>
         <source>Somehow not all inputs have valid sigantures!  You can choose to attempt to broadcast anyway, in case you think Armory is not evaluating the transaction state correctly. &lt;br&gt;&lt;br&gt;Otherwise, please confirm that you have created signatures from the correct wallets.  Perhaps try collecting signatures again...?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3008"/>
+        <location filename="MultiSigDialogs.py" line="3003"/>
         <source>&lt;font color=&quot;%1&quot;&gt;This transaction has enough signatures and can be broadcast from any online computer (you are currently offline)&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MultiSigDialogs.py" line="3012"/>
+        <location filename="MultiSigDialogs.py" line="3007"/>
         <source>&lt;font color=&quot;%1&quot;&gt;This transaction has enough signatures and can be broadcast&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9212,22 +9247,22 @@ For small transactions, 2 or 3 confirmations is usually acceptable. For larger t
 <context>
     <name>PromissoryCollectModel</name>
     <message>
-        <location filename="armorymodels.py" line="1514"/>
+        <location filename="armorymodels.py" line="1517"/>
         <source>Note ID</source>
         <translation>Note ID</translation>
     </message>
     <message>
-        <location filename="armorymodels.py" line="1514"/>
+        <location filename="armorymodels.py" line="1517"/>
         <source>Label</source>
         <translation>Label</translation>
     </message>
     <message>
-        <location filename="armorymodels.py" line="1514"/>
+        <location filename="armorymodels.py" line="1517"/>
         <source>Funding</source>
         <translation>Funding</translation>
     </message>
     <message>
-        <location filename="armorymodels.py" line="1514"/>
+        <location filename="armorymodels.py" line="1517"/>
         <source>Fee</source>
         <translation>Fee</translation>
     </message>
@@ -9253,17 +9288,17 @@ For small transactions, 2 or 3 confirmations is usually acceptable. For larger t
 <context>
     <name>RBFTreeModel</name>
     <message>
-        <location filename="TreeViewGUI.py" line="997"/>
+        <location filename="TreeViewGUI.py" line="1005"/>
         <source>Output ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="TreeViewGUI.py" line="998"/>
+        <location filename="TreeViewGUI.py" line="1006"/>
         <source>Address</source>
         <translation type="unfinished">Address</translation>
     </message>
     <message>
-        <location filename="TreeViewGUI.py" line="999"/>
+        <location filename="TreeViewGUI.py" line="1007"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9271,47 +9306,47 @@ For small transactions, 2 or 3 confirmations is usually acceptable. For larger t
 <context>
     <name>ReviewOfflineTxFrame</name>
     <message>
-        <location filename="TxFrames.py" line="1414"/>
+        <location filename="TxFrames.py" line="1415"/>
         <source>There is no security-sensitive information in this data below, so it is perfectly safe to copy-and-paste it into an email message, or save it to a borrowed USB key.</source>
         <translation>There is no security-sensitive information in this data below, so it is perfectly safe to copy-and-paste it into an email message, or save it to a borrowed USB key.</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1419"/>
+        <location filename="TxFrames.py" line="1420"/>
         <source>Save as file...</source>
         <translation>Save as file...</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1421"/>
+        <location filename="TxFrames.py" line="1422"/>
         <source>Save this data to a USB key or other device, to be transferred to a computer that contains the private keys for this wallet.</source>
         <translation>Save this data to a USB key or other device, to be transferred to a computer that contains the private keys for this wallet.</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1425"/>
+        <location filename="TxFrames.py" line="1426"/>
         <source>Copy to clipboard</source>
         <translation>Copy to clipboard</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1430"/>
+        <location filename="TxFrames.py" line="1431"/>
         <source>Copy the transaction data to the clipboard, so that it can be pasted into an email or a text document.</source>
         <translation>Copy the transaction data to the clipboard, so that it can be pasted into an email or a text document.</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1434"/>
+        <location filename="TxFrames.py" line="1435"/>
         <source>&lt;b&gt;Instructions for completing this transaction:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Instructions for completing this transaction:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1492"/>
+        <location filename="TxFrames.py" line="1493"/>
         <source>&lt;b&gt;Transaction Data&lt;/b&gt; <byte value="x9"/> (Unsigned ID: %1)</source>
         <translation>&lt;b&gt;Transaction Data&lt;/b&gt; &lt;byte value=&quot;x9&quot;/&gt; (Unsigned ID: %1)</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1499"/>
+        <location filename="TxFrames.py" line="1500"/>
         <source>The block of data shown below is the complete transaction you just requested, but is invalid because it does not contain any signatures.  You must take this data to the computer with the full wallet to get it signed, then bring it back here to be broadcast to the Bitcoin network. &lt;br&gt;&lt;br&gt;Use &quot;Save as file...&quot; to save an &lt;i&gt;*.unsigned.tx&lt;/i&gt; file to USB drive or other removable media. On the offline computer, click &quot;Offline Transactions&quot; on the main window.  Load the transaction, &lt;b&gt;review it&lt;/b&gt;, then sign it (the filename now end with &lt;i&gt;*.signed.tx&lt;/i&gt;).  Click &quot;Continue&quot; below when you have the signed transaction on this computer. &lt;br&gt;&lt;br&gt;&lt;b&gt;NOTE:&lt;/b&gt; The USB drive only ever holds public transaction data that will be broadcast to the network.  This data may be considered privacy-sensitive, but does &lt;u&gt;not&lt;/u&gt; compromise the security of your wallet.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1518"/>
+        <location filename="TxFrames.py" line="1519"/>
         <source>You have chosen to create the previous transaction but not sign it or broadcast it, yet.  You can save the unsigned transaction to file, or copy&amp;paste from the text box. You can use the following window (after clicking &quot;Continue&quot;) to sign and broadcast the transaction when you are ready</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9470,162 +9505,162 @@ For small transactions, 2 or 3 confirmations is usually acceptable. For larger t
         <translation>Create Unsigned</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="292"/>
+        <location filename="TxFrames.py" line="293"/>
         <source>Send!</source>
         <translation>Send!</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="130"/>
+        <location filename="TxFrames.py" line="131"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="177"/>
+        <location filename="TxFrames.py" line="178"/>
         <source>Manually Enter &quot;bitcoin:&quot; Link</source>
         <translation>Manually Enter &quot;bitcoin:&quot; Link</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="243"/>
+        <location filename="TxFrames.py" line="244"/>
         <source>&lt;b&gt;Sending from Wallet:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Sending from Wallet:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="258"/>
+        <location filename="TxFrames.py" line="259"/>
         <source>Send Bitcoins</source>
         <translation>Send Bitcoins</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="289"/>
+        <location filename="TxFrames.py" line="290"/>
         <source>Continue</source>
         <translation>Continue</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="290"/>
+        <location filename="TxFrames.py" line="291"/>
         <source>Click to create an unsigned transaction!</source>
         <translation>Click to create an unsigned transaction!</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="293"/>
+        <location filename="TxFrames.py" line="294"/>
         <source>Click to send bitcoins!</source>
         <translation>Click to send bitcoins!</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="975"/>
+        <location filename="TxFrames.py" line="976"/>
         <source>Invalid Address</source>
         <translation>Invalid Address</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="578"/>
+        <location filename="TxFrames.py" line="579"/>
         <source>Wrong Network!</source>
         <translation>Wrong Network!</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="594"/>
+        <location filename="TxFrames.py" line="595"/>
         <source>Zero Amount</source>
         <translation>Zero Amount</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="594"/>
+        <location filename="TxFrames.py" line="595"/>
         <source>You cannot send 0 BTC to any recipients.  &lt;br&gt;Please enter a positive amount for recipient %1.</source>
         <translation>You cannot send 0 BTC to any recipients.  &lt;br&gt;Please enter a positive amount for recipient %1.</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="600"/>
+        <location filename="TxFrames.py" line="601"/>
         <source>Negative Value</source>
         <translation>Negative Value</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="600"/>
+        <location filename="TxFrames.py" line="601"/>
         <source>You have specified a negative amount for recipient %1. &lt;br&gt;Only positive values are allowed!.</source>
         <translation>You have specified a negative amount for recipient %1. &lt;br&gt;Only positive values are allowed!.</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="605"/>
+        <location filename="TxFrames.py" line="606"/>
         <source>Too much precision</source>
         <translation>Too much precision</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="605"/>
+        <location filename="TxFrames.py" line="606"/>
         <source>Bitcoins can only be specified down to 8 decimal places. The smallest value that can be sent is  0.0000 0001 BTC. Please enter a new amount for recipient %1.</source>
         <translation>Bitcoins can only be specified down to 8 decimal places. The smallest value that can be sent is  0.0000 0001 BTC. Please enter a new amount for recipient %1.</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="611"/>
+        <location filename="TxFrames.py" line="612"/>
         <source>Missing recipient amount</source>
         <translation>Missing recipient amount</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="611"/>
+        <location filename="TxFrames.py" line="612"/>
         <source>You did not specify an amount to send!</source>
         <translation>You did not specify an amount to send!</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="615"/>
+        <location filename="TxFrames.py" line="616"/>
         <source>Invalid Value String</source>
         <translation>Invalid Value String</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="615"/>
+        <location filename="TxFrames.py" line="616"/>
         <source>The amount you specified to send to address %1 is invalid (%2).</source>
         <translation>The amount you specified to send to address %1 is invalid (%2).</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="642"/>
+        <location filename="TxFrames.py" line="643"/>
         <source>Excessive Fee</source>
         <translation>Excessive Fee</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="655"/>
+        <location filename="TxFrames.py" line="656"/>
         <source>Insufficient Fee</source>
         <translation>Insufficient Fee</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="669"/>
+        <location filename="TxFrames.py" line="670"/>
         <source>Coin Selection Error</source>
         <translation>Coin Selection Error</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="798"/>
+        <location filename="TxFrames.py" line="799"/>
         <source>Wallet is Locked</source>
         <translation>Wallet is Locked</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="798"/>
+        <location filename="TxFrames.py" line="799"/>
         <source>Cannot sign transaction while your wallet is locked. </source>
         <translation>Cannot sign transaction while your wallet is locked. </translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1021"/>
+        <location filename="TxFrames.py" line="1022"/>
         <source>Invalid Input</source>
         <translation>Invalid Input</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1021"/>
+        <location filename="TxFrames.py" line="1022"/>
         <source>Cannot compute the maximum amount because there is an error in the amount for recipient %1.</source>
         <translation>Cannot compute the maximum amount because there is an error in the amount for recipient %1.</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1031"/>
+        <location filename="TxFrames.py" line="1032"/>
         <source>Insufficient funds</source>
         <translation>Insufficient funds</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1031"/>
+        <location filename="TxFrames.py" line="1032"/>
         <source>You have specified more than your spendable balance to the other recipients and the transaction fee.  Therefore, the maximum amount for this recipient would actually be negative.</source>
         <translation>You have specified more than your spendable balance to the other recipients and the transaction fee.  Therefore, the maximum amount for this recipient would actually be negative.</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1156"/>
+        <location filename="TxFrames.py" line="1157"/>
         <source>+ Recipient</source>
         <translation>+ Recipient</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1158"/>
+        <location filename="TxFrames.py" line="1159"/>
         <source>- Recipient</source>
         <translation>- Recipient</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1046"/>
+        <location filename="TxFrames.py" line="1047"/>
         <source>Fills in the maximum spendable amount minus the amounts specified for other recipients and the transaction fee </source>
         <translation>Fills in the maximum spendable amount minus the amounts specified for other recipients and the transaction fee </translation>
     </message>
@@ -9635,47 +9670,37 @@ For small transactions, 2 or 3 confirmations is usually acceptable. For larger t
         <translation>Transaction fees go to users who contribute computing power to keep the Bitcoin network secure, and in return they get your transaction included in the blockchain faster.</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="567"/>
+        <location filename="TxFrames.py" line="568"/>
         <source>You have entered %1 invalid addresses. The errors have been highlighted on the entry screen</source>
         <translation>You have entered %1 invalid addresses. The errors have been highlighted on the entry screen</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="902"/>
+        <location filename="TxFrames.py" line="903"/>
         <source>Change address type mismatch</source>
         <translation>Change address type mismatch</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="902"/>
+        <location filename="TxFrames.py" line="903"/>
         <source>Armory is set to force the change address type to %1.&lt;br&gt;All the recipients in this transaction are of the %2 type.&lt;br&gt;&lt;br&gt;If sent as such, this transaction will damage your privacy. It is recommended you let Armory define the change script type automatically. You can do this by going to File -&gt; Settings and picking &lt;u&gt;&apos;Auto change&apos;&lt;/u&gt; in the Fee &amp; Change settings tab.&lt;br&gt;&lt;br&gt;&lt;b&gt;Note&lt;/b&gt;: When paying a P2SH script with the auto change setting on, the change script type will be set to P2SH. Only Armory 0.96 and later can spend from these scripts.&lt;br&gt;If you use an offline signing setup, make sure your signer is up to date.</source>
         <translation>Armory is set to force the change address type to %1.&lt;br&gt;All the recipients in this transaction are of the %2 type.&lt;br&gt;&lt;br&gt;If sent as such, this transaction will damage your privacy. It is recommended you let Armory define the change script type automatically. You can do this by going to File -&gt; Settings and picking &lt;u&gt;&apos;Auto change&apos;&lt;/u&gt; in the Fee &amp; Change settings tab.&lt;br&gt;&lt;br&gt;&lt;b&gt;Note&lt;/b&gt;: When paying a P2SH script with the auto change setting on, the change script type will be set to P2SH. Only Armory 0.96 and later can spend from these scripts.&lt;br&gt;If you use an offline signing setup, make sure your signer is up to date.</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="178"/>
+        <location filename="TxFrames.py" line="179"/>
         <source>Armory does not always succeed at registering itself to handle URL links from webpages and email. Click this button to copy a &quot;bitcoin:&quot; link directly into Armory.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="578"/>
+        <location filename="TxFrames.py" line="579"/>
         <source>Address %1 is for the wrong network!  You are on the &lt;b&gt;%2&lt;/b&gt; and the address you supplied is for the the &lt;b&gt;%3&lt;/b&gt;!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="642"/>
-        <source>Your transaction comes with a fee rate of &lt;b&gt;%1 satoshis per byte&lt;/b&gt;. &lt;/br&gt;&lt;/br&gt; This is much higher than the median fee rate of &lt;b&gt;%2 satoshi/Byte&lt;/b&gt;. &lt;br&gt;&lt;br&gt;Are you &lt;i&gt;absolutely sure&lt;/i&gt; that you want to send with this fee? If you do not want to proceed with this fee rate, click &quot;No&quot;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="TxFrames.py" line="655"/>
-        <source>Your transaction comes with a fee rate of &lt;b&gt;%1 satoshi/Byte&lt;/b&gt;. &lt;/br&gt;&lt;br&gt; This is much lower than the median fee rate of &lt;b&gt;%2 satoshi/Byte&lt;/b&gt;. &lt;br&gt;&lt;br&gt;Are you &lt;i&gt;absolutely sure&lt;/i&gt; that you want to send with this fee? If you do not want to proceed with this fee rate, click &quot;No&quot;.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="TxFrames.py" line="669"/>
+        <location filename="TxFrames.py" line="670"/>
         <source>There was an error constructing your transaction, due to a quirk in the way Bitcoin transactions work.  If you see this error more than once, try sending your BTC in two or more separate transactions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="975"/>
+        <location filename="TxFrames.py" line="976"/>
         <source>You specified an invalid change address for this transcation.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9685,40 +9710,50 @@ For small transactions, 2 or 3 confirmations is usually acceptable. For larger t
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="123"/>
+        <location filename="TxFrames.py" line="124"/>
         <source>RBF flagged inputs allow to respend the underlying outpoint for a higher fee as long as the original spending transaction remains unconfirmed. &lt;br&gt;&lt;br&gt;Checking this box will RBF flag all inputs in this transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="630"/>
+        <location filename="TxFrames.py" line="631"/>
         <source>Coin Selection Failure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="630"/>
+        <location filename="TxFrames.py" line="631"/>
         <source>Coin selection failed with error: &lt;b&gt;%1&lt;b/&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="TxFrames.py" line="643"/>
+        <source>Your transaction comes with a fee rate of &lt;b&gt;%1 satoshis per byte&lt;/b&gt;. &lt;/br&gt;&lt;/br&gt; This is at least an order of magnitude higher than the minimum suggested fee rate of &lt;b&gt;%2 satoshi/Byte&lt;/b&gt;. &lt;br&gt;&lt;br&gt;Are you &lt;i&gt;absolutely sure&lt;/i&gt; that you want to send with this fee? If you do not want to proceed with this fee rate, click &quot;No&quot;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="TxFrames.py" line="656"/>
+        <source>Your transaction comes with a fee rate of &lt;b&gt;%1 satoshi/Byte&lt;/b&gt;. &lt;/br&gt;&lt;br&gt; This is lower than the suggested minimum fee rate of &lt;b&gt;%2 satoshi/Byte&lt;/b&gt;. &lt;br&gt;&lt;br&gt;Are you &lt;i&gt;absolutely sure&lt;/i&gt; that you want to send with this fee? If you do not want to proceed with this fee rate, click &quot;No&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SentToAddrBookModel</name>
     <message>
-        <location filename="armorymodels.py" line="1429"/>
+        <location filename="armorymodels.py" line="1432"/>
         <source>Address</source>
         <translation>Address</translation>
     </message>
     <message>
-        <location filename="armorymodels.py" line="1430"/>
+        <location filename="armorymodels.py" line="1433"/>
         <source>Ownership</source>
         <translation>Ownership</translation>
     </message>
     <message>
-        <location filename="armorymodels.py" line="1431"/>
+        <location filename="armorymodels.py" line="1434"/>
         <source>Times Used</source>
         <translation>Times Used</translation>
     </message>
     <message>
-        <location filename="armorymodels.py" line="1432"/>
+        <location filename="armorymodels.py" line="1435"/>
         <source>Comment</source>
         <translation>Comment</translation>
     </message>
@@ -9772,272 +9807,272 @@ random letters, or 6 or more random words.
 <context>
     <name>SignBroadcastOfflineTxFrame</name>
     <message>
-        <location filename="TxFrames.py" line="1580"/>
+        <location filename="TxFrames.py" line="1581"/>
         <source>Sign</source>
         <translation>Sign</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1581"/>
+        <location filename="TxFrames.py" line="1582"/>
         <source>Broadcast</source>
         <translation>Broadcast</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1582"/>
+        <location filename="TxFrames.py" line="1583"/>
         <source>Save file...</source>
         <translation>Save file...</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1583"/>
+        <location filename="TxFrames.py" line="1584"/>
         <source>Load file...</source>
         <translation>Load file...</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1584"/>
+        <location filename="TxFrames.py" line="1585"/>
         <source>Copy Text</source>
         <translation>Copy Text</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1585"/>
+        <location filename="TxFrames.py" line="1586"/>
         <source>Copy Raw Tx (Hex)</source>
         <translation>Copy Raw Tx (Hex)</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1604"/>
+        <location filename="TxFrames.py" line="1605"/>
         <source>Signature is Invalid!</source>
         <translation>Signature is Invalid!</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1615"/>
+        <location filename="TxFrames.py" line="1616"/>
         <source>This is wallet from which the offline transaction spends bitcoins</source>
         <translation>This is wallet from which the offline transaction spends bitcoins</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1622"/>
+        <location filename="TxFrames.py" line="1623"/>
         <source>The name of the wallet</source>
         <translation>The name of the wallet</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1623"/>
+        <location filename="TxFrames.py" line="1624"/>
         <source>&lt;b&gt;Wallet Label:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Wallet Label:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1633"/>
+        <location filename="TxFrames.py" line="1634"/>
         <source>&lt;b&gt;Pre-Broadcast ID:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Pre-Broadcast ID:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1638"/>
+        <location filename="TxFrames.py" line="1639"/>
         <source>Net effect on this wallet&apos;s balance</source>
         <translation>Net effect on this wallet&apos;s balance</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1640"/>
+        <location filename="TxFrames.py" line="1641"/>
         <source>&lt;b&gt;Transaction Amount:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Transaction Amount:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1643"/>
+        <location filename="TxFrames.py" line="1644"/>
         <source>Click here for more&lt;br&gt; information about &lt;br&gt;this transaction</source>
         <translation>Click here for more&lt;br&gt; information about &lt;br&gt;this transaction</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1714"/>
+        <location filename="TxFrames.py" line="1715"/>
         <source>Inconsistent Data!</source>
         <translation>Inconsistent Data!</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1714"/>
+        <location filename="TxFrames.py" line="1715"/>
         <source>This transaction contains inconsistent information.  This is probably not your fault...</source>
         <translation>This transaction contains inconsistent information.  This is probably not your fault...</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1720"/>
+        <location filename="TxFrames.py" line="1721"/>
         <source>Wrong Network!</source>
         <translation>Wrong Network!</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1720"/>
+        <location filename="TxFrames.py" line="1721"/>
         <source>This transaction is actually for a different network!  Did you load the correct transaction?</source>
         <translation>This transaction is actually for a different network!  Did you load the correct transaction?</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1736"/>
+        <location filename="TxFrames.py" line="1737"/>
         <source>No connection to Bitcoin network!</source>
         <translation>No connection to Bitcoin network!</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1747"/>
+        <location filename="TxFrames.py" line="1748"/>
         <source>&lt;b&gt;&lt;font color=&quot;red&quot;&gt;Unrecognized!&lt;/font&gt;&lt;/b&gt;</source>
         <translation>&lt;b&gt;&lt;font color=&quot;red&quot;&gt;Unrecognized!&lt;/font&gt;&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1757"/>
+        <location filename="TxFrames.py" line="1758"/>
         <source>Offline Warning</source>
         <translation>Offline Warning</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1757"/>
+        <location filename="TxFrames.py" line="1758"/>
         <source>&lt;b&gt;Please review your transaction carefully before signing and broadcasting it!&lt;/b&gt;  The extra security of using offline wallets is lost if you do not confirm the transaction is correct!</source>
         <translation>&lt;b&gt;Please review your transaction carefully before signing and broadcasting it!&lt;/b&gt;  The extra security of using offline wallets is lost if you do not confirm the transaction is correct!</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1763"/>
+        <location filename="TxFrames.py" line="1764"/>
         <source>&lt;b&gt;&lt;font color=&quot;red&quot;&gt;Unsigned&lt;/font&gt;&lt;/b&gt;</source>
         <translation>&lt;b&gt;&lt;font color=&quot;red&quot;&gt;Unsigned&lt;/font&gt;&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1767"/>
+        <location filename="TxFrames.py" line="1768"/>
         <source>&lt;b&gt;&lt;font color=&quot;red&quot;&gt;Bad Signature!&lt;/font&gt;&lt;/b&gt;</source>
         <translation>&lt;b&gt;&lt;font color=&quot;red&quot;&gt;Bad Signature!&lt;/font&gt;&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1771"/>
+        <location filename="TxFrames.py" line="1772"/>
         <source>&lt;b&gt;&lt;font color=&quot;green&quot;&gt;All Signatures Valid!&lt;/font&gt;&lt;/b&gt;</source>
         <translation>&lt;b&gt;&lt;font color=&quot;green&quot;&gt;All Signatures Valid!&lt;/font&gt;&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1790"/>
+        <location filename="TxFrames.py" line="1791"/>
         <source>Multiple Input Wallets</source>
         <translation>Multiple Input Wallets</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1790"/>
+        <location filename="TxFrames.py" line="1791"/>
         <source>Somehow, you have obtained a transaction that actually pulls from more than one wallet.  The support for handling multi-wallet signatures is not currently implemented (this also could have happened if you imported the same private key into two different wallets).</source>
         <translation>Somehow, you have obtained a transaction that actually pulls from more than one wallet.  The support for handling multi-wallet signatures is not currently implemented (this also could have happened if you imported the same private key into two different wallets).</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1798"/>
+        <location filename="TxFrames.py" line="1799"/>
         <source>Unrelated Transaction</source>
         <translation>Unrelated Transaction</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1798"/>
+        <location filename="TxFrames.py" line="1799"/>
         <source>This transaction appears to have no relationship to any of the wallets stored on this computer.  Did you load the correct transaction?</source>
         <translation>This transaction appears to have no relationship to any of the wallets stored on this computer.  Did you load the correct transaction?</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1858"/>
+        <location filename="TxFrames.py" line="1859"/>
         <source>[[ Unrelated ]]</source>
         <translation>[[ Unrelated ]]</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1878"/>
+        <location filename="TxFrames.py" line="1879"/>
         <source>Invalid Transaction</source>
         <translation>Invalid Transaction</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1878"/>
+        <location filename="TxFrames.py" line="1879"/>
         <source>Transaction data is invalid and cannot be shown!</source>
         <translation>Transaction data is invalid and cannot be shown!</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1891"/>
+        <location filename="TxFrames.py" line="1892"/>
         <source>Cannot Sign</source>
         <translation>Cannot Sign</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1891"/>
+        <location filename="TxFrames.py" line="1892"/>
         <source>This transaction is not relevant to any of your wallets.Did you load the correct transaction?</source>
         <translation>This transaction is not relevant to any of your wallets.Did you load the correct transaction?</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1897"/>
+        <location filename="TxFrames.py" line="1898"/>
         <source>Not Signable</source>
         <translation>Not Signable</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1897"/>
+        <location filename="TxFrames.py" line="1898"/>
         <source>This is not a valid transaction, and thus it cannot be signed. </source>
         <translation>This is not a valid transaction, and thus it cannot be signed. </translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1902"/>
+        <location filename="TxFrames.py" line="1903"/>
         <source>Already Signed</source>
         <translation>Already Signed</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1902"/>
+        <location filename="TxFrames.py" line="1903"/>
         <source>This transaction has already been signed!</source>
         <translation>This transaction has already been signed!</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1908"/>
+        <location filename="TxFrames.py" line="1909"/>
         <source>No Private Keys!</source>
         <translation>No Private Keys!</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1908"/>
+        <location filename="TxFrames.py" line="1909"/>
         <source>This transaction refers one of your wallets, but that wallet is a watching-only wallet.  Therefore, private keys are not available to sign this transaction.</source>
         <translation>This transaction refers one of your wallets, but that wallet is a watching-only wallet.  Therefore, private keys are not available to sign this transaction.</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1935"/>
+        <location filename="TxFrames.py" line="1936"/>
         <source>Missing Change</source>
         <translation>Missing Change</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1955"/>
+        <location filename="TxFrames.py" line="1956"/>
         <source>Send Transaction</source>
         <translation>Send Transaction</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1962"/>
+        <location filename="TxFrames.py" line="1963"/>
         <source>Wallet is Locked</source>
         <translation>Wallet is Locked</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1962"/>
+        <location filename="TxFrames.py" line="1963"/>
         <source>Cannot sign transaction while your wallet is locked. </source>
         <translation>Cannot sign transaction while your wallet is locked. </translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1988"/>
+        <location filename="TxFrames.py" line="1989"/>
         <source>No Internet!</source>
         <translation>No Internet!</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1988"/>
+        <location filename="TxFrames.py" line="1989"/>
         <source>You do not currently have a connection to the Bitcoin network. If this does not seem correct, verify that  is open and synchronized with the network.</source>
         <translation>You do not currently have a connection to the Bitcoin network. If this does not seem correct, verify that  is open and synchronized with the network.</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1999"/>
+        <location filename="TxFrames.py" line="2000"/>
         <source>Signature Error</source>
         <translation>Signature Error</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="2003"/>
+        <location filename="TxFrames.py" line="2004"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="2029"/>
+        <location filename="TxFrames.py" line="2030"/>
         <source>File Remove Error</source>
         <translation>File Remove Error</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="2029"/>
+        <location filename="TxFrames.py" line="2030"/>
         <source>The file could not be deleted.  If you want to delete it, please do so manually.  The file was loaded from: &lt;br&gt;&lt;br&gt;%1: </source>
         <translation>The file could not be deleted.  If you want to delete it, please do so manually.  The file was loaded from: &lt;br&gt;&lt;br&gt;%1: </translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="2067"/>
+        <location filename="TxFrames.py" line="2068"/>
         <source>Formatting Error</source>
         <translation>Formatting Error</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="2067"/>
+        <location filename="TxFrames.py" line="2068"/>
         <source>The transaction data was not in a format recognized by Armory.</source>
         <translation>The transaction data was not in a format recognized by Armory.</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="2059"/>
+        <location filename="TxFrames.py" line="2060"/>
         <source>Transaction Saved!</source>
         <translation>Transaction Saved!</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="2059"/>
+        <location filename="TxFrames.py" line="2060"/>
         <source>Your transaction has been saved to the following location:
 
 %1
@@ -10050,42 +10085,42 @@ It can now be broadcast from any computer running Armory in online mode.</source
 It can now be broadcast from any computer running Armory in online mode.</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="2098"/>
+        <location filename="TxFrames.py" line="2099"/>
         <source>Load Transaction</source>
         <translation>Load Transaction</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="2120"/>
+        <location filename="TxFrames.py" line="2121"/>
         <source>&lt;i&gt;Copied!&lt;/i&gt;</source>
         <translation>&lt;i&gt;Copied!&lt;/i&gt;</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1565"/>
+        <location filename="TxFrames.py" line="1566"/>
         <source>Copy or load a transaction from file into the text box below.  If the transaction is unsigned and you have the correct wallet, you will have the opportunity to sign it.  If it is already signed you will have the opportunity to broadcast it to the Bitcoin network to make it final.</source>
         <translation>Copy or load a transaction from file into the text box below.  If the transaction is unsigned and you have the correct wallet, you will have the opportunity to sign it.  If it is already signed you will have the opportunity to broadcast it to the Bitcoin network to make it final.</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1628"/>
+        <location filename="TxFrames.py" line="1629"/>
         <source>A unique string that identifies an &lt;i&gt;unsigned&lt;/i&gt; transaction.  This is different than the ID that the transaction will have when it is finally broadcast, because the broadcast ID cannot be calculated without all the signatures</source>
         <translation>A unique string that identifies an &lt;i&gt;unsigned&lt;/i&gt; transaction.  This is different than the ID that the transaction will have when it is finally broadcast, because the broadcast ID cannot be calculated without all the signatures</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1981"/>
+        <location filename="TxFrames.py" line="1982"/>
         <source>Armory lost its connection to Bitcoin Core, and cannot broadcast any transactions until it is reconnected. Please verify that Bitcoin Core (or bitcoind) is open and synchronized with the network.</source>
         <translation>Armory lost its connection to Bitcoin Core, and cannot broadcast any transactions until it is reconnected. Please verify that Bitcoin Core (or bitcoind) is open and synchronized with the network.</translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1935"/>
+        <location filename="TxFrames.py" line="1936"/>
         <source>This transaction has %1 recipients, and none of them are addresses in this wallet (for receiving change). This can happen if you specified a custom change address for this transaction, or sometimes happens solely by chance with a multi-recipient transaction.  It could also be the result of someone tampering with the transaction. &lt;br&gt;&lt;br&gt;The transaction is valid and ready to be signed. Please verify the recipient and amounts carefully before confirming the transaction on the next screen.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="1999"/>
+        <location filename="TxFrames.py" line="2000"/>
         <source>Not all signatures are valid.  This transaction cannot be broadcast.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="TxFrames.py" line="2003"/>
+        <location filename="TxFrames.py" line="2004"/>
         <source>There was an error processing this transaction, for reasons that are probably not your fault...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10162,47 +10197,47 @@ It can now be broadcast from any computer running Armory in online mode.</transl
 <context>
     <name>TxInDispModel</name>
     <message>
-        <location filename="armorymodels.py" line="1237"/>
+        <location filename="armorymodels.py" line="1240"/>
         <source>Wallet ID</source>
         <translation>Wallet ID</translation>
     </message>
     <message>
-        <location filename="armorymodels.py" line="1238"/>
+        <location filename="armorymodels.py" line="1241"/>
         <source>Sender</source>
         <translation>Sender</translation>
     </message>
     <message>
-        <location filename="armorymodels.py" line="1239"/>
+        <location filename="armorymodels.py" line="1242"/>
         <source>Amount</source>
         <translation>Amount</translation>
     </message>
     <message>
-        <location filename="armorymodels.py" line="1240"/>
+        <location filename="armorymodels.py" line="1243"/>
         <source>Prev. Tx Hash</source>
         <translation>Prev. Tx Hash</translation>
     </message>
     <message>
-        <location filename="armorymodels.py" line="1241"/>
+        <location filename="armorymodels.py" line="1244"/>
         <source>Index</source>
         <translation>Index</translation>
     </message>
     <message>
-        <location filename="armorymodels.py" line="1242"/>
+        <location filename="armorymodels.py" line="1245"/>
         <source>From Block#</source>
         <translation>From Block#</translation>
     </message>
     <message>
-        <location filename="armorymodels.py" line="1243"/>
+        <location filename="armorymodels.py" line="1246"/>
         <source>Script Type</source>
         <translation>Script Type</translation>
     </message>
     <message>
-        <location filename="armorymodels.py" line="1244"/>
+        <location filename="armorymodels.py" line="1247"/>
         <source>Sequence</source>
         <translation>Sequence</translation>
     </message>
     <message>
-        <location filename="armorymodels.py" line="1245"/>
+        <location filename="armorymodels.py" line="1248"/>
         <source>Script</source>
         <translation>Script</translation>
     </message>
@@ -10210,22 +10245,22 @@ It can now be broadcast from any computer running Armory in online mode.</transl
 <context>
     <name>TxOutDispModel</name>
     <message>
-        <location filename="armorymodels.py" line="1331"/>
+        <location filename="armorymodels.py" line="1334"/>
         <source>Wallet ID</source>
         <translation>Wallet ID</translation>
     </message>
     <message>
-        <location filename="armorymodels.py" line="1332"/>
+        <location filename="armorymodels.py" line="1335"/>
         <source>Recipient</source>
         <translation>Recipient</translation>
     </message>
     <message>
-        <location filename="armorymodels.py" line="1333"/>
+        <location filename="armorymodels.py" line="1336"/>
         <source>Amount</source>
         <translation>Amount</translation>
     </message>
     <message>
-        <location filename="armorymodels.py" line="1334"/>
+        <location filename="armorymodels.py" line="1337"/>
         <source>Script Type</source>
         <translation>Script Type</translation>
     </message>
@@ -10282,37 +10317,37 @@ It can now be broadcast from any computer running Armory in online mode.</transl
 <context>
     <name>WalletAddrDispModel</name>
     <message>
-        <location filename="armorymodels.py" line="1082"/>
+        <location filename="armorymodels.py" line="1085"/>
         <source>Address</source>
         <translation>Address</translation>
     </message>
     <message>
-        <location filename="armorymodels.py" line="1083"/>
+        <location filename="armorymodels.py" line="1086"/>
         <source>Comment</source>
         <translation>Comment</translation>
     </message>
     <message>
-        <location filename="armorymodels.py" line="1084"/>
+        <location filename="armorymodels.py" line="1087"/>
         <source>#Tx</source>
         <translation>#Tx</translation>
     </message>
     <message>
-        <location filename="armorymodels.py" line="1085"/>
+        <location filename="armorymodels.py" line="1088"/>
         <source>Balance</source>
         <translation>Balance</translation>
     </message>
     <message>
-        <location filename="armorymodels.py" line="1053"/>
+        <location filename="armorymodels.py" line="1056"/>
         <source>&lt;u&gt;&lt;/u&gt;This is an imported address. Imported addresses are not protected by regular paper backups.  You must use the &quot;Backup Individual Keys&quot; option to protect it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="armorymodels.py" line="1058"/>
+        <location filename="armorymodels.py" line="1061"/>
         <source>&lt;u&gt;&lt;/u&gt;The order that this address was generated in this wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="armorymodels.py" line="1062"/>
+        <location filename="armorymodels.py" line="1065"/>
         <source>This address was created by Armory to receive change-back-to-self from an oversized transaction.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10580,27 +10615,27 @@ nter: &lt;Number&gt; (kb, mb)</translation>
 <context>
     <name>context</name>
     <message>
-        <location filename="qtdialogs.py" line="10896"/>
+        <location filename="qtdialogs.py" line="10901"/>
         <source>Invalid Code</source>
         <translation>Invalid Code</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10896"/>
+        <location filename="qtdialogs.py" line="10901"/>
         <source>You didn&apos;t enter a full SecurePrintu200bu2122 code.  This code is needed to decrypt your backup file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10907"/>
+        <location filename="qtdialogs.py" line="10912"/>
         <source>Bad SecurePrintu200bu2122 Code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10901"/>
+        <location filename="qtdialogs.py" line="10906"/>
         <source>The SecurePrintu200bu2122 code you entered has an error in it.  Note that the code is case-sensitive.  Please verify you entered it correctly and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="10907"/>
+        <location filename="qtdialogs.py" line="10912"/>
         <source>The SecurePrintu200bu2122 code you entered has unrecognized characters in it.  %1 Only the following characters are allowed: %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10608,36 +10643,36 @@ nter: &lt;Number&gt; (kb, mb)</translation>
 <context>
     <name>dlgChangeOwner</name>
     <message>
-        <location filename="qtdialogs.py" line="1972"/>
+        <location filename="qtdialogs.py" line="1974"/>
         <source>This wallet is mine</source>
         <translation>This wallet is mine</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2015"/>
+        <location filename="qtdialogs.py" line="2017"/>
         <source>Wallet owner (optional):</source>
         <translation>Wallet owner (optional):</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2023"/>
+        <location filename="qtdialogs.py" line="2025"/>
         <source>Set Wallet Owner</source>
         <translation>Set Wallet Owner</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="1975"/>
+        <location filename="qtdialogs.py" line="1977"/>
         <source>The funds in this wallet are currently identified as belonging to &lt;b&gt;&lt;i&gt;you&lt;/i&gt;&lt;/b&gt;.  As such, any funds available to this wallet will be included in the total balance displayed on the main screen.  
 
  If you do not actually own this wallet, or do not wish for its funds to be considered part of your balance, uncheck the box below.  Optionally, you can include the name of the person or organization that does own it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="1995"/>
+        <location filename="qtdialogs.py" line="1997"/>
         <source>The funds in this wallet are currently identified as belonging to &lt;i&gt;&lt;b&gt;%1&lt;/b&gt;&lt;/i&gt;.  If these funds are actually yours, and you would like the funds included in your balance in the main window, please check the box below.
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2004"/>
+        <location filename="qtdialogs.py" line="2006"/>
         <source>You might choose this option if you keep a full wallet on a non-internet-connected computer, and use this watching-only wallet on this computer to generate addresses and monitor incoming transactions.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10645,37 +10680,37 @@ nter: &lt;Number&gt; (kb, mb)</translation>
 <context>
     <name>dlgWarn</name>
     <message>
-        <location filename="qtdefines.py" line="447"/>
+        <location filename="qtdefines.py" line="448"/>
         <source>&amp;Yes</source>
         <translation>&amp;Yes</translation>
     </message>
     <message>
-        <location filename="qtdefines.py" line="448"/>
+        <location filename="qtdefines.py" line="449"/>
         <source>&amp;No</source>
         <translation>&amp;No</translation>
     </message>
     <message>
-        <location filename="qtdefines.py" line="456"/>
+        <location filename="qtdefines.py" line="457"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Cancel</translation>
     </message>
     <message>
-        <location filename="qtdefines.py" line="458"/>
+        <location filename="qtdefines.py" line="459"/>
         <source>&amp;OK</source>
         <translation>&amp;OK</translation>
     </message>
     <message>
-        <location filename="qtdefines.py" line="509"/>
+        <location filename="qtdefines.py" line="510"/>
         <source>Do not show this message again</source>
         <translation>Do not show this message again</translation>
     </message>
     <message>
-        <location filename="qtdefines.py" line="512"/>
+        <location filename="qtdefines.py" line="513"/>
         <source>Do not ask again</source>
         <translation>Do not ask again</translation>
     </message>
     <message>
-        <location filename="qtdefines.py" line="515"/>
+        <location filename="qtdefines.py" line="516"/>
         <source>Do not show this warning again</source>
         <translation>Do not show this warning again</translation>
     </message>
@@ -10683,12 +10718,12 @@ nter: &lt;Number&gt; (kb, mb)</translation>
 <context>
     <name>main</name>
     <message>
-        <location filename="qtdialogs.py" line="2030"/>
+        <location filename="qtdialogs.py" line="2032"/>
         <source>Careful!</source>
         <translation>Careful!</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2030"/>
+        <location filename="qtdialogs.py" line="2032"/>
         <source>Armory is not online yet, and will eventually need to be online to access any funds sent to your wallet.  Please &lt;u&gt;&lt;b&gt;do not&lt;/b&gt;&lt;/u&gt; receive Bitcoins to your Armory wallets until you have successfully gotten online &lt;i&gt;at least one time&lt;/i&gt;. &lt;br&gt;&lt;br&gt; Armory is still beta software, and some users report difficulty ever getting online. &lt;br&gt;&lt;br&gt; Do you wish to continue? </source>
         <translation>Armory is not online yet, and will eventually need to be online to access any funds sent to your wallet.  Please &lt;u&gt;&lt;b&gt;do not&lt;/b&gt;&lt;/u&gt; receive Bitcoins to your Armory wallets until you have successfully gotten online &lt;i&gt;at least one time&lt;/i&gt;. &lt;br&gt;&lt;br&gt; Armory is still beta software, and some users report difficulty ever getting online. &lt;br&gt;&lt;br&gt; Do you wish to continue? </translation>
     </message>
@@ -10711,87 +10746,87 @@ nter: &lt;Number&gt; (kb, mb)</translation>
         <translation>Expert User</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2063"/>
+        <location filename="qtdialogs.py" line="2065"/>
         <source>This is not your wallet!</source>
         <translation>This is not your wallet!</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2063"/>
+        <location filename="qtdialogs.py" line="2065"/>
         <source>Do not show this warning again</source>
         <translation>Do not show this warning again</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2063"/>
+        <location filename="qtdialogs.py" line="2065"/>
         <source>You are getting an address for a wallet that you have specified belongs to you, but you cannot actually spend the funds from this computer.  This is usually the case when you keep the full wallet on a separate computer for security purposes.&lt;br&gt;&lt;br&gt;If this does not sound right, then please do not use the following address.  Instead, change the wallet properties &quot;Belongs To&quot; field to specify that this wallet is not actually yours.</source>
         <translation>You are getting an address for a wallet that you have specified belongs to you, but you cannot actually spend the funds from this computer.  This is usually the case when you keep the full wallet on a separate computer for security purposes.&lt;br&gt;&lt;br&gt;If this does not sound right, then please do not use the following address.  Instead, change the wallet properties &quot;Belongs To&quot; field to specify that this wallet is not actually yours.</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="7040"/>
+        <location filename="qtdialogs.py" line="7045"/>
         <source>Unlock Paper Backup</source>
         <translation>Unlock Paper Backup</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="7043"/>
+        <location filename="qtdialogs.py" line="7048"/>
         <source>Unlock Failed</source>
         <translation>Unlock Failed</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="7066"/>
+        <location filename="qtdialogs.py" line="7071"/>
         <source>Verify Your Backup!</source>
         <translation>Verify Your Backup!</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="7202"/>
+        <location filename="qtdialogs.py" line="7207"/>
         <source>Bad Public Key</source>
         <translation>Bad Public Key</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="7202"/>
+        <location filename="qtdialogs.py" line="7207"/>
         <source>Public key data was not recognized</source>
         <translation>Public key data was not recognized</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="7211"/>
+        <location filename="qtdialogs.py" line="7216"/>
         <source>Bad Signature</source>
         <translation>Bad Signature</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="7211"/>
+        <location filename="qtdialogs.py" line="7216"/>
         <source>Signature data is malformed!</source>
         <translation>Signature data is malformed!</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="7219"/>
+        <location filename="qtdialogs.py" line="7224"/>
         <source>Address Mismatch</source>
         <translation>Address Mismatch</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8229"/>
+        <location filename="qtdialogs.py" line="8234"/>
         <source>Select</source>
         <translation>Select</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8235"/>
+        <location filename="qtdialogs.py" line="8240"/>
         <source>No wallets!</source>
         <translation>No wallets!</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8246"/>
+        <location filename="qtdialogs.py" line="8251"/>
         <source>Select from Address Book</source>
         <translation>Select from Address Book</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="12429"/>
+        <location filename="qtdialogs.py" line="12434"/>
         <source>Recovery Test</source>
         <translation>Recovery Test</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="12457"/>
+        <location filename="qtdialogs.py" line="12462"/>
         <source>Bad Backup!</source>
         <translation>Bad Backup!</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="12470"/>
+        <location filename="qtdialogs.py" line="12475"/>
         <source>Backup is Good!</source>
         <translation>Backup is Good!</translation>
     </message>
@@ -10801,52 +10836,52 @@ nter: &lt;Number&gt; (kb, mb)</translation>
         <translation>Export Lockbox Definition</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="12470"/>
+        <location filename="qtdialogs.py" line="12475"/>
         <source>Your backup works! &lt;br&gt;&lt;br&gt; The wallet ID computed from the data you entered matches the expected ID.  This confirms that the backup produces the same sequence of private keys as the original wallet! &lt;br&gt;&lt;br&gt; Computed wallet ID: %1 &lt;br&gt; Expected wallet ID: %2 &lt;br&gt; &lt;br&gt;</source>
         <translation>Your backup works! &lt;br&gt;&lt;br&gt; The wallet ID computed from the data you entered matches the expected ID.  This confirms that the backup produces the same sequence of private keys as the original wallet! &lt;br&gt;&lt;br&gt; Computed wallet ID: %1 &lt;br&gt; Expected wallet ID: %2 &lt;br&gt; &lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="2049"/>
+        <location filename="qtdialogs.py" line="2051"/>
         <source>You are getting an address for a wallet that does not appear to belong to you.  Any money sent to this address will not appear in your total balance, and cannot be spent from this computer. &lt;br&gt;&lt;br&gt; If this is actually your wallet (perhaps you maintain the full wallet on a separate computer), then please change the &quot;Belongs To&quot; field in the wallet-properties for this wallet.</source>
         <translation>You are getting an address for a wallet that does not appear to belong to you.  Any money sent to this address will not appear in your total balance, and cannot be spent from this computer. &lt;br&gt;&lt;br&gt; If this is actually your wallet (perhaps you maintain the full wallet on a separate computer), then please change the &quot;Belongs To&quot; field in the wallet-properties for this wallet.</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="7219"/>
+        <location filename="qtdialogs.py" line="7224"/>
         <source>!!! The address included in the signature block does not match the supplied public key!  This should never happen, and may in fact be an attempt to mislead you !!!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="8235"/>
+        <location filename="qtdialogs.py" line="8240"/>
         <source>You have no wallets so there is no address book to display.</source>
         <translation type="unfinished">You have no wallets so there is no address book to display.</translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="7043"/>
+        <location filename="qtdialogs.py" line="7048"/>
         <source>The wallet could not be unlocked.  Please try again with the correct unlock passphrase.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="7066"/>
+        <location filename="qtdialogs.py" line="7071"/>
         <source>&lt;b&gt;&lt;u&gt;Verify your backup!&lt;/u&gt;&lt;/b&gt; &lt;br&gt;&lt;br&gt;If you just made a backup, make sure that it is correct! The following steps are recommended to verify its integrity: &lt;br&gt;&lt;ul&gt;&lt;li&gt;Verify each line of the backup data contains &lt;b&gt;9 columns&lt;/b&gt; of &lt;b&gt;4 letters each&lt;/b&gt; (excluding any &quot;ID&quot; lines).&lt;/li&gt; &lt;li&gt;%1&lt;/li&gt;&lt;li&gt;Use Armory&apos;s backup tester to test the backup before you physiclly secure it.&lt;/li&gt; &lt;/ul&gt;&lt;br&gt;Armory has a backup tester that uses the exact same process as restoring your wallet, but stops before it writes any data to disk.  Would you like to test your backup now? </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="12429"/>
+        <location filename="qtdialogs.py" line="12434"/>
         <source>From the data you entered, Armory calculated the following wallet ID: &lt;font color=&quot;blue&quot;&gt;&lt;b&gt;%1&lt;/b&gt;&lt;/font&gt; &lt;br&gt;&lt;br&gt;Does this match the wallet ID on the backup you are testing?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="12437"/>
+        <location filename="qtdialogs.py" line="12442"/>
         <source>If this is your only backup and you are sure that you entered the data correctly, then it is &lt;b&gt;highly recommended you stop using this wallet!&lt;/b&gt;  If this wallet currently holds any funds, you should move the funds to a wallet that &lt;u&gt;does&lt;/u&gt; have a working backup. &lt;br&gt;&lt;br&gt; &lt;br&gt;&lt;br&gt;Wallet ID of the data you entered: %1 &lt;br&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="12447"/>
+        <location filename="qtdialogs.py" line="12452"/>
         <source>&lt;b&gt;Your backup works!&lt;/b&gt; &lt;br&gt;&lt;br&gt;The wallet ID is computed from a combination of the root private key, the &quot;chaincode&quot; and the first address derived from those two pieces of data.  A matching wallet ID guarantees it will produce the same chain of addresses as the original.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="12457"/>
+        <location filename="qtdialogs.py" line="12462"/>
         <source>If you are sure that you entered the backup information correctly, then it is &lt;b&gt;highly recommended you stop using this wallet!&lt;/b&gt;  If this wallet currently holds any funds, you should move the funds to a wallet that &lt;u&gt;does&lt;/u&gt; have a working backup.&lt;br&gt;&lt;br&gt;Computed wallet ID: %1 &lt;br&gt;Expected wallet ID: %2 &lt;br&gt;&lt;br&gt;Is it possible that you loaded a different backup than the one you just made?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10856,12 +10891,12 @@ nter: &lt;Number&gt; (kb, mb)</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="7053"/>
+        <location filename="qtdialogs.py" line="7058"/>
         <source>If the backup was printed with SecurePrintu200bu2122, please make sure you wrote the SecurePrintu200bu2122 code on the printed sheet of paper. Note that the code &lt;b&gt;&lt;u&gt;is&lt;/u&gt;&lt;/b&gt; case-sensitive!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qtdialogs.py" line="7060"/>
+        <location filename="qtdialogs.py" line="7065"/>
         <source>If the backup was created with SecurePrintu200bu2122, please make sure you wrote the SecurePrintu200bu2122 code on each fragment (or stored with each file fragment). The code is the same for all fragments.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10869,17 +10904,17 @@ nter: &lt;Number&gt; (kb, mb)</translation>
 <context>
     <name>self.main</name>
     <message>
-        <location filename="armorymodels.py" line="523"/>
+        <location filename="armorymodels.py" line="525"/>
         <source>&lt;a href=edtBlock&gt;Block:&lt;/a&gt;</source>
         <translation>&lt;a href=edtBlock&gt;Block:&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="armorymodels.py" line="529"/>
+        <location filename="armorymodels.py" line="531"/>
         <source>&lt;a href=edtDate&gt;Date:&lt;/a&gt;</source>
         <translation>&lt;a href=edtDate&gt;Date:&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="armorymodels.py" line="535"/>
+        <location filename="armorymodels.py" line="537"/>
         <source>&lt;a href=goToTop&gt;Top&lt;/a&gt;</source>
         <translation>&lt;a href=goToTop&gt;Top&lt;/a&gt;</translation>
     </message>

--- a/qtdialogs.py
+++ b/qtdialogs.py
@@ -3585,9 +3585,9 @@ class DlgIntroMessage(ArmoryDialog):
       lblSlogan.setAlignment(Qt.AlignHCenter | Qt.AlignVCenter)
 
       lblDescr = QRichLabel(self.tr(
-         '<b>You are about to use the most secure and feature-rich Bitcoin client'
-         'software available!</b>  But please remember, this software'
-         'is still <i>Beta</i> - Armory developers will not be held responsible'
+         '<b>You are about to use the most secure and feature-rich Bitcoin client '
+         'software available!</b>  But please remember, this software '
+         'is still <i>Beta</i> - Armory developers will not be held responsible '
          'for loss of bitcoins resulting from the use of this software!'
          '<br><br>'))
       lblDescr.setOpenExternalLinks(True)


### PR DESCRIPTION
Fixed several typos in the Greetings! Welcome to Armory! pop up via qtdialogs.py and running the exact pylupdate4 command listed at https://github.com/goatpig/BitcoinArmory/blob/master/translations.md#update-transifex-translations, as instructed by achow101 at #242.

Rebased to testing branch as instructed by gotapig at https://github.com/goatpig/BitcoinArmory/pull/244#issuecomment-309239431