### PR TITLE
Make libCppBlockUtils not dependent on GUI

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -23,13 +23,11 @@ copy-script:
 	cp cppForSwig/ArmoryDB ./ArmoryDB
 
 # SWIG code and requirements.
-if HAVE_GUI
 	cp cppForSwig/CppBlockUtils.py ./CppBlockUtils.py
 if BUILD_DARWIN
 	cp cppForSwig/.libs/libCppBlockUtils.dylib ./_CppBlockUtils.so
 else
 	cp cppForSwig/.libs/libCppBlockUtils.so ./_CppBlockUtils.so
-endif
 endif
 
 .PHONY: copy-script lrelease qrc_img_resources.py
@@ -42,14 +40,14 @@ uninstall-old:
 	rm -f $(DESTDIR)$(prefix)/bin/ArmoryDB
 
 install-exec-hook: uninstall-old
-if HAVE_GUI
-	mkdir -p $(DESTDIR)$(prefix)/lib/armory/ui
 	mkdir -p $(DESTDIR)$(prefix)/lib/armory/armoryengine
-	mkdir -p $(DESTDIR)$(prefix)/lib/armory/lang
 	mkdir -p $(DESTDIR)$(prefix)/share/applications
 	cp *.py *.so README.md $(DESTDIR)$(prefix)/lib/armory
-	cp -r ui/* $(DESTDIR)$(prefix)/lib/armory/ui
 	cp -r armoryengine/* $(DESTDIR)$(prefix)/lib/armory/armoryengine
+if HAVE_GUI
+	mkdir -p $(DESTDIR)$(prefix)/lib/armory/ui
+	mkdir -p $(DESTDIR)$(prefix)/lib/armory/lang
+	cp -r ui/* $(DESTDIR)$(prefix)/lib/armory/ui
 	cp lang/*.qm $(DESTDIR)$(prefix)/lib/armory/lang
 endif
 
@@ -66,11 +64,9 @@ endif
 
 # Skip Linux-specific steps on OSX.
 if ! BUILD_DARWIN
-if HAVE_GUI
 	rsync -rupE --exclude="img/.DS_Store" img $(DESTDIR)$(prefix)/share/armory/
 	sed "s: /usr: $(prefix):g" < dpkgfiles/armory > $(DESTDIR)$(prefix)/bin/armory
 	chmod +x $(DESTDIR)$(prefix)/bin/armory
-endif
 endif
 
 uninstall-hook: uninstall-old

--- a/configure.ac
+++ b/configure.ac
@@ -61,9 +61,6 @@ m4_include([m4/ax_cxx_compile_stdcxx.m4])
 #check for c++11
 AX_CXX_COMPILE_STDCXX([11], [noext], [mandatory], [nodefault])
 
-if test "x$with_gui" = "xyes"; then
-#check for  swig
-
 AC_CHECK_PROG([HAVE_SWIG], [swig], [yes], [no])
 AS_IF([test $HAVE_SWIG == yes], [],
 	[AC_MSG_ERROR([missing swig!])]) 
@@ -78,6 +75,9 @@ AC_SUBST([AX_SWIG_PYTHON_CPPFLAGS], [`python-config --includes`])
 fi
 
 AC_MSG_RESULT([AX_SWIG_PYTHON_CPPFLAGS: $AX_SWIG_PYTHON_CPPFLAGS])
+
+if test "x$with_gui" = "xyes"; then
+#check for  gui
 
 AC_CHECK_PROG([HAVE_PYRCC4], [pyrcc4], [yes], [no])
 AS_IF([test $HAVE_PYRCC4 == yes], [],

--- a/cppForSwig/Makefile.am
+++ b/cppForSwig/Makefile.am
@@ -75,7 +75,6 @@ ArmoryDB_LDADD = -Llmdb -llmdb \
 ArmoryDB_LDFLAGS = -static $(LDFLAGS)
 
 #libCppBlockUtils
-if HAVE_GUI
 lib_LTLIBRARIES = libCppBlockUtils.la
 
 libCppBlockUtils_la_SOURCES = $(INCLUDE_FILES) \
@@ -107,4 +106,3 @@ clean-local:
 	rm -f CppBlockUtils.py
 	rm -f CppBlockUtils_wrap.cxx
 	rm -f CppBlockUtils_wrap.h
-endif


### PR DESCRIPTION
_CppBlockUtils.so is required for armoryd but does not require the GUI