### PR TITLE
Prevent bitcoind from printing to stdout

### DIFF
--- a/SDM.py
+++ b/SDM.py
@@ -410,6 +410,7 @@ class SatoshiDaemonManager(object):
          pargs.append('-regtest')
 
       pargs.append('-datadir=%s' % self.satoshiHome)
+      pargs.append('-noprinttoconsole')
 
       try:
          # Don't want some strange error in this size-check to abort loading


### PR DESCRIPTION
Fixes #497

bitcoind now prints to console by default when `-daemon` is not set. Since we do not use `-daemon`, the output to stdout produced by bitcoind is getting caught somewhere and causing bitcoind to block. This PR sets `-noprinttoconsole` when we start bitcoind to suppress this behavior.