### PR TITLE
Minor Autotools cleanup

### DIFF
--- a/cppForSwig/Makefile.am
+++ b/cppForSwig/Makefile.am
@@ -35,8 +35,6 @@ ARMORYCLI_SOURCE_FILES = Accounts.cpp \
 	Assets.cpp \
 	BDM_mainthread.cpp \
 	BDM_Server.cpp \
-    ScrAddrFilter.cpp \
-	ZeroConf.cpp \
 	BitcoinP2P.cpp \
 	BlockchainScanner.cpp \
 	BlockchainScanner_Super.cpp \
@@ -55,12 +53,14 @@ ARMORYCLI_SOURCE_FILES = Accounts.cpp \
 	nodeRPC.cpp \
 	Progress.cpp \
 	ReentrantLock.cpp \
+	ScrAddrFilter.cpp \
 	ScrAddrObj.cpp \
 	SocketObject.cpp \
 	SshParser.cpp \
 	StringSockets.cpp \
 	StoredBlockObj.cpp \
-	txio.cpp
+	txio.cpp \
+	ZeroConf.cpp
 ARMORYCOMMON_SOURCE_FILES = BDM_seder.cpp \
 	BinaryData.cpp \
 	Blockchain.cpp \

--- a/cppForSwig/Makefile.tests.include
+++ b/cppForSwig/Makefile.tests.include
@@ -27,10 +27,7 @@ bin_PROGRAMS += gtest/DB1kIterTest
 gtest_DB1kIterTest_SOURCES = gtest/DB1kIterTest.cpp
 gtest_DB1kIterTest_CXXFLAGS = $(AM_CXXFLAGS)
 gtest_DB1kIterTest_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES)
-gtest_DB1kIterTest_LDADD = -Llmdb -llmdb \
-	-Lcryptopp -lcryptopp \
-	-Lfcgi/libfcgi -lfcgi \
-	gtest/libgtest.la libArmoryCLI.la
+gtest_DB1kIterTest_LDADD = gtest/libgtest.la libArmoryCLI.la
 gtest_DB1kIterTest_LDFLAGS = $(AM_LDFLAGS) $(LDFLAGS) -static
 TESTS += gtest/DB1kIterTest
 
@@ -40,10 +37,7 @@ bin_PROGRAMS += gtest/SupernodeTests
 gtest_SupernodeTests_SOURCES = gtest/SupernodeTests.cpp
 gtest_SupernodeTests_CXXFLAGS = $(AM_CXXFLAGS)
 gtest_SupernodeTests_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES)
-gtest_SupernodeTests_LDADD = -Llmdb -llmdb \
-	-Lcryptopp -lcryptopp \
-	-Lfcgi/libfcgi -lfcgi \
-	gtest/libgtest.la libArmoryCLI.la libArmoryGUI.la
+gtest_SupernodeTests_LDADD = gtest/libgtest.la libArmoryCLI.la libArmoryGUI.la
 gtest_SupernodeTests_LDFLAGS = $(AM_LDFLAGS) $(LDFLAGS) -static
 TESTS += gtest/SupernodeTests
 
@@ -52,10 +46,7 @@ bin_PROGRAMS += gtest/CppBlockUtilsTests
 gtest_CppBlockUtilsTests_SOURCES = gtest/CppBlockUtilsTests.cpp
 gtest_CppBlockUtilsTests_CXXFLAGS = $(AM_CXXFLAGS)
 gtest_CppBlockUtilsTests_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES)
-gtest_CppBlockUtilsTests_LDADD = -Llmdb -llmdb \
-	-Lcryptopp -lcryptopp \
-	-Lfcgi/libfcgi -lfcgi \
-	gtest/libgtest.la libArmoryCLI.la libArmoryGUI.la
+gtest_CppBlockUtilsTests_LDADD = gtest/libgtest.la libArmoryCLI.la libArmoryGUI.la
 gtest_CppBlockUtilsTests_LDFLAGS = $(AM_LDFLAGS) $(LDFLAGS) -static
 TESTS += gtest/CppBlockUtilsTests
 endif


### PR DESCRIPTION
- Keep source files consistent in formatting and listing (alphabetical order).
- Remove libraries that aren't required for linking.