### PR TITLE
Allow specifying arbitrary python versions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -74,7 +74,7 @@ if test "x$cross_compiling" != "xyes"; then
 		[AC_MSG_ERROR([failed to procure swig include path, make sure swig is installed])])
 	AX_PYTHON_MODULE([psutil], [fatal])
 else
-AC_SUBST([AX_SWIG_PYTHON_CPPFLAGS], [`python-config --includes`])
+AC_SUBST([AX_SWIG_PYTHON_CPPFLAGS], [`$PYTHON-config --includes`])
 fi
 
 AC_MSG_RESULT([AX_SWIG_PYTHON_CPPFLAGS: $AX_SWIG_PYTHON_CPPFLAGS])

--- a/m4/ax_python_devel.m4
+++ b/m4/ax_python_devel.m4
@@ -275,9 +275,7 @@ EOD`
 	#
 	AC_MSG_CHECKING(python extra linking flags)
 	if test -z "$PYTHON_EXTRA_LIBS"; then
-		PYTHON_EXTRA_LIBS=`$PYTHON -c "import distutils.sysconfig; \
-			conf = distutils.sysconfig.get_config_var; \
-			print (conf('LINKFORSHARED'))"`
+		PYTHON_EXTRA_LIBS=`$PYTHON-config --ldflags`
 	fi
 	AC_MSG_RESULT([$PYTHON_EXTRA_LIBS])
 	AC_SUBST(PYTHON_EXTRA_LIBS)


### PR DESCRIPTION
You should be able to pass the python version to configure now like `./configure PYTHON_VERSION='3.6'`