### PR TITLE
[TRIVIAL] Catch DB error

### DIFF
--- a/ui/TxFrames.py
+++ b/ui/TxFrames.py
@@ -385,20 +385,23 @@ class SendBitcoinsFrame(ArmoryFrame):
          self.unsignedCheckBoxUpdate()
       if self.selectWltCallback:
          self.selectWltCallback(wlt)
-   
+
    #############################################################################      
    def setupCoinSelectionInstance(self):
       if self.wlt is None:
          self.coinSelection = None
          return
-      
-      self.coinSelection = self.wlt.cppWallet.getCoinSelectionInstance()
-      
+
+      try:
+         self.coinSelection = self.wlt.cppWallet.getCoinSelectionInstance()
+      except Cpp.DbErrorMsg as dbErr:
+         LOGERROR('DB error: %s', dbErr.what())
+
       try:
          self.resetCoinSelectionRecipients()
       except:
          pass
-     
+
    #############################################################################   
    def setupCoinSelectionForLockbox(self, lbox):
       try:        


### PR DESCRIPTION
A user had a database error due to re-downloading the blockchain. This, as expected, upset the DB and required a rebuild. However, the error wasn't caught. In the future, catch the error, print the message, and continue.