### PR TITLE
Update macOS build process

### DIFF
--- a/osxbuild/build-app.py
+++ b/osxbuild/build-app.py
@@ -453,7 +453,7 @@ def compile_pip():
    if path.exists(pipexe):
       logprint('Pip already installed')
    else:
-      command = 'python -s setup.py --no-user-cfg install --force --verbose'
+      command = 'python2 -s setup.py --no-user-cfg install --force --verbose'
 
       # Unpack and build setuptools
       logprint('Installing setuptools.')
@@ -517,6 +517,7 @@ def compile_qt():
    execAndWait('patch -p1 < %s' % path.join(os.getcwd(), 'qpaintengine_mac.patch'), cwd=qtBuildDir)
    # macOS 10.13 errors on unused code.
    execAndWait('patch -p1 < %s' % path.join(os.getcwd(), 'qt_cocoa_helpers_mac.patch'), cwd=qtBuildDir)
+   execAndWait('patch -p1 < %s' % path.join(os.getcwd(), 'clang-5-darwin.patch'), cwd=qtBuildDir)
 
    # Configure Qt. http://wiki.phisys.com/index.php/Compiling_Phi has an example
    # that can be checked for ideas.
@@ -569,7 +570,7 @@ def compile_sip():
       logprint('Sip is already installed.')
    else:
       sipPath = unpack(tarfilesToDL['sip'])
-      command  = 'python configure.py'
+      command  = 'python2 configure.py'
       command += ' --destdir="%s"' % PYSITEPKGS
       command += ' --bindir="%s/bin"' % PYFRAMEBASE
       command += ' --incdir="%s/include"' % PYFRAMEBASE
@@ -592,7 +593,7 @@ def compile_pyqt():
    else:
       pyqtPath = unpack(tarfilesToDL['pyqt'])
       incDir = path.join(PYFRAMEBASE, 'include')
-      execAndWait('python ./configure-ng.py --confirm-license --sip-incdir="%s"' % incDir, cwd=pyqtPath)
+      execAndWait('python2 ./configure-ng.py --confirm-license --sip-incdir="%s"' % incDir, cwd=pyqtPath)
       execAndWait('make %s' % MAKEFLAGS, cwd=pyqtPath)
 
    # Need to add pyrcc4 to the PATH
@@ -607,7 +608,7 @@ def compile_psutil():
    if glob.glob(PYSITEPKGS + '/psutil*'):
       logprint('Psutil already installed')
    else:
-      command = 'python -s setup.py --no-user-cfg install --force --verbose'
+      command = 'python2 -s setup.py --no-user-cfg install --force --verbose'
       psPath = unpack(tarfilesToDL['psutil'])
       execAndWait(command, cwd=psPath)
 
@@ -618,7 +619,7 @@ def compile_twisted():
    if glob.glob(PYSITEPKGS + '/Twisted*'):
       logprint('Twisted already installed')
    else:
-      command = "python -s setup.py --no-user-cfg install --force --verbose"
+      command = "python2 -s setup.py --no-user-cfg install --force --verbose"
       twpath = unpack(tarfilesToDL['Twisted'])
       execAndWait(command, cwd=twpath)
 
@@ -631,7 +632,7 @@ def compile_armory():
    armoryDB = path.join(APPBASE, 'Contents/MacOS/ArmoryDB')
    currentDir = os.getcwd()
    os.chdir("..")
-   execAndWait('python update_version.py')
+   execAndWait('python2 update_version.py')
    os.chdir(currentDir)
    execAndWait('./autogen.sh', cwd='..')
    execAndWait('./configure %s' % CONFIGFLAGS, cwd='..')

--- a/osxbuild/clang-5-darwin.patch
+++ b/osxbuild/clang-5-darwin.patch
@@ -1,0 +1,11 @@
+--- a/src/gui/text/qfontengine_coretext.mm
++++ b/src/gui/text/qfontengine_coretext.mm
+@@ -886,7 +886,7 @@ void QCoreTextFontEngine::getUnscaledGlyph(glyph_t glyph, QPainterPath *path, gl
+ 
+ QFixed QCoreTextFontEngine::emSquareSize() const
+ {
+-    return QFixed::QFixed(int(CTFontGetUnitsPerEm(ctfont)));
++    return QFixed(int(CTFontGetUnitsPerEm(ctfont)));
+ }
+ 
+ QFontEngine *QCoreTextFontEngine::cloneWithSize(qreal pixelSize) const

--- a/osxbuild/macOS_build_notes.md
+++ b/osxbuild/macOS_build_notes.md
@@ -25,7 +25,7 @@ If a bug is found, please consult the [Bitcoin Forum](https://bitcointalk.org/in
 
  4. Install and link dependencies required by the Armory build process but not by included Armory binaries.
 
-        brew install xz swig gettext openssl automake libtool homebrew/dupes/zlib
+        brew install xz swig gettext openssl automake libtool homebrew/dupes/zlib python2
         brew link gettext --force
 
  5. Restart your Mac. (This is necessary due to issues related to the Python install.)
@@ -48,7 +48,7 @@ If a bug is found, please consult the [Bitcoin Forum](https://bitcointalk.org/in
 		git submodule init  (Required only if using Git version control, as discussed in Step 7.2.)
 		git submodule update  (Required only if using Git version control, as discussed in Step 7.2.)
 		cd osxbuild
-        python build-app.py > /dev/null
+        python2 build-app.py > /dev/null
 
 The "> /dev/null" line in step 9 is optional. All this does is prevent the command line from being overwhelmed with build output. The output will automatically be saved to osxbuild/build-app.log.txt no matter what.
 


### PR DESCRIPTION
Recently, brew switched things up such that typing "python" on the command line executes Python 3, not Python 2. Force systems to stick to Python 2 as part of the build process.

In addition, include a patch (https://trac.macports.org/ticket/55932) required to get Qt4 to build using Xcode 9.3 (clang 9.1).