### PR TITLE
Enable libwebsockets compilation for *NIX

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -102,6 +102,29 @@ AS_IF([test $HAVE_LRELEASE == yes], [],
 
 fi
 
+# Check for CMake - needed to build libwebsockets.
+# 2.8.9 is the minimum version libwebsockets requires.
+AC_CHECK_PROGS(CMAKE, cmake)
+if test -z "$CMAKE"; then
+   AC_MSG_ERROR([missing cmake in path - make sure cmake is installed])
+fi
+cmake_version=`$CMAKE --version 2>/dev/null | sed q | awk '{print $3}'`
+AS_VERSION_COMPARE("$cmake_version", 2.8.9,
+AC_MSG_ERROR([CMake 2.8.9 or later is needed to build libwebsockets]),,)
+
+# AS_IF is misleading. libwebsockets_build doesn't exist. We're just looking for
+# an excuse to trigger the libwebsockets setup. libwebsockets uses CMake, and
+# converting to Autotools would be a bad idea. Autotools and CMake don't play
+# nicely, so we just use CMake to create a Makefile that can be kicked off
+# later. Oh, and if CMake fails, we have to use a hack (check for the existence
+# of a Makefile) to see if we should proceed. Got a better solution? Speak up!
+AS_IF([test "x$libwebsockets_build" != xno],
+	[echo "Configuring libwebsockets"; lwsPreDir=`pwd`; echo $lwsPreDir; cd cppForSwig/libwebsockets/build/; cmake .. -DLWS_WITH_SSL=OFF -DLWS_SSL_CLIENT_USE_OS_CA_CERTS=OFF; cd $lwsPreDir],
+	[echo "You should never, ever see this message when building libwebsockets!"])
+if test ! -f "$srcdir/cppForSwig/libwebsockets/build/Makefile" ; then
+	AC_MSG_ERROR([libwebsockets setup failed - abort Armory setup])
+fi
+
 AC_SUBST([CXX_STANDARD], $CXX_STANDARD)
 
 dnl Determine build OS and do other OS-specific things.

--- a/cppForSwig/Makefile.am
+++ b/cppForSwig/Makefile.am
@@ -3,8 +3,8 @@ bin_PROGRAMS =
 noinst_PROGRAMS =
 lib_LTLIBRARIES =
 
-DIST_SUBDIRS = lmdb fcgi cryptopp
-SUBDIRS = lmdb fcgi cryptopp $(MAYBE_BUILD)
+DIST_SUBDIRS = lmdb fcgi cryptopp libwebsockets/build
+SUBDIRS = lmdb fcgi cryptopp libwebsockets/build $(MAYBE_BUILD)
 
 SWIG_FLAGS = -c++ -python -threads
 AM_CXXFLAGS = $(CXXFLAGS)
@@ -55,6 +55,7 @@ ARMORYCLI_SOURCE_FILES = Accounts.cpp \
 	ReentrantLock.cpp \
 	ScrAddrFilter.cpp \
 	ScrAddrObj.cpp \
+	Server.cpp \
 	SocketObject.cpp \
 	SshParser.cpp \
 	StringSockets.cpp \

--- a/cppForSwig/libwebsockets/.gitignore
+++ b/cppForSwig/libwebsockets/.gitignore
@@ -1,4 +1,5 @@
-#Ignore build files
+# Ignore build files.
+# NB: build/.gitignore is a trick to get Autotools to work. Leave it alone.
 config.h
 config.log
 config.status

--- a/linuxbuild/Linux_build_notes.md
+++ b/linuxbuild/Linux_build_notes.md
@@ -43,7 +43,7 @@ HEAD is now at a3d01aa... bump version
 
 In Ubuntu, you are required to install some packages before attempting to build Armory. To do so, type the following line (omitting the dollar sign) into a terminal. This only needs to be done once:
 
-    $ sudo apt-get install git-core pkg-config build-essential pyqt4-dev-tools swig libqtcore4 libqt4-dev python-qt4 python-dev python-twisted python-psutil
+    $ sudo apt-get install git-core pkg-config build-essential pyqt4-dev-tools swig libqtcore4 libqt4-dev python-qt4 python-dev python-twisted python-psutil cmake
 
 Now, you need to clone Armory's git repository and initialize the submodules:
 
@@ -54,7 +54,7 @@ $ git submodule init
 $ git submodule update
 ~~~
 
-At this point, you may want to check the authenticity of the source code, as stated above. You can do that by typing the following (replacing `0.93.1` with the latest Armory version):
+At this point, you may want to check the authenticity of the source code, as stated above. You can do that by typing the following (replacing `0.96` with the specific Armory version that you're compiling):
 
 ~~~bash
 $ git checkout v0.96

--- a/osxbuild/macOS_build_notes.md
+++ b/osxbuild/macOS_build_notes.md
@@ -25,7 +25,7 @@ If a bug is found, please consult the [Bitcoin Forum](https://bitcointalk.org/in
 
  4. Install and link dependencies required by the Armory build process but not by included Armory binaries.
 
-        brew install xz swig gettext openssl automake libtool homebrew/dupes/zlib
+        brew install xz swig gettext openssl automake libtool zlib cmake
         brew link gettext --force
 
  5. Restart your Mac. (This is necessary due to issues related to the Python install.)


### PR DESCRIPTION
CMake is invoked in a somewhat hacky manner. It works but a better solution would be appreciated. The basic idea is to use CMake to configure libwebsockets in configure.ac, and then add the result as a subdirectory in Makefile.am. Autotools also forces the "build" subdirectory to pre-exist in order to work. Include an empty .gitignore file to force the subdirectory to be included.

In addition, compile Server.cpp so that ArmoryDB will link properly.