### PR TITLE
Minor macOS doc updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Multi-signature transactions are accommodated under-the-hood about 80%, and will
 ## Building Armory From Source
 
 [Instructions for Windows](windowsbuild/Windows_build_notes.md)
-[Instructions for macOS](osxbuild/OSX_build_notes.md)
+[Instructions for macOS](osxbuild/macOS_build_notes.md)
 [Instructions for Ubuntu and Arch Linux](linuxbuild/Linux_build_notes.md)
 
 ### Dependencies
@@ -60,7 +60,7 @@ Multi-signature transactions are accommodated under-the-hood about 80%, and will
 [LMDB page](http://symas.com/mdb/)
 
 * macOS
- [Instructions for downloading, verifying, and running Armory on macOS](README_OSX.md).
+ [Instructions for downloading, verifying, and running Armory on macOS](README_macOS.md).
 
 ## Sample Code
 

--- a/README_macOS.md
+++ b/README_macOS.md
@@ -1,4 +1,4 @@
-# macOS (OS X) README
+# macOS README
 ## Requirements
 Armory will run on macOS 10.8 and beyond. It is highly recommended to install Armory on the newest version of macOS that is feasible, as Apple often introduces changes to newer versions that make support of older versions difficult, if not impossible.
 
@@ -60,6 +60,9 @@ Once the builds are verified, the following steps should be followed. (Note that
 
 ## Compiling Armory
 See the [macOS build README](osxbuild/OSX_build_notes.md) for more info.
+
+## Running armoryd
+As of 2017, armoryd (a JSON-RPC daemon for Armory) is [in its own repo](https://github.com/goatpig/armoryd), separate from Armory. If users wish to run armoryd under macOS, the easiest solution is to open up Armory.app and place armoryd.py alongside the Armory codebase (Contents/MacOS/py/usr/local/lib/armory). The user can then execute the script that kicks off armoryd (`Contents/MacOS/armoryd`).
 
 ## macOS-specific Bugs
 Armory developers make a best effort to ensure that all Armory features are available on all versions of Armory. Unfortunately, there are rare cases where the macOS version is missing features or has bugs not found elsewhere. The following is a list of known bugs/issues. Please report any other bugs on the [Bitcoin Forum](https://bitcointalk.org/index.php?board=97.0) or on the *bitcoin-armory* IRC channel on Freenode.

--- a/osxbuild/macOS_build_notes.md
+++ b/osxbuild/macOS_build_notes.md
@@ -1,4 +1,4 @@
-# macOS (OS X) BUILD NOTES
+# macOS BUILD NOTES
 These notes describe what had to be done on fresh installs of macOS 10.8 - 10.13 in order to compile Armory.
 
 ## Requirements / Caveats
@@ -25,7 +25,7 @@ If a bug is found, please consult the [Bitcoin Forum](https://bitcointalk.org/in
 
  4. Install and link dependencies required by the Armory build process but not by included Armory binaries.
 
-        brew install python xz swig gettext openssl automake libtool homebrew/dupes/zlib
+        brew install xz swig gettext openssl automake libtool homebrew/dupes/zlib
         brew link gettext --force
 
  5. Restart your Mac. (This is necessary due to issues related to the Python install.)
@@ -36,7 +36,7 @@ If a bug is found, please consult the [Bitcoin Forum](https://bitcointalk.org/in
 
  7. Download Armory [here](https://github.com/goatpig/BitcoinArmory). There are two options.
 
-   7.1. Download the source code from the [GitHub Armory releases page](https://github.com/goatpig/BitcoinArmory/releases/). Ensure that you download **only** the relevant "src.tar.gz" file, and **not** the code from the "Download ZIP" buttonfound elsewhere on GitHub. (Long story short, the `fcgi` submodule, which Armory requires, will **only** be included in the "src.tar.gz" file due to a long-standing GitHub bug affecting code auto-downloads.) After verifying the code, per the [macOS README directions](../README_OSX.md), unzip the code.
+   7.1. Download the source code from the [GitHub Armory releases page](https://github.com/goatpig/BitcoinArmory/releases/). Ensure that you download **only** the relevant "src.tar.gz" file, and **not** the code from the "Download ZIP" buttonfound elsewhere on GitHub. (Long story short, the `fcgi` submodule, which Armory requires, will **only** be included in the "src.tar.gz" file due to a long-standing GitHub bug affecting code auto-downloads.) After verifying the code, per the [macOS README directions](../README_macOS.md), unzip the code.
 
    7.2. The more advanced method, which is recommended only for developers and other advanced tinkerers, is to use [Git version control](https://en.wikipedia.org/wiki/Git) in order to obtain the code. While more advanced, this makes it far easier to obtain code updates and to submit patches to Armory. Go [here](https://github.com/goatpig/BitcoinArmory) and use the "Clone or download" button to get a URL to use to clone the code. [This page](https://help.github.com/articles/cloning-a-repository-from-github/) has a partial tutorial, and [SourceTree](https://www.sourcetreeapp.com/) is a good app for starters. It is highly recommended that, at a bare minimum, users learn how to clone a repo and successfully switch between branches before going any further.
 


### PR DESCRIPTION
- Tell users how to use armoryd (off in its own repo now).
- Complete the OS X -> macOS switch, including filenames.