### PR TITLE
Do not subtract MESSAGE_HEADER_LEN from version payload length

### DIFF
--- a/cppForSwig/BitcoinP2P.cpp
+++ b/cppForSwig/BitcoinP2P.cpp
@@ -520,7 +520,7 @@ void Payload_Version::deserialize(uint8_t* data, size_t len)
    vheader_.nonce_ = *(uint64_t*)dataptr;
    dataptr += 8;
 
-   size_t remaining = len - MESSAGE_HEADER_LEN - USERAGENT_OFFSET;
+   size_t remaining = len - USERAGENT_OFFSET;
    uint64_t uaLen;
    auto varintlen = get_varint(uaLen, dataptr, remaining);
    dataptr += varintlen;


### PR DESCRIPTION
The payload length does not include the MESSAGE_HEADER_LEN which means that our calculation for the remaining size of the version payload is too small. When the payload length is exactly 104 bytes (as it is with Bitcoin Core 0.15.0.1 due to the slightly longer user agent), this will cause `get_varint` to fail. This was not experienced before because the version message was 2 bytes shorter at 102 bytes so the size remaining was greater than 0.

This should fix the bug identified by @jameshilliard on IRC.