### PR TITLE
Include witness in transaction copy

### DIFF
--- a/qtdialogs.py
+++ b/qtdialogs.py
@@ -5261,7 +5261,7 @@ class DlgDispTxInfo(ArmoryDialog):
          pytx = ustx.getPyTxSignedIfPossible(signer=ustx.signerType)
 
 
-      self.pytx = pytx.copyWithoutWitness()
+      self.pytx = pytx.copy()
 
       if self.mode == None:
          self.mode = self.main.usermode


### PR DESCRIPTION
Should fix a bug where witnesses are missing from raw hex copy.