### PR TITLE
The fcgi directory is completely empty!

### DIFF
--- a/cppForSwig/Makefile.am
+++ b/cppForSwig/Makefile.am
@@ -3,8 +3,8 @@ if BUILD_TESTS
 MAYBE_BUILD += gtest
 endif
 
-DIST_SUBDIRS = lmdb fcgi cryptopp
-SUBDIRS = lmdb fcgi cryptopp $(MAYBE_BUILD)
+DIST_SUBDIRS = lmdb cryptopp
+SUBDIRS = lmdb cryptopp $(MAYBE_BUILD)
 
 SWIG_FLAGS = -c++ -python -threads
 AM_CXXFLAGS = $(CXXFLAGS) -std=c++11


### PR DESCRIPTION
The fcgi directory has nothing in it; it has no Makefile.am and
thus `configure` fails.

Please note that I am attempting to build out-of-tree, as is "normal"
to protect the source code from corruption: viz.
```
./autogen.sh
mkdir build
cd build
../configure
make
``` 

I suspect that maybe the fcgi directory plays some role during build ???