### PR TITLE
bug: convert QString to string

### DIFF
--- a/ArmoryQt.py
+++ b/ArmoryQt.py
@@ -2240,7 +2240,7 @@ class ArmoryMainWindow(QMainWindow):
 
       types = ffilter
       types.append('All files (*)')
-      typesStr = ';; '.join(types)
+      typesStr = ';; '.join([str(x) for x in types])
 
       # Open the native file save dialog and grab the saved file/path unless
       # we're in OS X, where native dialogs sometimes freeze. Looks like a Qt


### PR DESCRIPTION
Fix a bug while trying to backup a wallet. I selected 'digital backup - unencrypted' but when clicking on the button to show the dialog that selects a directory to save the backup I saw this error:

```
Traceback (most recent call last):
  File "/home/jon/BitcoinArmory/ui/WalletFrames.py", line 1117, in clickedDoIt
    isBackupCreated = self.main.makeWalletCopy(self, self.wlt, 'Decrypt', 'decrypt')
  File "./ArmoryQt.py", line 1614, in makeWalletCopy
    ffilter=[self.tr('Root Pubkey Text Files (*.rootpubkey)')]))
  File "/home/jon/BitcoinArmory/armoryengine/Decorators.py", line 48, in inner
    rv = func(*args, **kwargs)
  File "./ArmoryQt.py", line 2224, in getFileSave
    typesStr = ';; '.join(types)
TypeError: sequence item 0: expected string, QString found
```
The solution is simply to convert each element of `types` to a string using `str()`