### PR TITLE
BugFix: If no .git directory exists the script returns the print mess…

### DIFF
--- a/update_version.py
+++ b/update_version.py
@@ -3,26 +3,29 @@ import os
 script_dir = os.path.dirname(os.path.realpath(__file__))
 os.chdir(script_dir)
 
-if os.path.exists('.git') \
-   and os.path.exists(os.path.join("armoryengine", "ArmoryUtils.py")):
-    current_head = os.path.join(".git", "HEAD")
-    f = open(current_head, "r")
-    ref = f.read()
-    f.close()
-    path_parts = ref[5:-1].split("/")
-    hash_loc = os.path.join(".git", *path_parts)
-    f = open(hash_loc, "r")
-    build = f.read()[:10]
-    f.close()
+if os.path.exists('.git'):
+    if os.path.exists(os.path.join("armoryengine", "ArmoryUtils.py")):
+        current_head = os.path.join(".git", "HEAD")
+        f = open(current_head, "r")
+        ref = f.read()
+        f.close()
+        path_parts = ref[5:-1].split("/")
+        hash_loc = os.path.join(".git", *path_parts)
+        f = open(hash_loc, "r")
+        build = f.read()[:10]
+        f.close()
 
-    build_file = os.path.join("armoryengine", "ArmoryBuild.py")
-    f = open(build_file, "w")
-    f.write("BTCARMORY_BUILD = '%s'\n" % build)
-    f.close()
-
-    print "Build number has been updated to %s" % build
-
+    else:
+        print "Please run this script from the root Armory source directory" \
+            " along with the .git directory"
 else:
-    print "Please run this script from the root Armory source directory" \
-        " along with the .git directory"
+    import subprocess
+    build = subprocess.check_output("git ls-remote --heads https://github.com/goatpig/BitcoinArmory.git refs/heads/master", shell=True)
+    build = build[:10]
 
+build_file = os.path.join("armoryengine", "ArmoryBuild.py")
+f = open(build_file, "w")
+f.write("BTCARMORY_BUILD = '%s'\n" % build)
+f.close()
+
+print "Build number has been updated to %s" % build

--- a/update_version.py
+++ b/update_version.py
@@ -1,4 +1,12 @@
 import os
+import urllib2
+
+def _fetch_url( url ):
+    try:
+        urllib2.urlopen(url, timeout=1)
+        return True
+    except urllib2.URLError as err:
+        return False
 
 script_dir = os.path.dirname(os.path.realpath(__file__))
 os.chdir(script_dir)
@@ -19,9 +27,13 @@ if os.path.exists('.git'):
         print "Please run this script from the root Armory source directory" \
             " along with the .git directory"
 else:
-    import subprocess
-    build = subprocess.check_output("git ls-remote --heads https://github.com/goatpig/BitcoinArmory.git refs/heads/master", shell=True)
-    build = build[:10]
+    url = 'https://github.com/goatpig/BitcoinArmory.git'
+    if _fetch_url( url ):
+        import subprocess
+        build = subprocess.check_output('git ls-remote --heads %s refs/heads/master' % url, shell=True)
+        build = build[:10]
+    else:
+        build = 'tgz_offlne'
 
 build_file = os.path.join("armoryengine", "ArmoryBuild.py")
 f = open(build_file, "w")


### PR DESCRIPTION
…age.

BugFix: If no .git directory exists the script returns the print message. When executing the script from a tar.gz where .git directory does not exists, it should try to get the HEAD from the remote repository.