### PR TITLE
Fix OSX build

### DIFF
--- a/cppForSwig/ThreadSafeClasses.h
+++ b/cppForSwig/ThreadSafeClasses.h
@@ -438,10 +438,9 @@ public:
       if (updatemap.size() == 0)
          return;
 
-      auto newMap = make_shared<map<T, U>>();
+      auto newMap = make_shared<map<T, U>>( move(updatemap));
 
       unique_lock<mutex> lock(mu_);
-      *newMap = updatemap;
       newMap->insert(map_->begin(), map_->end());
 
       map_ = newMap;


### PR DESCRIPTION
Here is error message from compiler

/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/utility:341:15: error: object of type 'ScrAddrFilter::AddrAndHash' cannot be assigned because its copy assignment operator is implicitly deleted
        first = _VSTD::forward<first_type>(__p.first);
              ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/map:646:15: note: in instantiation of member function 'std::__1::pair<ScrAddrFilter::AddrAndHash, int>::operator=' requested here
        {__nc = __v.__cc; return *this;}
              ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/__tree:1249:35: note: in instantiation of member function 'std::__1::__value_type<ScrAddrFilter::AddrAndHash, int>::operator=' requested here
                __cache->__value_ = *__first;
                                  ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/__tree:1190:9: note: in instantiation of function template specialization 'std::__1::__tree<std::__1::__value_type<ScrAddrFilter::AddrAndHash, int>, std::__1::__map_value_compare<ScrAddrFilter::AddrAndHash, std::__1::__value_type<ScrAddrFilter::AddrAndHash, int>, std::__1::less<ScrAddrFilter::AddrAndHash>, true>, std::__1::allocator<std::__1::__value_type<ScrAddrFilter::AddrAndHash, int> > >::__assign_multi<std::__1::__tree_const_iterator<std::__1::__value_type<ScrAddrFilter::AddrAndHash, int>, std::__1::__tree_node<std::__1::__value_type<ScrAddrFilter::AddrAndHash, int>, void *> *, long> >' requested here
        __assign_multi(__t.begin(), __t.end());
        ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/map:934:21: note: in instantiation of member function 'std::__1::__tree<std::__1::__value_type<ScrAddrFilter::AddrAndHash, int>, std::__1::__map_value_compare<ScrAddrFilter::AddrAndHash, std::__1::__value_type<ScrAddrFilter::AddrAndHash, int>, std::__1::less<ScrAddrFilter::AddrAndHash>, true>, std::__1::allocator<std::__1::__value_type<ScrAddrFilter::AddrAndHash, int> > >::operator=' requested here
            __tree_ = __m.__tree_;
                    ^
/Users/user/Dev/BlocksettleArmory/cppForSwig/ThreadSafeClasses.h:444:15: note: in instantiation of member function 'std::__1::map<ScrAddrFilter::AddrAndHash, int, std::__1::less<ScrAddrFilter::AddrAndHash>, std::__1::allocator<std::__1::pair<const ScrAddrFilter::AddrAndHash, int> > >::operator=' requested here
      *newMap = updatemap;
              ^
/Users/user/Dev/BlocksettleArmory/cppForSwig/BDM_supportClasses.h:312:20: note: in instantiation of member function 'TransactionalMap<ScrAddrFilter::AddrAndHash, int>::update' requested here
      scrAddrMap_->update(saMap);
                   ^
/Users/user/Dev/BlocksettleArmory/cppForSwig/BDM_supportClasses.h:149:24: note: copy assignment operator of 'AddrAndHash' is implicitly deleted because field 'scrAddr_' has no copy assignment operator
      const BinaryData scrAddr_;
                       ^