### PR TITLE
Fix Armory minimization issue on macOS

### DIFF
--- a/ArmoryQt.py
+++ b/ArmoryQt.py
@@ -142,8 +142,8 @@ class ArmoryMainWindow(QMainWindow):
       else:
          if USE_TESTNET or USE_REGTEST:
             self.iconfile = ':/armory_icon_green_fullres.png'
-            ArmoryMac.MacDockIconHandler.instance().setMainWindow(self)
-            ArmoryMac.MacDockIconHandler.instance().setIcon(QIcon(self.iconfile))
+         ArmoryMac.MacDockIconHandler.instance().setMainWindow(self)
+         ArmoryMac.MacDockIconHandler.instance().setIcon(QIcon(self.iconfile))
       self.lblLogoIcon.setAlignment(Qt.AlignHCenter | Qt.AlignVCenter)
 
       self.netMode     = NETWORKMODE.Offline


### PR DESCRIPTION
When running Armory in mainnet mode and setting Armory to minimize to the tray when clicking the close button, the Armory icon in the macOS dock can only close Armory, and not restore it. Fix this problem and remove the need for the workaround (use the Armory icon in the menu bar to restore).