### PR TITLE
BugFix: /usr/env does not exists on Mac OS X.

### DIFF
--- a/osxbuild/build-app.py
+++ b/osxbuild/build-app.py
@@ -1,4 +1,4 @@
-#!/usr/env python
+#!/usr/bin/env python
 """Build Armory as a Mac OS X Application."""
 
 import os


### PR DESCRIPTION
BugFix: env binary does not reside on /usr/ directory but it does on /usr/bin/.