### PR TITLE
Work around build break

### DIFF
--- a/cppForSwig/BtcUtils.cpp
+++ b/cppForSwig/BtcUtils.cpp
@@ -7,9 +7,9 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "BtcUtils.h"
-#include "hmac.h"
-#include "sha.h"
-#include "base64.h"
+#include "cryptopp/hmac.h"
+#include "cryptopp/sha.h"
+#include "cryptopp/base64.h"
 #include "EncryptionUtils.h"
 #include "BlockDataManagerConfig.h"
 

--- a/cppForSwig/BtcUtils.h
+++ b/cppForSwig/BtcUtils.h
@@ -29,10 +29,10 @@
 #include <stdexcept>
 
 #include "BinaryData.h"
-#include "cryptlib.h"
-#include "sha.h"
-#include "integer.h"
-#include "ripemd.h"
+#include "cryptopp/cryptlib.h"
+#include "cryptopp/sha.h"
+#include "cryptopp/integer.h"
+#include "cryptopp/ripemd.h"
 #include "UniversalTimer.h"
 #include "log.h"
 

--- a/cppForSwig/EncryptionUtils.cpp
+++ b/cppForSwig/EncryptionUtils.cpp
@@ -7,8 +7,8 @@
 ////////////////////////////////////////////////////////////////////////////////
 #include "EncryptionUtils.h"
 #include "log.h"
-#include "integer.h"
-#include "oids.h"
+#include "cryptopp/integer.h"
+#include "cryptopp/oids.h"
 
 //#include <openssl/ec.h>
 //#include <openssl/ecdsa.h>

--- a/cppForSwig/EncryptionUtils.h
+++ b/cppForSwig/EncryptionUtils.h
@@ -59,14 +59,14 @@
 #include <cmath>
 #include <algorithm>
 
-#include "cryptlib.h"
-#include "osrng.h"
-#include "sha.h"
-#include "aes.h"
-#include "modes.h"
-#include "eccrypto.h"
-#include "filters.h"
-#include "DetSign.h"
+#include "cryptopp/cryptlib.h"
+#include "cryptopp/osrng.h"
+#include "cryptopp/sha.h"
+#include "cryptopp/aes.h"
+#include "cryptopp/modes.h"
+#include "cryptopp/eccrypto.h"
+#include "cryptopp/filters.h"
+#include "cryptopp/DetSign.h"
 
 #include "BinaryData.h"
 #include "BtcUtils.h"


### PR DESCRIPTION
The source code does not build under Ubuntu 16.04 (Xenial) - these changes are needed for make forward progress.

I note that the files in the `cryptopp` directory appear to mirror the files installed by the `libcrypto++-dev` package.  This makes me nervous from the security standpoint: if there any bug-fixes to `libcrypto++-dev`, the BitcoinArmory will not benefit from them.  Also, copying source code like this just makes the whole package harder to audit.  Copying source is usually considered to be an emergency measure, when the copied package is out-of-date or unmaintained, which does not seem to be the case for  `libcrypto++-dev`. So this is a confusing situation.