### PR TITLE
Use estimatesmartfee instead of estimatefee

### DIFF
--- a/cppForSwig/nodeRPC.cpp
+++ b/cppForSwig/nodeRPC.cpp
@@ -206,7 +206,7 @@ float NodeRPC::getFeeByte(unsigned blocksToConfirm)
    ReentrantLock lock(this);
 
    JSON_object json_obj;
-   json_obj.add_pair("method", "estimatefee");
+   json_obj.add_pair("method", "estimatesmartfee");
 
    auto json_array = make_shared<JSON_array>();
    json_array->add_value(blocksToConfirm);


### PR DESCRIPTION
Bitcoin Core 0.16 will deprecate the `estimatefee` command in favor of the `estimatesmartfee` command. `estimatefee` will be hidden behind a command line switch and then removed in Bitcoin Core 0.17. Switch to using `estimatesmartfee` so that fee estimation will still work.

See https://github.com/bitcoin/bitcoin/pull/11031