### PR TITLE
Autotools cleanup

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@ LT_INIT
 
 AC_CANONICAL_HOST
 
-#reset these flags if they are the default -g -02
+# Reset these flags if they are the system default "-g -02".
 AS_IF([test "$CFLAGS" = "-g -O2"] ,[AC_SUBST(CFLAGS, [ ])])
 AS_IF([test "$CXXFLAGS" = "-g -O2"] ,[AC_SUBST(CXXFLAGS, [ ])])
 
@@ -183,6 +183,7 @@ AC_CONFIG_SUBDIRS([cppForSwig/fcgi cppForSwig/cryptopp])
 
 AC_OUTPUT
 
+echo "  Armory flags"
 echo "  CC              = $CC"
 echo "  CFLAGS          = $CFLAGS"
 echo "  CPP             = $CPP"

--- a/configure.ac
+++ b/configure.ac
@@ -79,15 +79,18 @@ if test "x$cross_compiling" != "xyes"; then
 	AX_SWIG_PYTHON([no])
 	AS_IF([test -z $AX_SWIG_PYTHON_CPPFLAGS], 
 		[AC_MSG_ERROR([failed to procure swig include path, make sure swig is installed])])
-	AC_SUBST([PYTHON_LIBS], [`python-config --libs`])
+	AC_SUBST([PYTHON_CFLAGS], [`python-config --cflags`])
+	AC_SUBST([PYTHON_LDFLAGS], [`python-config --ldflags`])
 	AX_PYTHON_MODULE([psutil], [fatal])
 else
 AC_SUBST([AX_SWIG_PYTHON_CPPFLAGS], [`python-config --includes`])
-AC_SUBST([PYTHON_LIBS], [`python-config --libs`])
+AC_SUBST([PYTHON_CFLAGS], [`python-config --cflags`])
+AC_SUBST([PYTHON_LDFLAGS], [`python-config --ldflags`])
 fi
 
 AC_MSG_RESULT([AX_SWIG_PYTHON_CPPFLAGS: $AX_SWIG_PYTHON_CPPFLAGS])
-AC_MSG_RESULT([PYTHON_LIBS: $PYTHON_LIBS])
+AC_MSG_RESULT([PYTHON_CFLAGS: $PYTHON_LDFLAGS])
+AC_MSG_RESULT([PYTHON_LDFLAGS: $PYTHON_LDFLAGS])
 
 AC_CHECK_PROG([HAVE_PYRCC4], [pyrcc4], [yes], [no])
 AS_IF([test $HAVE_PYRCC4 == yes], [],

--- a/cppForSwig/Makefile.am
+++ b/cppForSwig/Makefile.am
@@ -59,10 +59,10 @@ if HAVE_GUI
 lib_LTLIBRARIES += libCppBlockUtils.la
 libCppBlockUtils_la_SOURCES = $(CPPBLOCKUTILS_SOURCE_FILES) \
 			      CppBlockUtils_wrap.cxx
-libCppBlockUtils_la_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES) \
-		    		$(EXTRA_PYTHON_INCLUDES) $(AX_SWIG_PYTHON_CPPFLAGS)
+libCppBlockUtils_la_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES)
 libCppBlockUtils_la_CXXFLAGS = $(AM_CXXFLAGS) -Ilmdb \
 				-Ifcgi/include \
+				$(EXTRA_PYTHON_INCLUDES) $(AX_SWIG_PYTHON_CPPFLAGS) \
 				-D__STDC_LIMIT_MACROS
 libCppBlockUtils_la_LIBADD = lmdb/liblmdb.la \
 		 	 	cryptopp/libcryptopp.la \

--- a/cppForSwig/Makefile.am
+++ b/cppForSwig/Makefile.am
@@ -24,39 +24,71 @@ INCLUDE_FILES = -Ibech32/ref/c++ -Icryptopp -Ifcgi
 
 ARMORYDB_SOURCE_FILES = main.cpp
 
-ARMORYGUI_SOURCE_FILES = SwigClient.cpp WalletManager.cpp Wallets.cpp \
-	CoinSelection.cpp TransactionBatch.cpp Accounts.cpp Addresses.cpp \
-	AssetEncryption.cpp Assets.cpp DecryptedDataContainer.cpp \
-	DerivationScheme.cpp
-ARMORYCLI_SOURCE_FILES = lmdb_wrapper.cpp BlockObj.cpp BlockUtils.cpp \
-	BtcWallet.cpp LedgerEntry.cpp ScrAddrObj.cpp Blockchain.cpp \
-	BDM_mainthread.cpp BDM_supportClasses.cpp nodeRPC.cpp BDM_Server.cpp \
-	BlockDataViewer.cpp HistoryPager.cpp Progress.cpp txio.cpp \
-	StoredBlockObj.cpp DatabaseBuilder.cpp BlockchainScanner.cpp \
-	BlockchainScanner_Super.cpp BlockDataMap.cpp BitcoinP2P.cpp  \
-	SshParser.cpp
-ARMORYCOMMON_SOURCE_FILES = UniversalTimer.cpp BinaryData.cpp \
-	BtcUtils.cpp DBUtils.cpp EncryptionUtils.cpp \
-	BDM_seder.cpp DataObject.cpp FcgiMessage.cpp \
-	SocketObject.cpp StringSockets.cpp \
-	BlockDataManagerConfig.cpp TxClasses.cpp \
-	Script.cpp Signer.cpp \
-	Transactions.cpp ReentrantLock.cpp JSON_codec.cpp \
-	log.cpp TxEvalState.cpp \
-	bech32/ref/c++/bech32.cpp bech32/ref/c++/segwit_addr.cpp
+ARMORYGUI_SOURCE_FILES = CoinSelection.cpp \
+	SwigClient.cpp \
+	TransactionBatch.cpp \
+	WalletManager.cpp \
+	Wallets.cpp
+ARMORYCLI_SOURCE_FILES = Accounts.cpp \
+	Addresses.cpp \
+	AssetEncryption.cpp \
+	Assets.cpp \
+	BDM_mainthread.cpp \
+	BDM_Server.cpp \
+	BDM_supportClasses.cpp \
+	BitcoinP2P.cpp \
+	BlockchainScanner.cpp \
+	BlockchainScanner_Super.cpp \
+	BlockDataViewer.cpp \
+	BlockUtils.cpp \
+	BtcWallet.cpp \
+	DatabaseBuilder.cpp \
+	DataObject.cpp \
+	DecryptedDataContainer.cpp \
+	DerivationScheme.cpp \
+	FcgiMessage.cpp \
+	HistoryPager.cpp \
+	LedgerEntry.cpp \
+	lmdb_wrapper.cpp \
+	log.cpp \
+	nodeRPC.cpp \
+	Progress.cpp \
+	ReentrantLock.cpp \
+	ScrAddrObj.cpp \
+	SocketObject.cpp \
+	SshParser.cpp \
+	StringSockets.cpp \
+	StoredBlockObj.cpp \
+	txio.cpp
+ARMORYCOMMON_SOURCE_FILES = BDM_seder.cpp \
+	BinaryData.cpp \
+	Blockchain.cpp \
+	BlockDataManagerConfig.cpp \
+	BlockDataMap.cpp \
+	BlockObj.cpp \
+	BtcUtils.cpp \
+	DBUtils.cpp \
+	EncryptionUtils.cpp \
+	JSON_codec.cpp \
+	Script.cpp \
+	Signer.cpp \
+	Transactions.cpp \
+	TxClasses.cpp \
+	TxEvalState.cpp \
+	txio.cpp \
+	UniversalTimer.cpp \
+	bech32/ref/c++/bech32.cpp \
+	bech32/ref/c++/segwit_addr.cpp
 
 # libArmoryCommon - Required by all Armory programs/libraries.
 # May be able to modularize in the future so that it's not monolithic.
 lib_LTLIBRARIES += libArmoryCommon.la
 libArmoryCommon_la_SOURCES = $(ARMORYCOMMON_SOURCE_FILES)
 libArmoryCommon_la_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES)
-libArmoryCommon_la_CXXFLAGS = $(AM_CXXFLAGS) -Ilmdb \
-				-Ifcgi/include \
-				-D__STDC_LIMIT_MACROS
+libArmoryCommon_la_CXXFLAGS = $(AM_CXXFLAGS) -D__STDC_LIMIT_MACROS
 libArmoryCommon_la_LIBADD = lmdb/liblmdb.la \
-		 	 	cryptopp/libcryptopp.la \
-		 	 	fcgi/libfcgi/libfcgi.la \
-		 	 	-lpthread
+				cryptopp/libcryptopp.la \
+				-lpthread
 libArmoryCommon_la_LDFLAGS = $(LDFLAGS) -shared
 
 # Common command-line functionality library
@@ -65,12 +97,10 @@ libArmoryCLI_la_SOURCES = $(ARMORYCLI_SOURCE_FILES)
 libArmoryCLI_la_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES) \
 			$(PYTHON_CFLAGS)
 libArmoryCLI_la_CXXFLAGS = $(AM_CXXFLAGS) -Ilmdb \
-			-Ifcgi/include \
 			-D__STDC_LIMIT_MACROS
 libArmoryCLI_la_LIBADD = lmdb/liblmdb.la \
-			cryptopp/libcryptopp.la \
-			fcgi/libfcgi/libfcgi.la \
-			libArmoryCommon.la \
+			 fcgi/libfcgi/libfcgi.la \
+			 libArmoryCommon.la \
 			-lpthread
 libArmoryCLI_la_LDFLAGS = $(LDFLAGS) -shared
 
@@ -80,8 +110,6 @@ ArmoryDB_SOURCES = $(ARMORYDB_SOURCE_FILES)
 ArmoryDB_CXXFLAGS = $(AM_CXXFLAGS) -D__STDC_LIMIT_MACROS
 ArmoryDB_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES)
 ArmoryDB_LDADD = fcgi/libfcgi/libfcgi.la \
-		 cryptopp/libcryptopp.la \
-		 lmdb/liblmdb.la \
 		 libArmoryCommon.la \
 		 libArmoryCLI.la \
 		 -lpthread
@@ -93,13 +121,9 @@ lib_LTLIBRARIES += libArmoryGUI.la
 libArmoryGUI_la_SOURCES = $(ARMORYGUI_SOURCE_FILES)
 libArmoryGUI_la_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES) \
 			$(PYTHON_CFLAGS)
-libArmoryGUI_la_CXXFLAGS = $(AM_CXXFLAGS) -Ilmdb \
-			-Ifcgi/include \
+libArmoryGUI_la_CXXFLAGS = $(AM_CXXFLAGS)
 			-D__STDC_LIMIT_MACROS
-libArmoryGUI_la_LIBADD = lmdb/liblmdb.la \
-			cryptopp/libcryptopp.la \
-			fcgi/libfcgi/libfcgi.la \
-			libArmoryCommon.la \
+libArmoryGUI_la_LIBADD = libArmoryCommon.la \
 			-lpthread
 libArmoryGUI_la_LDFLAGS = $(LDFLAGS) $(PYTHON_LDFLAGS) -shared
 
@@ -112,11 +136,7 @@ libCppBlockUtils_la_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES) \
 libCppBlockUtils_la_CXXFLAGS = $(AM_CXXFLAGS) -Ilmdb \
 				-Ifcgi/include \
 				-D__STDC_LIMIT_MACROS
-libCppBlockUtils_la_LIBADD = lmdb/liblmdb.la \
-		 	 	cryptopp/libcryptopp.la \
-		 	 	fcgi/libfcgi/libfcgi.la \
-		 	 	libArmoryCommon.la \
-		 	 	libArmoryGUI.la \
+libCppBlockUtils_la_LIBADD = libArmoryGUI.la \
 		 	 	-lpthread
 libCppBlockUtils_la_LDFLAGS = $(LDFLAGS) $(PYTHON_LDFLAGS) -shared
 

--- a/cppForSwig/Makefile.am
+++ b/cppForSwig/Makefile.am
@@ -23,7 +23,7 @@ endif
 INCLUDE_FILES = -Ibech32/ref/c++ -Icryptopp -Ifcgi
 
 DB_SOURCE_FILES = main.cpp
-CPPBLOCKUTILS_SOURCE_FILES = UniversalTimer.cpp BinaryData.cpp \
+ARMORYUTILS_SOURCE_FILES = UniversalTimer.cpp BinaryData.cpp \
 	BtcUtils.cpp DBUtils.cpp EncryptionUtils.cpp \
 	BDM_seder.cpp DataObject.cpp FcgiMessage.cpp \
 	SocketObject.cpp SwigClient.cpp StringSockets.cpp \
@@ -42,6 +42,20 @@ CPPBLOCKUTILS_SOURCE_FILES = UniversalTimer.cpp BinaryData.cpp \
 	BlockchainScanner_Super.cpp BlockDataMap.cpp BitcoinP2P.cpp  \
 	SshParser.cpp
 
+# libArmoryUtils - Required by all Armory programs/libraries.
+# May be able to modularize in the future so that it's not monolithic.
+lib_LTLIBRARIES += libArmoryUtils.la
+libArmoryUtils_la_SOURCES = $(ARMORYUTILS_SOURCE_FILES)
+libArmoryUtils_la_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES)
+libArmoryUtils_la_CXXFLAGS = $(AM_CXXFLAGS) -Ilmdb \
+				-Ifcgi/include \
+				-D__STDC_LIMIT_MACROS
+libArmoryUtils_la_LIBADD = lmdb/liblmdb.la \
+		 	 	cryptopp/libcryptopp.la \
+		 	 	fcgi/libfcgi/libfcgi.la \
+		 	 	-lpthread
+libArmoryUtils_la_LDFLAGS = $(LDFLAGS) -shared
+
 #ArmoryDB
 bin_PROGRAMS += ArmoryDB
 ArmoryDB_SOURCES = $(DB_SOURCE_FILES)
@@ -50,26 +64,26 @@ ArmoryDB_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES)
 ArmoryDB_LDADD = fcgi/libfcgi/libfcgi.la \
 		 cryptopp/libcryptopp.la \
 		 lmdb/liblmdb.la \
-		 libCppBlockUtils.la \
+		 libArmoryUtils.la \
 		 -lpthread
 ArmoryDB_LDFLAGS = -static $(LDFLAGS)
 
-#libCppBlockUtils - "shared" LDFLAG due to SWIG requirements
+#libCppBlockUtils - SWIG/GUI library.
+# "shared" LDFLAG due to SWIG requirements.
 if HAVE_GUI
 lib_LTLIBRARIES += libCppBlockUtils.la
-libCppBlockUtils_la_SOURCES = $(CPPBLOCKUTILS_SOURCE_FILES) \
-			      CppBlockUtils_wrap.cxx
-libCppBlockUtils_la_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES)
+libCppBlockUtils_la_SOURCES = CppBlockUtils_wrap.cxx
+libCppBlockUtils_la_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES) \
+				$(PYTHON_CFLAGS)
 libCppBlockUtils_la_CXXFLAGS = $(AM_CXXFLAGS) -Ilmdb \
 				-Ifcgi/include \
-				$(EXTRA_PYTHON_INCLUDES) $(AX_SWIG_PYTHON_CPPFLAGS) \
 				-D__STDC_LIMIT_MACROS
 libCppBlockUtils_la_LIBADD = lmdb/liblmdb.la \
 		 	 	cryptopp/libcryptopp.la \
 		 	 	fcgi/libfcgi/libfcgi.la \
-		 	 	$(PYTHON_LIBS)
+		 	 	libArmoryUtils.la \
 		 	 	-lpthread
-libCppBlockUtils_la_LDFLAGS = $(LDFLAGS) `pkg-config --libs python-2.7` -shared
+libCppBlockUtils_la_LDFLAGS = $(LDFLAGS) $(PYTHON_LDFLAGS) -shared
 
 if BUILD_DARWIN
 libCppBlockUtils_la_LDFLAGS += -Wl,-rpath,@executable_path/ -Wl,-rpath,@loader_path/
@@ -77,15 +91,15 @@ endif
 
 #custom rules
 CppBlockUtils_wrap.cxx: CppBlockUtils.i
-	swig $(SWIG_FLAGS) CppBlockUtils.i 
+	swig $(SWIG_FLAGS) CppBlockUtils.i
 
 .PHONY: CppBlockUtils_wrap.cxx
+endif
 
 clean-local:
 	rm -f CppBlockUtils.py
 	rm -f CppBlockUtils_wrap.cxx
 	rm -f CppBlockUtils_wrap.h
-endif
 
 # .include file prevents gtest subdir from building a second copy of Armory.
 # Also provides a convenient spot to place all test-related materials.

--- a/cppForSwig/Makefile.am
+++ b/cppForSwig/Makefile.am
@@ -22,55 +22,89 @@ endif
 
 INCLUDE_FILES = -Ibech32/ref/c++ -Icryptopp -Ifcgi
 
-DB_SOURCE_FILES = main.cpp
-ARMORYUTILS_SOURCE_FILES = UniversalTimer.cpp BinaryData.cpp \
-	BtcUtils.cpp DBUtils.cpp EncryptionUtils.cpp \
-	BDM_seder.cpp DataObject.cpp FcgiMessage.cpp \
-	SocketObject.cpp SwigClient.cpp StringSockets.cpp \
-	BlockDataManagerConfig.cpp TxClasses.cpp \
-	WalletManager.cpp Wallets.cpp Script.cpp Signer.cpp \
-	Transactions.cpp CoinSelection.cpp ReentrantLock.cpp JSON_codec.cpp \
-	TransactionBatch.cpp log.cpp TxEvalState.cpp \
-	Accounts.cpp Addresses.cpp AssetEncryption.cpp Assets.cpp \
-	DecryptedDataContainer.cpp DerivationScheme.cpp \
-	bech32/ref/c++/bech32.cpp bech32/ref/c++/segwit_addr.cpp \
-	lmdb_wrapper.cpp BlockObj.cpp BlockUtils.cpp \
+ARMORYDB_SOURCE_FILES = main.cpp
+
+ARMORYGUI_SOURCE_FILES = SwigClient.cpp WalletManager.cpp Wallets.cpp \
+	CoinSelection.cpp TransactionBatch.cpp Accounts.cpp Addresses.cpp \
+	AssetEncryption.cpp Assets.cpp DecryptedDataContainer.cpp \
+	DerivationScheme.cpp
+ARMORYCLI_SOURCE_FILES = lmdb_wrapper.cpp BlockObj.cpp BlockUtils.cpp \
 	BtcWallet.cpp LedgerEntry.cpp ScrAddrObj.cpp Blockchain.cpp \
 	BDM_mainthread.cpp BDM_supportClasses.cpp nodeRPC.cpp BDM_Server.cpp \
 	BlockDataViewer.cpp HistoryPager.cpp Progress.cpp txio.cpp \
 	StoredBlockObj.cpp DatabaseBuilder.cpp BlockchainScanner.cpp \
 	BlockchainScanner_Super.cpp BlockDataMap.cpp BitcoinP2P.cpp  \
 	SshParser.cpp
+ARMORYCOMMON_SOURCE_FILES = UniversalTimer.cpp BinaryData.cpp \
+	BtcUtils.cpp DBUtils.cpp EncryptionUtils.cpp \
+	BDM_seder.cpp DataObject.cpp FcgiMessage.cpp \
+	SocketObject.cpp StringSockets.cpp \
+	BlockDataManagerConfig.cpp TxClasses.cpp \
+	Script.cpp Signer.cpp \
+	Transactions.cpp ReentrantLock.cpp JSON_codec.cpp \
+	log.cpp TxEvalState.cpp \
+	bech32/ref/c++/bech32.cpp bech32/ref/c++/segwit_addr.cpp
 
-# libArmoryUtils - Required by all Armory programs/libraries.
+# libArmoryCommon - Required by all Armory programs/libraries.
 # May be able to modularize in the future so that it's not monolithic.
-lib_LTLIBRARIES += libArmoryUtils.la
-libArmoryUtils_la_SOURCES = $(ARMORYUTILS_SOURCE_FILES)
-libArmoryUtils_la_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES)
-libArmoryUtils_la_CXXFLAGS = $(AM_CXXFLAGS) -Ilmdb \
+lib_LTLIBRARIES += libArmoryCommon.la
+libArmoryCommon_la_SOURCES = $(ARMORYCOMMON_SOURCE_FILES)
+libArmoryCommon_la_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES)
+libArmoryCommon_la_CXXFLAGS = $(AM_CXXFLAGS) -Ilmdb \
 				-Ifcgi/include \
 				-D__STDC_LIMIT_MACROS
-libArmoryUtils_la_LIBADD = lmdb/liblmdb.la \
+libArmoryCommon_la_LIBADD = lmdb/liblmdb.la \
 		 	 	cryptopp/libcryptopp.la \
 		 	 	fcgi/libfcgi/libfcgi.la \
 		 	 	-lpthread
-libArmoryUtils_la_LDFLAGS = $(LDFLAGS) -shared
+libArmoryCommon_la_LDFLAGS = $(LDFLAGS) -shared
+
+# Common command-line functionality library
+lib_LTLIBRARIES += libArmoryCLI.la
+libArmoryCLI_la_SOURCES = $(ARMORYCLI_SOURCE_FILES)
+libArmoryCLI_la_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES) \
+			$(PYTHON_CFLAGS)
+libArmoryCLI_la_CXXFLAGS = $(AM_CXXFLAGS) -Ilmdb \
+			-Ifcgi/include \
+			-D__STDC_LIMIT_MACROS
+libArmoryCLI_la_LIBADD = lmdb/liblmdb.la \
+			cryptopp/libcryptopp.la \
+			fcgi/libfcgi/libfcgi.la \
+			libArmoryCommon.la \
+			-lpthread
+libArmoryCLI_la_LDFLAGS = $(LDFLAGS) -shared
 
 #ArmoryDB
 bin_PROGRAMS += ArmoryDB
-ArmoryDB_SOURCES = $(DB_SOURCE_FILES)
+ArmoryDB_SOURCES = $(ARMORYDB_SOURCE_FILES)
 ArmoryDB_CXXFLAGS = $(AM_CXXFLAGS) -D__STDC_LIMIT_MACROS
 ArmoryDB_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES)
 ArmoryDB_LDADD = fcgi/libfcgi/libfcgi.la \
 		 cryptopp/libcryptopp.la \
 		 lmdb/liblmdb.la \
-		 libArmoryUtils.la \
+		 libArmoryCommon.la \
+		 libArmoryCLI.la \
 		 -lpthread
-ArmoryDB_LDFLAGS = -static $(LDFLAGS)
+ArmoryDB_LDFLAGS = -shared $(LDFLAGS)
 
-#libCppBlockUtils - SWIG/GUI library.
-# "shared" LDFLAG due to SWIG requirements.
 if HAVE_GUI
+# Common GUI functionality library
+lib_LTLIBRARIES += libArmoryGUI.la
+libArmoryGUI_la_SOURCES = $(ARMORYGUI_SOURCE_FILES)
+libArmoryGUI_la_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES) \
+			$(PYTHON_CFLAGS)
+libArmoryGUI_la_CXXFLAGS = $(AM_CXXFLAGS) -Ilmdb \
+			-Ifcgi/include \
+			-D__STDC_LIMIT_MACROS
+libArmoryGUI_la_LIBADD = lmdb/liblmdb.la \
+			cryptopp/libcryptopp.la \
+			fcgi/libfcgi/libfcgi.la \
+			libArmoryCommon.la \
+			-lpthread
+libArmoryGUI_la_LDFLAGS = $(LDFLAGS) $(PYTHON_LDFLAGS) -shared
+
+#libCppBlockUtils - SWIG library.
+# "shared" LDFLAG due to SWIG requirements.
 lib_LTLIBRARIES += libCppBlockUtils.la
 libCppBlockUtils_la_SOURCES = CppBlockUtils_wrap.cxx
 libCppBlockUtils_la_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES) \
@@ -81,12 +115,14 @@ libCppBlockUtils_la_CXXFLAGS = $(AM_CXXFLAGS) -Ilmdb \
 libCppBlockUtils_la_LIBADD = lmdb/liblmdb.la \
 		 	 	cryptopp/libcryptopp.la \
 		 	 	fcgi/libfcgi/libfcgi.la \
-		 	 	libArmoryUtils.la \
+		 	 	libArmoryCommon.la \
+		 	 	libArmoryGUI.la \
 		 	 	-lpthread
 libCppBlockUtils_la_LDFLAGS = $(LDFLAGS) $(PYTHON_LDFLAGS) -shared
 
 if BUILD_DARWIN
 libCppBlockUtils_la_LDFLAGS += -Wl,-rpath,@executable_path/ -Wl,-rpath,@loader_path/
+libArmoryCLI_la_LDFLAGS += -Wl,-rpath,@executable_path/ -Wl,-rpath,@loader_path/
 endif
 
 #custom rules

--- a/cppForSwig/Makefile.tests.include
+++ b/cppForSwig/Makefile.tests.include
@@ -22,19 +22,6 @@ gtest_ContainerTests_LDADD = gtest/libgtest.la libArmoryCommon.la
 gtest_ContainerTests_LDFLAGS = $(AM_LDFLAGS) $(LDFLAGS) -static
 TESTS += gtest/ContainerTests
 
-if HAVE_GUI
-# CppBlockUtilsTests
-bin_PROGRAMS += gtest/CppBlockUtilsTests
-gtest_CppBlockUtilsTests_SOURCES = gtest/CppBlockUtilsTests.cpp
-gtest_CppBlockUtilsTests_CXXFLAGS = $(AM_CXXFLAGS)
-gtest_CppBlockUtilsTests_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES)
-gtest_CppBlockUtilsTests_LDADD = -Llmdb -llmdb \
-	-Lcryptopp -lcryptopp \
-	-Lfcgi/libfcgi -lfcgi \
-	gtest/libgtest.la libArmoryCommon.la libArmoryCLI.la libArmoryGUI.la
-gtest_CppBlockUtilsTests_LDFLAGS = $(AM_LDFLAGS) $(LDFLAGS) -static
-TESTS += gtest/CppBlockUtilsTests
-
 # DB1kIterTest
 bin_PROGRAMS += gtest/DB1kIterTest
 gtest_DB1kIterTest_SOURCES = gtest/DB1kIterTest.cpp
@@ -43,7 +30,7 @@ gtest_DB1kIterTest_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES)
 gtest_DB1kIterTest_LDADD = -Llmdb -llmdb \
 	-Lcryptopp -lcryptopp \
 	-Lfcgi/libfcgi -lfcgi \
-	gtest/libgtest.la libArmoryCommon.la libArmoryCLI.la libArmoryGUI.la
+	gtest/libgtest.la libArmoryCLI.la
 gtest_DB1kIterTest_LDFLAGS = $(AM_LDFLAGS) $(LDFLAGS) -static
 TESTS += gtest/DB1kIterTest
 
@@ -55,7 +42,20 @@ gtest_SupernodeTests_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES)
 gtest_SupernodeTests_LDADD = -Llmdb -llmdb \
 	-Lcryptopp -lcryptopp \
 	-Lfcgi/libfcgi -lfcgi \
-	gtest/libgtest.la libArmoryCommon.la libArmoryGUI.la
+	gtest/libgtest.la libArmoryCLI.la libArmoryGUI.la
 gtest_SupernodeTests_LDFLAGS = $(AM_LDFLAGS) $(LDFLAGS) -static
 TESTS += gtest/SupernodeTests
+
+if HAVE_GUI
+# CppBlockUtilsTests - Contains the bulk of the tests (CLI or GUI)
+bin_PROGRAMS += gtest/CppBlockUtilsTests
+gtest_CppBlockUtilsTests_SOURCES = gtest/CppBlockUtilsTests.cpp
+gtest_CppBlockUtilsTests_CXXFLAGS = $(AM_CXXFLAGS)
+gtest_CppBlockUtilsTests_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES)
+gtest_CppBlockUtilsTests_LDADD = -Llmdb -llmdb \
+	-Lcryptopp -lcryptopp \
+	-Lfcgi/libfcgi -lfcgi \
+	gtest/libgtest.la libArmoryCLI.la libArmoryGUI.la
+gtest_CppBlockUtilsTests_LDFLAGS = $(AM_LDFLAGS) $(LDFLAGS) -static
+TESTS += gtest/CppBlockUtilsTests
 endif

--- a/cppForSwig/Makefile.tests.include
+++ b/cppForSwig/Makefile.tests.include
@@ -10,7 +10,19 @@ lib_LTLIBRARIES += gtest/libgtest.la
 gtest_libgtest_la_CXXFLAGS = $(AM_CXXFLAGS)
 gtest_libgtest_la_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES)
 gtest_libgtest_la_SOURCES = gtest/TestUtils.cpp gtest/gtest-all.cc
+gtest_libgtest_la_LIBADD = libArmoryCommon.la libArmoryCLI.la
+gtest_libgtest_la_LDFLAGS = $(AM_LDFLAGS) $(LDFLAGS) -shared
 
+# ContainerTests
+bin_PROGRAMS += gtest/ContainerTests
+gtest_ContainerTests_SOURCES = gtest/ContainerTests.cpp
+gtest_ContainerTests_CXXFLAGS = $(AM_CXXFLAGS)
+gtest_ContainerTests_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES)
+gtest_ContainerTests_LDADD = gtest/libgtest.la libArmoryCommon.la
+gtest_ContainerTests_LDFLAGS = $(AM_LDFLAGS) $(LDFLAGS) -static
+TESTS += gtest/ContainerTests
+
+if HAVE_GUI
 # CppBlockUtilsTests
 bin_PROGRAMS += gtest/CppBlockUtilsTests
 gtest_CppBlockUtilsTests_SOURCES = gtest/CppBlockUtilsTests.cpp
@@ -19,7 +31,7 @@ gtest_CppBlockUtilsTests_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES)
 gtest_CppBlockUtilsTests_LDADD = -Llmdb -llmdb \
 	-Lcryptopp -lcryptopp \
 	-Lfcgi/libfcgi -lfcgi \
-	gtest/libgtest.la libArmoryUtils.la
+	gtest/libgtest.la libArmoryCommon.la libArmoryCLI.la libArmoryGUI.la
 gtest_CppBlockUtilsTests_LDFLAGS = $(AM_LDFLAGS) $(LDFLAGS) -static
 TESTS += gtest/CppBlockUtilsTests
 
@@ -31,18 +43,9 @@ gtest_DB1kIterTest_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES)
 gtest_DB1kIterTest_LDADD = -Llmdb -llmdb \
 	-Lcryptopp -lcryptopp \
 	-Lfcgi/libfcgi -lfcgi \
-	gtest/libgtest.la libArmoryUtils.la
+	gtest/libgtest.la libArmoryCommon.la libArmoryCLI.la libArmoryGUI.la
 gtest_DB1kIterTest_LDFLAGS = $(AM_LDFLAGS) $(LDFLAGS) -static
 TESTS += gtest/DB1kIterTest
-
-# ContainerTests
-bin_PROGRAMS += gtest/ContainerTests
-gtest_ContainerTests_SOURCES = gtest/ContainerTests.cpp
-gtest_ContainerTests_CXXFLAGS = $(AM_CXXFLAGS)
-gtest_ContainerTests_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES)
-gtest_ContainerTests_LDADD = gtest/libgtest.la libArmoryUtils.la
-gtest_ContainerTests_LDFLAGS = $(AM_LDFLAGS) $(LDFLAGS)
-TESTS += gtest/ContainerTests
 
 # SupernodeTests
 bin_PROGRAMS += gtest/SupernodeTests
@@ -52,6 +55,7 @@ gtest_SupernodeTests_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES)
 gtest_SupernodeTests_LDADD = -Llmdb -llmdb \
 	-Lcryptopp -lcryptopp \
 	-Lfcgi/libfcgi -lfcgi \
-	gtest/libgtest.la libArmoryUtils.la
+	gtest/libgtest.la libArmoryCommon.la libArmoryGUI.la
 gtest_SupernodeTests_LDFLAGS = $(AM_LDFLAGS) $(LDFLAGS) -static
-TESTS += SupernodeTests
+TESTS += gtest/SupernodeTests
+endif

--- a/cppForSwig/Makefile.tests.include
+++ b/cppForSwig/Makefile.tests.include
@@ -19,7 +19,7 @@ gtest_CppBlockUtilsTests_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES)
 gtest_CppBlockUtilsTests_LDADD = -Llmdb -llmdb \
 	-Lcryptopp -lcryptopp \
 	-Lfcgi/libfcgi -lfcgi \
-	gtest/libgtest.la libCppBlockUtils.la
+	gtest/libgtest.la libArmoryUtils.la
 gtest_CppBlockUtilsTests_LDFLAGS = $(AM_LDFLAGS) $(LDFLAGS) -static
 TESTS += gtest/CppBlockUtilsTests
 
@@ -31,7 +31,7 @@ gtest_DB1kIterTest_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES)
 gtest_DB1kIterTest_LDADD = -Llmdb -llmdb \
 	-Lcryptopp -lcryptopp \
 	-Lfcgi/libfcgi -lfcgi \
-	gtest/libgtest.la libCppBlockUtils.la
+	gtest/libgtest.la libArmoryUtils.la
 gtest_DB1kIterTest_LDFLAGS = $(AM_LDFLAGS) $(LDFLAGS) -static
 TESTS += gtest/DB1kIterTest
 
@@ -40,7 +40,7 @@ bin_PROGRAMS += gtest/ContainerTests
 gtest_ContainerTests_SOURCES = gtest/ContainerTests.cpp
 gtest_ContainerTests_CXXFLAGS = $(AM_CXXFLAGS)
 gtest_ContainerTests_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES)
-gtest_ContainerTests_LDADD = gtest/libgtest.la libCppBlockUtils.la
+gtest_ContainerTests_LDADD = gtest/libgtest.la libArmoryUtils.la
 gtest_ContainerTests_LDFLAGS = $(AM_LDFLAGS) $(LDFLAGS)
 TESTS += gtest/ContainerTests
 
@@ -52,6 +52,6 @@ gtest_SupernodeTests_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES)
 gtest_SupernodeTests_LDADD = -Llmdb -llmdb \
 	-Lcryptopp -lcryptopp \
 	-Lfcgi/libfcgi -lfcgi \
-	gtest/libgtest.la libCppBlockUtils.la
+	gtest/libgtest.la libArmoryUtils.la
 gtest_SupernodeTests_LDFLAGS = $(AM_LDFLAGS) $(LDFLAGS) -static
 TESTS += SupernodeTests

--- a/cppForSwig/cryptopp/configure.ac
+++ b/cppForSwig/cryptopp/configure.ac
@@ -21,12 +21,9 @@ AC_ARG_ENABLE([debug],
               [want_debug="$enableval"], [want_debug=no])
 
 if test "x$want_debug" = "xyes" -a $ac_cv_c_compiler_gnu != no; then
-  CFLAGS="$CFLAGS -O0 -g"
-  CXXFLAGS="$CXXFLAGS -O0 -g"
+  CFLAGS="-O0 -g"
+  CXXFLAGS="-O0 -g"
   AC_DEFINE([DEBUG], 1, [Define for debugging])
-else
-  CFLAGS="$CFLAGS -O2"
-  CXXFLAGS="$CXXFLAGS -O2"
 fi
 
 # Checks for programs.
@@ -88,11 +85,11 @@ AC_COMPILE_IFELSE(
 [CLANG=yes], [CLANG=no])
 AC_LANG_POP([C++])
 
-AC_MSG_RESULT([$CLANG])
+AC_MSG_RESULT([clang has been detected: $CLANG])
 AC_SUBST([CLANG])
 
 AM_CONDITIONAL([CRYPTOPP_HAVE_CLANG], [test x$CLANG = xyes])
-AM_CONDITIONAL([CRYPTOPP_HAVE_GCC], [test $CXX == g++])
+AM_CONDITIONAL([CRYPTOPP_HAVE_GCC], [test "x$CXX" = "xg++"])
 
 #set this otherwise autoconf complains about conditionals never getting defined
 AM_CONDITIONAL([GAS210_OR_LATER], [test "a" == "b"])
@@ -101,7 +98,7 @@ AM_CONDITIONAL([GAS219_OR_LATER], [test "a" == "b"])
 AM_CONDITIONAL([HAVE_AES], [test "a" == "b"])
 AM_CONDITIONAL([HAVE_PCLMUL], [test "a" == "b"])
 
-if test $CXX == g++; then
+if test "x$CXX" == "xg++"; then
 AM_CONDITIONAL([GAS210_OR_LATER], [test $(as -v 2>&1 | egrep -c "GNU assembler version (2\.[1-9][0-9]|[3-9])")])
 AM_CONDITIONAL([GAS217_OR_LATER], [test $(as -v 2>&1 | egrep -c "GNU assembler version (2\.1[7-9]|2\.[2-9]|[3-9])")])
 AM_CONDITIONAL([GAS219_OR_LATER], [test $(as -v 2>&1 | egrep -c "GNU assembler version (2\.19|2\.[2-9]|[3-9])")])
@@ -135,3 +132,13 @@ AM_CONDITIONAL([IS_X86], [test x$HOST_MACHINE = xx86])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT
+
+echo "  Crypto++ flags"
+echo "  CC              = $CC"
+echo "  CFLAGS          = $CFLAGS"
+echo "  CPP             = $CPP"
+echo "  CPPFLAGS        = $CPPFLAGS"
+echo "  CXX             = $CXX"
+echo "  CXXFLAGS        = $CXXFLAGS"
+echo "  LDFLAGS         = $LDFLAGS"
+echo "  LD              = $LD"

--- a/cppForSwig/cryptopp/configure.ac
+++ b/cppForSwig/cryptopp/configure.ac
@@ -21,8 +21,6 @@ AC_ARG_ENABLE([debug],
               [want_debug="$enableval"], [want_debug=no])
 
 if test "x$want_debug" = "xyes" -a $ac_cv_c_compiler_gnu != no; then
-  CFLAGS="-O0 -g"
-  CXXFLAGS="-O0 -g"
   AC_DEFINE([DEBUG], 1, [Define for debugging])
 fi
 


### PR DESCRIPTION
- Fix a couple of Autotools warnings.
- Remove redundant CFLAGS and CXXFLAGS values.
- Fix a linker error.
- Add some output to help with Autotools debugging.