### PR TITLE
Fixes for check_version.py

### DIFF
--- a/update_version.py
+++ b/update_version.py
@@ -1,26 +1,50 @@
 import os
+from subprocess import check_output, CalledProcessError
 
 script_dir = os.path.dirname(os.path.realpath(__file__))
 os.chdir(script_dir)
+git_cmd = 'git rev-parse --short=10 HEAD'
 
 if os.path.exists('.git') \
    and os.path.exists(os.path.join("armoryengine", "ArmoryUtils.py")):
-    current_head = os.path.join(".git", "HEAD")
-    f = open(current_head, "r")
-    ref = f.read()
-    f.close()
-    path_parts = ref[5:-1].split("/")
-    hash_loc = os.path.join(".git", *path_parts)
-    f = open(hash_loc, "r")
-    build = f.read()[:10]
-    f.close()
+    build = None
 
-    build_file = os.path.join("armoryengine", "ArmoryBuild.py")
-    f = open(build_file, "w")
-    f.write("BTCARMORY_BUILD = '%s'\n" % build)
-    f.close()
+    # First try to determine head using Git...
+    try:
+        build = check_output(git_cmd.split(), shell=False)
+    except OSError as err:
+        print "Failed to execute '%s': %s" % (git_cmd, err.strerror)
+    except CalledProcessError as err:
+        print "Command '%s' failed (rc %i)" % (git_cmd, err.returncode)
 
-    print "Build number has been updated to %s" % build
+    # Fallback to classic code
+    if not build:
+        print "Falling back to old method to determine HEAD"
+
+        current_head = os.path.join(".git", "HEAD")
+        f = open(current_head, "r")
+        ref = f.read()
+        f.close()
+        path_parts = ref[5:-1].split("/")
+        hash_loc = os.path.join(".git", *path_parts)
+
+        if not os.path.exists(hash_loc) and len(ref.strip()) == 40:
+            # HEAD is probably detached and we've got a hash already
+            build = ref[:10]
+        else:
+            f = open(hash_loc, "r")
+            build = f.read()[:10]
+            f.close()
+
+    if build:
+        build_file = os.path.join("armoryengine", "ArmoryBuild.py")
+        f = open(build_file, "w")
+        f.write("BTCARMORY_BUILD = '%s'\n" % build)
+        f.close()
+
+        print "Build number has been updated to %s" % build
+    else:
+        print "Failed to determine build number!"
 
 else:
     print "Please run this script from the root Armory source directory" \


### PR DESCRIPTION
There was an issue finding detached head commit hash. I started by fixing this using git to find the head commit...

Then I realized you may want to use the old code if e.g. you don't have git available (windows builds maybe?), so I fixed it.

Let me know if you'd like to keep just one of these two options, rather than try both.

Also if you'd like to stick with git, you may want to consider git-describe instead for a more meaningful build id:

    $ git describe
    v0.96.3.992-95-gab20f9b3

Format can be modified; the default is:
`<nearest annotated tag> - <commit count since tag> - <abbrev ref>`