### PR TITLE
Add 0.96.3 mac download

### DIFF
--- a/_posts/2017-09-22-0.96.3-release.md
+++ b/_posts/2017-09-22-0.96.3-release.md
@@ -55,5 +55,6 @@ Thank you to all the contributors:
 - [Armory 0.96.3 Ubuntu/Debian 64-bit with GCC 5.4](https://github.com/goatpig/BitcoinArmory/releases/download/v0.96.3/armory_0.96.3-gcc5.4_amd64.deb)
 - [Armory 0.96.3 Windows 64-bit Installer](https://github.com/goatpig/BitcoinArmory/releases/download/v0.96.3/armory_0.96.3_win64.exe)
 - [Armory 0.96.3 Windows 64-bit Zip Package](https://github.com/goatpig/BitcoinArmory/releases/download/v0.96.3/armory_0.96.3_win64.zip)
+- [Armory 0.96.3 Mac OSX Package](https://github.com/goatpig/BitcoinArmory/releases/download/v0.96.3/armory_0.96.3_osx.tar.gz)
 - [Armory 0.96.3 Source Tarball](https://github.com/goatpig/BitcoinArmory/releases/download/v0.96.3/armory_0.96.3-src.tar.gz)
 - [Armory 0.96.3 Signed Hash File](https://github.com/goatpig/BitcoinArmory/releases/download/v0.96.3/sha256sum.txt.asc)


### PR DESCRIPTION
Apparently the download link isn't there.