### PR TITLE
Build GUI elements when tests are enabled

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,12 +12,12 @@ EXTRA_DIST = *.py *.md LICENSE LICENSE-ATI LICENSE-MIT \
 ACLOCAL_AMFLAGS = -I build-aux/m4
 
 lrelease:
-if HAVE_GUI
+if BUILD_CLIENT
 	lrelease lang/*.ts
 endif
 
 qrc_img_resources.py: imgList.xml
-if HAVE_GUI
+if BUILD_CLIENT
 	pyrcc4 -o qrc_img_resources.py imgList.xml
 endif
 
@@ -25,7 +25,7 @@ copy-script:
 	cp cppForSwig/ArmoryDB ./ArmoryDB
 
 # SWIG code and requirements.
-if HAVE_GUI
+if BUILD_CLIENT
 	cp cppForSwig/CppBlockUtils.py ./CppBlockUtils.py
 if BUILD_DARWIN
 	cp cppForSwig/.libs/libCppBlockUtils.dylib ./_CppBlockUtils.so
@@ -44,7 +44,7 @@ uninstall-old:
 	rm -f $(DESTDIR)$(prefix)/bin/ArmoryDB
 
 install-exec-hook: uninstall-old
-if HAVE_GUI
+if BUILD_CLIENT
 	mkdir -p $(DESTDIR)$(prefix)/lib/armory/ui
 	mkdir -p $(DESTDIR)$(prefix)/lib/armory/armoryengine
 	mkdir -p $(DESTDIR)$(prefix)/lib/armory/lang
@@ -103,7 +103,7 @@ endif
 
 # Skip Linux-specific steps on OSX.
 if ! BUILD_DARWIN
-if HAVE_GUI
+if BUILD_CLIENT
 	rsync -rupE --exclude="img/.DS_Store" img $(DESTDIR)$(prefix)/share/armory/
 	sed "s: /usr: $(prefix):g" < dpkgfiles/armory > $(DESTDIR)$(prefix)/bin/armory
 	chmod +x $(DESTDIR)$(prefix)/bin/armory

--- a/configure.ac
+++ b/configure.ac
@@ -46,8 +46,12 @@ else
   CXXFLAGS="$CXXFLAGS -O2"
 fi
 
-AM_CONDITIONAL([HAVE_GUI], [test "x$with_gui" = "xyes"])
-   
+# Even if the GUI is disabled, build GUI elements if tests are enabled.
+AS_IF([test "x$with_gui" = "xyes"], [build_client=yes],
+	[test "x$want_tests" = "xyes"], [build_client=yes],
+	[build_client=no])
+AM_CONDITIONAL([BUILD_CLIENT], [test x$build_client = xyes])
+
 AC_PROG_CC
 AC_PROG_CXX
 AM_CONDITIONAL([HAVE_GCC], [test $CXX = g++])
@@ -68,7 +72,7 @@ AX_CXX_COMPILE_STDCXX([11], [noext], [mandatory], [nodefault])
 # Make the compilation flags quiet unless V=1 is used.
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
-if test "x$with_gui" = "xyes"; then
+if test "x$build_client" = "xyes"; then
 #check for  swig
 
 AC_CHECK_PROG([HAVE_SWIG], [swig], [yes], [no])
@@ -168,7 +172,7 @@ case $host in
   *linux*)
     BUILD_OS=linux
 
-    if test "x$with_gui" = "xyes"; then
+    if test "x$build_client" = "xyes"; then
        # Check existence of Qt packages.
        if ! pkg-config --exists 'QtCore >= 4.8 QtCore <= 5 QtGui >= 4.8 QtGui <= 5'; then
        	   AC_MSG_ERROR([missing QtCore library, make sure libqtcore4 and libqt4-dev are installed])
@@ -229,4 +233,4 @@ echo "  LD              = $LD"
 echo "  with tests      = $want_tests"
 echo "  with benchmarks = $want_benchmark"
 echo "  debug symbols   = $want_debug"
-echo "  with GUI        = $with_gui"
+echo "  with GUI/client = $build_client"

--- a/cppForSwig/Makefile.am
+++ b/cppForSwig/Makefile.am
@@ -114,7 +114,7 @@ ArmoryDB_LDADD = fcgi/libfcgi/libfcgi.la \
 		 -lpthread
 ArmoryDB_LDFLAGS = -static $(LDFLAGS)
 
-if HAVE_GUI
+if BUILD_CLIENT
 # Common GUI functionality library
 lib_LTLIBRARIES += libArmoryGUI.la
 libArmoryGUI_la_SOURCES = $(ARMORYGUI_SOURCE_FILES)

--- a/cppForSwig/Makefile.tests.include
+++ b/cppForSwig/Makefile.tests.include
@@ -31,7 +31,6 @@ gtest_DB1kIterTest_LDADD = gtest/libgtest.la
 gtest_DB1kIterTest_LDFLAGS = $(AM_LDFLAGS) $(LDFLAGS) -static
 TESTS += gtest/DB1kIterTest
 
-if HAVE_GUI
 # SupernodeTests
 bin_PROGRAMS += gtest/SupernodeTests
 gtest_SupernodeTests_SOURCES = gtest/SupernodeTests.cpp
@@ -49,4 +48,3 @@ gtest_CppBlockUtilsTests_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES)
 gtest_CppBlockUtilsTests_LDADD = gtest/libgtest.la libArmoryGUI.la
 gtest_CppBlockUtilsTests_LDFLAGS = $(AM_LDFLAGS) $(LDFLAGS) -static
 TESTS += gtest/CppBlockUtilsTests
-endif


### PR DESCRIPTION
Right now, unit tests that require the GUI library (libCppBlockUtils or libArmoryGUI) are intertwined with "headless" (libArmoryCLI or ArmoryDB) code. To keep things simple, just force the building of GUI elements when tests are enabled.