### PR TITLE
libbtc update

### DIFF
--- a/cppForSwig/libbtc/Makefile.am
+++ b/cppForSwig/libbtc/Makefile.am
@@ -25,6 +25,7 @@ include_HEADERS = \
     include/btc/hash.h \
     include/btc/portable_endian.h \
     include/btc/random.h \
+    include/btc/ripemd160.h \
     include/btc/script.h \
     include/btc/segwit_addr.h \
     include/btc/serialize.h \
@@ -33,9 +34,6 @@ include_HEADERS = \
     include/btc/tx.h \
     include/btc/utils.h \
     include/btc/vector.h
-
-noinst_HEADERS = \
-	src/ripemd160.h
 
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = libbtc.pc

--- a/cppForSwig/libbtc/include/btc/ecc_key.h
+++ b/cppForSwig/libbtc/include/btc/ecc_key.h
@@ -52,6 +52,10 @@ LIBBTC_API void btc_privkey_encode_wif(const btc_key* privkey, const btc_chainpa
 LIBBTC_API btc_bool btc_privkey_decode_wif(const char *privkey_wif, const btc_chainparams* chain, btc_key* privkey);
 
 LIBBTC_API void btc_pubkey_init(btc_pubkey* pubkey);
+
+// Compute the length of a pubkey with a given first byte.
+LIBBTC_API unsigned int btc_pubkey_get_length(unsigned char ch_header);
+
 LIBBTC_API btc_bool btc_pubkey_is_valid(const btc_pubkey* pubkey);
 LIBBTC_API void btc_pubkey_cleanse(btc_pubkey* pubkey);
 LIBBTC_API void btc_pubkey_from_key(const btc_key* privkey, btc_pubkey* pubkey_inout);

--- a/cppForSwig/libbtc/include/btc/ripemd160.h
+++ b/cppForSwig/libbtc/include/btc/ripemd160.h
@@ -22,11 +22,15 @@
  */
 
 
-#ifndef __RIPEMD160_H__
-#define __RIPEMD160_H__
+#ifndef __LIBBTC_RIPEMD160_H__
+#define __LIBBTC_RIPEMD160_H__
 
-#include <stdint.h>
+#include "btc.h"
 
-void ripemd160(const uint8_t* msg, uint32_t msg_len, uint8_t* hash);
+LIBBTC_BEGIN_DECL
 
-#endif
+LIBBTC_API void btc_ripemd160(const uint8_t* msg, uint32_t msg_len, uint8_t* hash);
+
+LIBBTC_END_DECL
+
+#endif // END __LIBBTC_RIPEMD160_H__

--- a/cppForSwig/libbtc/include/btc/script.h
+++ b/cppForSwig/libbtc/include/btc/script.h
@@ -195,6 +195,7 @@ enum opcodetype {
 };
 
 enum btc_tx_out_type {
+    BTC_TX_INVALID = -1,
     BTC_TX_NONSTANDARD,
     // 'standard' transaction types:
     BTC_TX_PUBKEY,
@@ -210,6 +211,9 @@ typedef struct btc_script_op_ {
     unsigned char* data; /* associated data, if any */
     size_t datalen;
 } btc_script_op;
+
+// Maximum script length in bytes
+static const int MAX_SCRIPT_SIZE = 10000;
 
 //copy a script without the codeseperator ops
 btc_bool btc_script_copy_without_op_codeseperator(const cstring* scriptin, cstring* scriptout);

--- a/cppForSwig/libbtc/src/bip32.c
+++ b/cppForSwig/libbtc/src/bip32.c
@@ -35,12 +35,11 @@
 #include <btc/ecc.h>
 #include <btc/ecc_key.h>
 #include <btc/hash.h>
+#include <btc/ripemd160.h>
 #include <btc/sha2.h>
 #include <btc/utils.h>
 
 #include "memory.h"
-
-#include "ripemd160.h"
 
 // write 4 big endian bytes
 static void write_be(uint8_t* data, uint32_t x)
@@ -126,7 +125,7 @@ btc_bool btc_hdnode_public_ckd(btc_hdnode* inout, uint32_t i)
     write_be(data + BTC_ECKEY_COMPRESSED_LENGTH, i);
 
     sha256_Raw(inout->public_key, BTC_ECKEY_COMPRESSED_LENGTH, fingerprint);
-    ripemd160(fingerprint, 32, fingerprint);
+    btc_ripemd160(fingerprint, 32, fingerprint);
     inout->fingerprint = (fingerprint[0] << 24) + (fingerprint[1] << 16) + (fingerprint[2] << 8) + fingerprint[3];
 
     memset(inout->private_key, 0, 32);
@@ -169,7 +168,7 @@ btc_bool btc_hdnode_private_ckd(btc_hdnode* inout, uint32_t i)
     write_be(data + BTC_ECKEY_COMPRESSED_LENGTH, i);
 
     sha256_Raw(inout->public_key, BTC_ECKEY_COMPRESSED_LENGTH, fingerprint);
-    ripemd160(fingerprint, 32, fingerprint);
+    btc_ripemd160(fingerprint, 32, fingerprint);
     inout->fingerprint = (fingerprint[0] << 24) + (fingerprint[1] << 16) +
                          (fingerprint[2] << 8) + fingerprint[3];
 
@@ -248,7 +247,7 @@ void btc_hdnode_get_hash160(const btc_hdnode* node, uint160 hash160_out)
 {
     uint256 hashout;
     btc_hash_sngl_sha256(node->public_key, BTC_ECKEY_COMPRESSED_LENGTH, hashout);
-    ripemd160(hashout, sizeof(hashout), hash160_out);
+    btc_ripemd160(hashout, sizeof(hashout), hash160_out);
 }
 
 void btc_hdnode_get_p2pkh_address(const btc_hdnode* node, const btc_chainparams* chain, char* str, int strsize)

--- a/cppForSwig/libbtc/src/ecc_key.c
+++ b/cppForSwig/libbtc/src/ecc_key.c
@@ -36,11 +36,10 @@
 #include <btc/ecc.h>
 #include <btc/hash.h>
 #include <btc/random.h>
+#include <btc/ripemd160.h>
 #include <btc/script.h>
 #include <btc/segwit_addr.h>
 #include <btc/utils.h>
-
-#include "ripemd160.h"
 
 
 void btc_privkey_init(btc_key* privkey)
@@ -131,6 +130,16 @@ void btc_pubkey_init(btc_pubkey* pubkey)
 }
 
 
+unsigned int btc_pubkey_get_length(unsigned char ch_header)
+{
+    if (ch_header == 2 || ch_header == 3)
+        return BTC_ECKEY_COMPRESSED_LENGTH;
+    if (ch_header == 4 || ch_header == 6 || ch_header == 7)
+        return BTC_ECKEY_UNCOMPRESSED_LENGTH;
+    return 0;
+}
+
+
 btc_bool btc_pubkey_is_valid(const btc_pubkey* pubkey)
 {
     return btc_ecc_verify_pubkey(pubkey->pubkey, pubkey->compressed);
@@ -151,7 +160,7 @@ void btc_pubkey_get_hash160(const btc_pubkey* pubkey, uint160 hash160)
     uint256 hashout;
     btc_hash_sngl_sha256(pubkey->pubkey, pubkey->compressed ? BTC_ECKEY_COMPRESSED_LENGTH : BTC_ECKEY_UNCOMPRESSED_LENGTH, hashout);
 
-    ripemd160(hashout, sizeof(hashout), hash160);
+    btc_ripemd160(hashout, sizeof(hashout), hash160);
 }
 
 

--- a/cppForSwig/libbtc/src/ripemd160.c
+++ b/cppForSwig/libbtc/src/ripemd160.c
@@ -24,7 +24,7 @@
 
 #include <string.h>
 
-#include "ripemd160.h"
+#include <btc/ripemd160.h>
 
 #define ROL(x, n) (((x) << (n)) | ((x) >> (32 - (n))))
 
@@ -289,7 +289,7 @@ static void compress(uint32_t* MDbuf, uint32_t* X)
     MDbuf[0] = ddd;
 }
 
-void ripemd160(const uint8_t* msg, uint32_t msg_len, uint8_t* hash)
+void btc_ripemd160(const uint8_t* msg, uint32_t msg_len, uint8_t* hash)
 {
     uint32_t i;
     int j;

--- a/cppForSwig/libbtc/src/script.c
+++ b/cppForSwig/libbtc/src/script.c
@@ -32,9 +32,9 @@
 
 #include <btc/buffer.h>
 #include <btc/hash.h>
+#include <btc/ripemd160.h>
 #include <btc/serialize.h>
 
-#include "ripemd160.h" //non exposed header
 
 btc_bool btc_script_copy_without_op_codeseperator(const cstring* script_in, cstring* script_out)
 {
@@ -159,6 +159,11 @@ btc_bool btc_script_get_ops(const cstring* script_in, vector* ops_out)
             continue;
         }
 
+        // don't alloc a push buffer if there is no more data available
+        if (buf.len == 0 || data_len > buf.len) {
+            goto err_out;
+        }
+
         op->data = btc_calloc(1, data_len);
         memcpy(op->data, buf.p, data_len);
         op->datalen = data_len;
@@ -189,8 +194,11 @@ static btc_bool btc_script_is_op_pubkey(const btc_script_op* op)
 {
     if (!btc_script_is_pushdata(op->op))
         return false;
-    if (op->datalen < 33 || op->datalen > 120)
+    if (op->datalen != BTC_ECKEY_COMPRESSED_LENGTH && op->datalen != BTC_ECKEY_UNCOMPRESSED_LENGTH)
         return false;
+    if (btc_pubkey_get_length(op->data[0]) != op->datalen) {
+        return false;
+    }
     return true;
 }
 
@@ -204,11 +212,21 @@ static btc_bool btc_script_is_op_pubkeyhash(const btc_script_op* op)
 }
 
 // OP_PUBKEY, OP_CHECKSIG
-btc_bool btc_script_is_pubkey(const vector* ops)
+btc_bool btc_script_is_pubkey(const vector* ops, vector* data_out)
 {
-    return ((ops->len == 2) &&
+    if ((ops->len == 2) &&
             btc_script_is_op(vector_idx(ops, 1), OP_CHECKSIG) &&
-            btc_script_is_op_pubkey(vector_idx(ops, 0)));
+            btc_script_is_op_pubkey(vector_idx(ops, 0))) {
+        if (data_out) {
+            //copy the full pubkey (33 or 65) in case of a non empty vector
+            const btc_script_op* op = vector_idx(ops, 0);
+            uint8_t* buffer = btc_calloc(1, op->datalen);
+            memcpy(buffer, op->data, op->datalen);
+            vector_add(data_out, buffer);
+        }
+        return true;
+    }
+    return false;
 }
 
 // OP_DUP, OP_HASH160, OP_PUBKEYHASH, OP_EQUALVERIFY, OP_CHECKSIG,
@@ -233,12 +251,24 @@ btc_bool btc_script_is_pubkeyhash(const vector* ops, vector* data_out)
 }
 
 // OP_HASH160, OP_PUBKEYHASH, OP_EQUAL
-btc_bool btc_script_is_scripthash(const vector* ops)
+btc_bool btc_script_is_scripthash(const vector* ops, vector* data_out)
 {
-    return ((ops->len == 3) &&
+    if ((ops->len == 3) &&
             btc_script_is_op(vector_idx(ops, 0), OP_HASH160) &&
             btc_script_is_op_pubkeyhash(vector_idx(ops, 1)) &&
-            btc_script_is_op(vector_idx(ops, 2), OP_EQUAL));
+            btc_script_is_op(vector_idx(ops, 2), OP_EQUAL)) {
+
+        if (data_out) {
+            //copy the data (hash160) in case of a non empty vector
+            const btc_script_op* op = vector_idx(ops, 1);
+            uint8_t* buffer = btc_calloc(1, sizeof(uint160));
+            memcpy(buffer, op->data, sizeof(uint160));
+            vector_add(data_out, buffer);
+        }
+
+        return true;
+    }
+    return false;
 }
 
 static btc_bool btc_script_is_op_smallint(const btc_script_op* op)
@@ -267,9 +297,9 @@ enum btc_tx_out_type btc_script_classify_ops(const vector* ops)
 {
     if (btc_script_is_pubkeyhash(ops, NULL))
         return BTC_TX_PUBKEYHASH;
-    if (btc_script_is_scripthash(ops))
+    if (btc_script_is_scripthash(ops, NULL))
         return BTC_TX_SCRIPTHASH;
-    if (btc_script_is_pubkey(ops))
+    if (btc_script_is_pubkey(ops, NULL))
         return BTC_TX_PUBKEY;
     if (btc_script_is_multisig(ops))
         return BTC_TX_MULTISIG;
@@ -288,9 +318,9 @@ enum btc_tx_out_type btc_script_classify(const cstring* script, vector* data_out
 
     if (btc_script_is_pubkeyhash(ops, data_out))
         tx_out_type = BTC_TX_PUBKEYHASH;
-    if (btc_script_is_scripthash(ops))
+    if (btc_script_is_scripthash(ops, data_out))
         tx_out_type = BTC_TX_SCRIPTHASH;
-    if (btc_script_is_pubkey(ops))
+    if (btc_script_is_pubkey(ops, data_out))
         tx_out_type = BTC_TX_PUBKEY;
     if (btc_script_is_multisig(ops))
         tx_out_type = BTC_TX_MULTISIG;
@@ -420,7 +450,7 @@ btc_bool btc_script_get_scripthash(const cstring* script_in, uint160 scripthash)
     }
     uint256 hash;
     btc_hash_sngl_sha256((const unsigned char *)script_in->str, script_in->len, hash);
-    ripemd160(hash, sizeof(hash), scripthash);
+    btc_ripemd160(hash, sizeof(hash), scripthash);
 
     return true;
 }

--- a/cppForSwig/libbtc/src/tx.c
+++ b/cppForSwig/libbtc/src/tx.c
@@ -808,6 +808,8 @@ enum btc_tx_sign_result btc_tx_sign_input(btc_tx *tx_in_out, const cstring *scri
     if (type == BTC_TX_SCRIPTHASH) {
         // p2sh script, need the redeem script
         // for now, pretend to be a p2sh-p2wpkh
+        vector_free(script_pushes, true);
+        script_pushes = vector_new(1, free);
         type = BTC_TX_WITNESS_V0_PUBKEYHASH;
         uint8_t *hash160 = btc_calloc(1, 20);
         btc_pubkey_get_hash160(&pubkey, hash160);

--- a/cppForSwig/libbtc/test/tx_tests.c
+++ b/cppForSwig/libbtc/test/tx_tests.c
@@ -1363,3 +1363,22 @@ void test_tx_sign() {
     btc_tx_free(tx);
 }
 
+void test_scripts() {
+    const char *script_p2pk = "41042f462d3245d2f3a015f7f9505f763ee1080cab36191d07ae9e6509f71bb68818719e6fb41c019bf48ae11c45b024d476e19b6963103ce8647fc15fee513b15c7ac";
+    const char *script_p2pkh = "76a91481edb497b5ba6eb9e67b7ed50fb220395f76f95088ac";
+    int outlen;
+    cstring* script_data_p2pk = cstr_new_sz(strlen(script_p2pk) / 2);
+    utils_hex_to_bin(script_p2pk, (unsigned char *)script_data_p2pk->str, strlen(script_p2pk), &outlen);
+    script_data_p2pk->len = outlen;
+
+    cstring* script_data_p2pkh = cstr_new_sz(strlen(script_p2pkh) / 2);
+    utils_hex_to_bin(script_p2pkh, (unsigned char *)script_data_p2pkh->str, strlen(script_p2pkh), &outlen);
+    script_data_p2pkh->len = outlen;
+
+    vector* vec = vector_new(16, free);
+    enum btc_tx_out_type type = btc_script_classify(script_data_p2pk, vec);
+    u_assert_int_eq(type, BTC_TX_PUBKEY);
+    type = btc_script_classify(script_data_p2pkh, vec);
+    u_assert_int_eq(type, BTC_TX_PUBKEYHASH);
+    vector_free(vec, true);
+}

--- a/cppForSwig/libbtc/test/unittester.c
+++ b/cppForSwig/libbtc/test/unittester.c
@@ -58,6 +58,7 @@ extern void test_script_parse();
 extern void test_script_op_codeseperator();
 extern void test_invalid_tx_deser();
 extern void test_tx_sign();
+extern void test_scripts();
 extern void test_eckey();
 
 #ifdef WITH_WALLET
@@ -107,6 +108,7 @@ int main()
     u_run_test(test_tx_sighash);
     u_run_test(test_tx_sighash_ext);
     u_run_test(test_tx_negative_version);
+    u_run_test(test_scripts);
     u_run_test(test_block_header);
     u_run_test(test_script_parse);
     u_run_test(test_script_op_codeseperator);


### PR DESCRIPTION
Updates libbtc to the latest version. Among other things, this exposes RIPEMD-160, which is required if libbtc is going to replace as much of Crypto++ as possible without pulling in extra code from elsewhere.