### PR TITLE
TRIVIAL: Make logs slightly friendlier to read

### DIFF
--- a/cppForSwig/BlockDataManagerConfig.cpp
+++ b/cppForSwig/BlockDataManagerConfig.cpp
@@ -892,7 +892,7 @@ bool NodeChainState::processState(
    
    if (pct_int != prev_pct_int_)
    {
-      LOGINFO << "waiting on node sync: " << pct_ << "%";
+      LOGINFO << "waiting on node sync: " << float(pct_ * 100.0) << "%";
       prev_pct_int_ = pct_int;
    }
 


### PR DESCRIPTION
When ArmoryDB catches up with the node's blockchain, the percentage isn't expressed as a fraction of 100. Fix that.