### PR TITLE
Update regtest RPC port to 18443

### DIFF
--- a/armoryengine/ArmoryUtils.py
+++ b/armoryengine/ArmoryUtils.py
@@ -525,7 +525,7 @@ else:
    bdmConfig.selectNetwork("Test")
    
    BITCOIN_PORT = 18444 if USE_REGTEST else 18333
-   BITCOIN_RPC_PORT = 18332
+   BITCOIN_RPC_PORT = 18443 if USE_REGTEST else 18332
    ARMORY_RPC_PORT     = 18225
    if USE_TESTNET:
       MAGIC_BYTES  = '\x0b\x11\x09\x07'


### PR DESCRIPTION
The Bitcoin Core rpc port was changed to 18443 in https://github.com/bitcoin/bitcoin/pull/10825. This change is in bitcoin master and will be in Bitcoin Core 0.16.0.