### PR TITLE
Update macOS-related README materials

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,9 @@ Multi-signature transactions are accommodated under-the-hood about 80%, and will
 
 ## Building Armory From Source
 
-[Instructions for Windows](windowsbuild/Windows_build_notes.md)  
-[Instructions for Mac OS X](osxbuild/OSX_build_notes.md)  
+[Instructions for Windows](windowsbuild/Windows_build_notes.md)
+[Instructions for macOS](osxbuild/OSX_build_notes.md)
 [Instructions for Ubuntu and Arch Linux](linuxbuild/Linux_build_notes.md)
-
 
 ### Dependencies
 
@@ -59,6 +58,9 @@ Multi-signature transactions are accommodated under-the-hood about 80%, and will
 
 * LMDB - database engine, modified to suit Armory's use cases
 [LMDB page](http://symas.com/mdb/)
+
+* macOS
+ [Instructions for downloading, verifying, and running Armory on macOS](README_OSX.md).
 
 ## Sample Code
 

--- a/README_OSX.md
+++ b/README_OSX.md
@@ -1,10 +1,10 @@
 # macOS (OS X) README
 ## Requirements
-Armory will run on OS X 10.8 and beyond. Armory may run on 10.7 if compiled in a particular form. See osxbuild/OSX\_build\_notes.md for more information.
+Armory will run on macOS 10.8 and beyond. It is highly recommended to install Armory on the newest version of macOS that is feasible, as Apple often introduces changes to newer versions that make support of older versions difficult, if not impossible.
 
-Due to [Python](https://python.org/) requirements that can't be met by macOS 10.12 (Sierra), users must use `brew` to install an updated version of OpenSSL in order for Armory 0.95.1 and beyond to run. Please follow these instructions.
+Due to [Python](https://python.org/) requirements that can't be met by default on macOS, users must use `brew` to install an updated version of OpenSSL in order for Armory to run. Please follow these instructions.
 
-1. Open a terminal and run the `brew` command. If `brew` is not found, please execute the following commands from the command line. If the final command returns any errors, consult Google, the *bitcoin-armory* IRC channel on Freenode, or the [Bitcoin Forum](https://bitcointalk.org/index.php?board=97.0) for further instructions.
+1. Open a terminal and run the `brew` command. If `brew` isn't found, please execute the following commands from the terminal (aka command line). If the final command returns any errors, consult Google, the *bitcoin-armory* IRC channel on Freenode, or the [Bitcoin Forum](https://bitcointalk.org/index.php?board=97.0) for further instructions.
 
         /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
         touch ~/.bashrc
@@ -18,9 +18,51 @@ Due to [Python](https://python.org/) requirements that can't be met by macOS 10.
 
         brew install openssl
 
-You may now run Armory.
+## Downloading and Verifying Armory
+Official Armory builds are signed by goatpig, the lead maintainer. However, goatpig isn't a member of the [Apple Developer Program](https://developer.apple.com/). Therefore, he can't sign Armory with an official key from Apple. Due to [Gatekeeper](https://support.apple.com/en-us/HT202491) requirements, this can prevent Armory from being run immediately upon unzipping files posted by goatpig. There are two possible solutions, but first, it is highly recommended that users verify builds posted by goatpig. The following steps will verify the code, and are adopted from [the official verification directions for Linux](https://btcarmory.com/docs/verify). For the sake of this example, assume the version of Armory is 2.4.1.99.
+
+1. Install [GPG Suite](https://gpgtools.org/) if it hasn't been installed already. (If you can run `gpg` on the terminal or see GPG Keychain in the Launchpad, GPG Suite has been installed.)
+
+2. Open the terminal.
+
+3. **PERFORM THIS STEP ONLY ONCE FOR YOUR MACHINE.** Download and import the [official signing key](https://keyserver.ubuntu.com/pks/lookup?search=goatpig) (GPG fingerprint 4922589A as of Nov. 2017). Make sure the fingerprint matches the fingerprint on the key server!
+
+        gpg --recv-keys --keyserver keyserver.ubuntu.com 4922589A
+
+4. Download the appropriate macOS build [from the release page](https://github.com/goatpig/BitcoinArmory/releases/) (e.g., *armory\_2.4.1.99\_osx.tar.gz*), along with *sha256sum.txt.asc*, which will contain a GPG-signed list of SHA-256 hashes of the code posted by goatpig. If a macOS-specific *shasum* file is unavailable, try *sha256sum.txt.asc* instead.
+
+5. Verify the SHA-256 hash of the macOS build.
+
+        shasum -a 256 -c sha256sum.txt.asc armory_2.4.1.99_osx.tar.gz 2>&1 | grep OK
+
+   If you see `armory_2.4.1.99_osx.tar.gz: OK` in the terminal, the code is an exact copy of what goatpig posted.
+
+6. Verify that the SHA-256 hash list was actually signed by goatpig.
+
+        gpg --verify sha256sum.txt.asc
+
+   If you see `gpg: Good signature from "goatpig (Offline signing key for Armory releases) <moothecowlord@gmail.com>" [unknown]` in the terminal, the SHA-256 hash list was signed by goatpig. If the macOS code has the correct hash and the list of hashes were signed by goatpig, you now know the code is exactly what was uploaded by goatpig.
+
+If verification fails at any point, double-check the commands you're running, and double check the fingerprint on the Ubuntu keyserver. If the fingerprints match and the commands are correct, [please post on Bitcoin Forum's Armory subforum](https://bitcointalk.org/index.php?board=97.0) or the *bitcoin-armory* IRC channel on Freenode and notify goatpig immediately.
+
+## Running Armory
+Once the builds are verified, the following steps should be followed. (Note that these steps aren't required by people who compile their own version of Armory.)
+
+1. Upon unzipping Armory, move Armory to a new directory. Moving Amrory into /Applications will make Armory accessible from the Launchpad.
+
+2. Follow [these directions from Apple](https://support.apple.com/kb/PH25088?locale=en_US) to ensure that Armory will run successfully.
+
+3. The first time a new version of Armory is run, macOS will ask if you wish to run the program. Click "Yes" and continue on. If macOS is stubborn and won't run Armory, you'll have to go to "Security & Privacy" under "System Preferences". From there, under "General", you should see a note about "Armory.app" not being able to run. Depending on which version of macOS you have, you have two options, both of which apply to the "Allow apps downloaded from" setting.
+
+   3.1. On macOS versions starting with 10.13, you'll see the message "'Armory.app' was blocked from opening because it isn't from an identified developer." Click "Open Anyway" and continue on, ignoring the aforementioned warning about unsigned code. Be sure that you are selecting the option *only* for Armory, and not for other programs!
+
+   3.2. If the option in Step 2.1 is unavailable, there is an alternative. On all supported versions of macOS, click the lock and unlock it, choose "Anywhere", re-lock the system, and start Armory, ignoring the unsigned code warning. (If the "Anywhere" option isn't seen, [follow these instructions](http://osxdaily.com/2016/09/27/allow-apps-from-anywhere-macos-gatekeeper/) to bring it up.) If you wish, you may reset the "Allow apps downloaded from" setting to a more strict setting at this point. macOS will remember that you allowed Armory to run.
+
+## Compiling Armory
+See the [macOS build README](osxbuild/OSX_build_notes.md) for more info.
 
 ## macOS-specific Bugs
-Armory developers make a best effort to ensure that all Armory features are available on all versions of Armory. Unfortunately, there are rare cases where the OS X version is missing features or has bugs not found elsewhere. The following is a list of known bugs/issues. Please report any other bugs on the [Bitcoin Forum](https://bitcointalk.org/index.php?board=97.0) or on the *bitcoin-armory* IRC channel on Freenode.
+Armory developers make a best effort to ensure that all Armory features are available on all versions of Armory. Unfortunately, there are rare cases where the macOS version is missing features or has bugs not found elsewhere. The following is a list of known bugs/issues. Please report any other bugs on the [Bitcoin Forum](https://bitcointalk.org/index.php?board=97.0) or on the *bitcoin-armory* IRC channel on Freenode.
 
-- The "File Open" dialog under OS X Armory is very "dumb." This is due to an unknown Qt 4 bug that causes Armory to crash whenever a much nicer dialog is opened. This means opening files in certain locations (e.g., thumb drives) is very difficult. The only consistent solutions are to copy files over to a location that can be opened, or to generate a [symbolic link](http://askubuntu.com/questions/600714/creating-a-symlink-from-one-folder-to-another-with-different-names) to the desired directory.
+- Due to unknown issues with multithreading on Qt 4 (a library Armory uses), there are rare instances where Armory may crash suddenly. The Armory team has done its best to mitigate the crashes, with very few users reporting any crashes at all. Armory developers themselves haven't experienced any such crashes since approximately June 2015, and no users have reported such issues since around that time.
+- The "File Open" dialog under macOS Armory is very "dumb." This is due to an unknown Qt 4 bug that causes Armory to crash whenever a "native" dialog is opened. This means opening files in certain locations (e.g., thumb drives) is very difficult. The only consistent solutions are to copy files over to a location that can be opened, or to generate a [symbolic link](http://askubuntu.com/questions/600714/creating-a-symlink-from-one-folder-to-another-with-different-names) to the desired directory.

--- a/osxbuild/OSX_build_notes.md
+++ b/osxbuild/OSX_build_notes.md
@@ -2,12 +2,12 @@
 These notes describe what had to be done on fresh installs of macOS 10.8 - 10.13 in order to compile Armory.
 
 ## Requirements / Caveats
-Armory is designed to run only on OS X 10.8 or later. Running on 10.7 may be possible with proper code editing. However, this isn't recommended due to issues with C++11 support under OS X 10.7. The latest versions of OS X and Xcode that can compile 10.7-compatible binaries are OS X 10.11 and Xcode 7.3.1. (The binaries are also compatible with macOS 10.12 and beyond.) An [Apple developer account](https://developer.apple.com/) may be used to obtain Xcode 7.3.1.
+Armory is designed to run only on macOS 10.8 or later. Running on 10.7 may be possible with proper code editing. However, this isn't recommended due to [issues with C++11 support under macOS 10.7](https://github.com/bitcoin/bitcoin/issues/8577#issuecomment-255945996). The latest versions of macOS and Xcode that can compile 10.7-compatible binaries are macOS 10.11 and Xcode 7.3.1. (The binaries are also compatible with macOS 10.12 and beyond.) An [Apple developer account](https://developer.apple.com/) may be used to obtain Xcode 7.3.1.
 
 If a bug is found, please consult the [Bitcoin Forum](https://bitcointalk.org/index.php?board=97.0) or *bitcoin-armory* IRC channel on Freenode for further instructions.
 
 ## Instructions
- 1. Install the latest version of [Xcode](https://itunes.apple.com/us/app/xcode/id497799835). As a space-saving alternative, get an Apple developer account, log in, and download the latest version of Command Line Tools for Xcode.
+ 1. Get an Apple developer account (free), log in, and download the latest version of Command Line Tools for Xcode. As an alternative, install the latest version of [Xcode](https://itunes.apple.com/us/app/xcode/id497799835) and download Command Line Tools via Xcode. Either choice will be updated via the App Store.
 
  2. Open a terminal and install the Xcode commandline tools. Follow any prompts that appear.
 
@@ -34,15 +34,19 @@ If a bug is found, please consult the [Bitcoin Forum](https://bitcointalk.org/in
 
         sudo ln -s /usr/local/bin/glibtoolize /usr/local/bin/libtoolize
 
- 7. Download Armory [here](https://github.com/goatpig/BitcoinArmory), either as a static zip file or via Git version control. If downloading a zip file, unzip the zip file.
+ 7. Download Armory [here](https://github.com/goatpig/BitcoinArmory). There are two options.
 
- 8. (*OPTIONAL*) If compiling on a pre-10.12 macOS version, change the minimum version to 10.7 from 10.8 in osxbuild/build-app.py, osxbuild/objc\_armory/ArmoryMac.pro, and osxbuild/qmake\_LFLAGS.patch by searching for instances of 10.8 and changing them to 10.7.
+   7.1. Download the source code from the [GitHub Armory releases page](https://github.com/goatpig/BitcoinArmory/releases/). Ensure that you download **only** the relevant "src.tar.gz" file, and **not** the code from the "Download ZIP" buttonfound elsewhere on GitHub. (Long story short, the `fcgi` submodule, which Armory requires, will **only** be included in the "src.tar.gz" file due to a long-standing GitHub bug affecting code auto-downloads.) After verifying the code, per the [macOS README directions](../README_OSX.md), unzip the code.
+
+   7.2. The more advanced method, which is recommended only for developers and other advanced tinkerers, is to use [Git version control](https://en.wikipedia.org/wiki/Git) in order to obtain the code. While more advanced, this makes it far easier to obtain code updates and to submit patches to Armory. Go [here](https://github.com/goatpig/BitcoinArmory) and use the "Clone or download" button to get a URL to use to clone the code. [This page](https://help.github.com/articles/cloning-a-repository-from-github/) has a partial tutorial, and [SourceTree](https://www.sourcetreeapp.com/) is a good app for starters. It is highly recommended that, at a bare minimum, users learn how to clone a repo and successfully switch between branches before going any further.
+
+ 8. (*OPTIONAL*) If compiling on a pre-10.12 macOS version with the intention of compiling for macOS 10.7, change the minimum version to 10.7 from 10.8 in osxbuild/build-app.py, osxbuild/objc\_armory/ArmoryMac.pro, and osxbuild/qmake\_LFLAGS.patch by searching for instances of 10.8 and changing them to 10.7.
 
  9. Compile Armory.
 
         cd *Location of Armory source code*  (An example would be ~/Projects/BitcoinArmory)
-		git submodule init  (Required only if using Git version control, as discussed in Step 7.)
-		git submodule update  (Required only if using Git version control, as discussed in Step 7.)
+		git submodule init  (Required only if using Git version control, as discussed in Step 7.2.)
+		git submodule update  (Required only if using Git version control, as discussed in Step 7.2.)
 		cd osxbuild
         python build-app.py > /dev/null
 
@@ -52,10 +56,5 @@ Armory.app will be found under the "workspace" subdirectory. It can be moved any
 
 To avoid runtime issues (e.g. *ImportError: No module named pkg_resources*) when attempting to run builds on other machines/VMs, make sure $PYTHONPATH is empty. In addition, try not to have any "brew"ed libpng, Python or Qt modules installed. Any of the above could lead to unpredictable behavior.
 
-If you're running a beta version of Xcode, the build tools will need to point to the beta. Open a terminal and run
-
-`sudo xcode-select --switch /Applications/Xcode-Beta.app`
-
-Command line tools should be updated automatically whenever a new version of Xcode is used. However, due to Apple constantly changing requirements for running command line tools, the following command should be run after every Xcode upgrade.
-
-`xcode-select --install`
+## Compilation issues
+If you run into any compilation issues, please [post on Bitcoin Forum's Armory subforum](https://bitcointalk.org/index.php?board=97.0) or consult the *bitcoin-armory* IRC channel on Freenode. Note that compilation of "dev"/"testing" versions of Armory may be broken on Linux and macOS. Armory's developed primarily for Windows, with Linux and macOS compilation issues fixed once goatpig's satisfied with the state of the Windows code. The "master" code should never be broken, as it consists of what gets officially released.


### PR DESCRIPTION
- Point macOS users to the appropriate files in the main README.
- Clarify various points regarding compilation and verification.
- OS X -> macOS.