### PR TITLE
Update build directions to cover Ubuntu 18.04

### DIFF
--- a/linuxbuild/Linux_build_notes.md
+++ b/linuxbuild/Linux_build_notes.md
@@ -43,7 +43,7 @@ HEAD is now at a3d01aa... bump version
 
 In Ubuntu, you are required to install some packages before attempting to build Armory. To do so, type the following line (omitting the dollar sign) into a terminal. This only needs to be done once:
 
-    $ sudo apt-get install git-core pkg-config build-essential pyqt4-dev-tools swig libqtcore4 libqt4-dev python-qt4 python-dev python-twisted python-psutil cmake
+    $ sudo apt-get install python git-core pkg-config build-essential pyqt4-dev-tools swig libqtcore4 libqt4-dev python-qt4 python-dev python-twisted python-psutil cmake autoconf libtool
 
 Now, you need to clone Armory's git repository and initialize the submodules:
 


### PR DESCRIPTION
Some might apply pre-18.04 (whoops!) but "python" is definitely required as of 18.04. (Python 2 isn't installed by default.)