### PR TITLE
Fix GUI/client build issues

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -68,9 +68,8 @@ else
   CXXFLAGS="$CXXFLAGS -O2"
 fi
 
-# Even if the GUI is disabled, build GUI elements if tests are enabled.
+# For now, the GUI is considered synonymous with the client. This may change.
 AS_IF([test "x$with_gui" = "xyes"], [build_client=yes],
-	[test "x$want_tests" = "xyes"], [build_client=yes],
 	[build_client=no])
 AM_CONDITIONAL([BUILD_CLIENT], [test x$build_client = xyes])
 

--- a/cppForSwig/Makefile.am
+++ b/cppForSwig/Makefile.am
@@ -47,16 +47,12 @@ INCLUDE_FILES = -Ibech32/ref/c++ -Ilmdb/libraries/liblmdb \
 	-Ilibbtc/include -Ilibbtc/src/secp256k1/include \
 	$(LWS_CFLAGS)
 
-# Files should *not* be marked as "common" if at all possible.
+# Files should *not* be marked as "common" if at all possible. Also, a refactor
+# might not hurt one of these days. Some of the "common" files could be GUI/CLI
+# files but are "common" for the sake of unit testing. In an ideal world, the
+# unit tests would be split into multiple files as needed. One day....
 ARMORYDB_SOURCE_FILES = main.cpp
-ARMORYGUI_SOURCE_FILES = AsyncClient.cpp \
-	CoinSelection.cpp \
-	ClientClasses.cpp \
-	SwigClient.cpp \
-	TransactionBatch.cpp \
-	WalletManager.cpp \
-	Wallets.cpp \
-	WebSocketClient.cpp
+ARMORYGUI_SOURCE_FILES = TransactionBatch.cpp
 ARMORYCLI_SOURCE_FILES = BDM_mainthread.cpp \
 	BDM_Server.cpp \
 	BitcoinP2P.cpp \
@@ -90,10 +86,13 @@ ARMORYCOMMON_SOURCE_FILES = Accounts.cpp \
 	Addresses.cpp \
 	AssetEncryption.cpp \
 	Assets.cpp \
+	AsyncClient.cpp \
 	BinaryData.cpp \
 	BIP32_Node.cpp \
 	BlockDataManagerConfig.cpp \
 	BtcUtils.cpp \
+	ClientClasses.cpp \
+	CoinSelection.cpp \
 	DecryptedDataContainer.cpp \
 	DerivationScheme.cpp \
 	EncryptionUtils.cpp \
@@ -103,14 +102,19 @@ ARMORYCOMMON_SOURCE_FILES = Accounts.cpp \
 	Script.cpp \
 	Signer.cpp \
 	SocketObject.cpp \
+	StoredBlockObj.cpp \
+	SwigClient.cpp \
 	Transactions.cpp \
 	TxClasses.cpp \
 	TxEvalState.cpp \
 	txio.cpp \
 	UniversalTimer.cpp \
+	WalletManager.cpp \
+	Wallets.cpp \
+	WebSocketClient.cpp \
+	WebSocketMessage.cpp \
 	bech32/ref/c++/bech32.cpp \
-	bech32/ref/c++/segwit_addr.cpp \
-	WebSocketMessage.cpp
+	bech32/ref/c++/segwit_addr.cpp
 
 PROTOBUF_PROTO = protobuf/AddressBook.proto \
 	protobuf/AddressData.proto \

--- a/cppForSwig/Makefile.tests.include
+++ b/cppForSwig/Makefile.tests.include
@@ -10,7 +10,7 @@ lib_LTLIBRARIES += gtest/libgtest.la
 gtest_libgtest_la_CXXFLAGS = $(AM_CXXFLAGS)
 gtest_libgtest_la_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES)
 gtest_libgtest_la_SOURCES = gtest/TestUtils.cpp gtest/gtest-all.cc
-gtest_libgtest_la_LIBADD = libArmoryCommon.la libArmoryCLI.la libArmoryGUI.la
+gtest_libgtest_la_LIBADD = libArmoryCommon.la libArmoryCLI.la
 gtest_libgtest_la_LDFLAGS = $(AM_LDFLAGS) $(LDFLAGS) -shared
 
 # ContainerTests
@@ -40,7 +40,7 @@ gtest_SupernodeTests_LDADD = gtest/libgtest.la
 gtest_SupernodeTests_LDFLAGS = $(AM_LDFLAGS) $(LDFLAGS) -static
 TESTS += gtest/SupernodeTests
 
-# CppBlockUtilsTests - Contains the bulk of the tests (CLI or GUI)
+# CppBlockUtilsTests - Contains the bulk of the tests
 bin_PROGRAMS += gtest/CppBlockUtilsTests
 gtest_CppBlockUtilsTests_SOURCES = gtest/CppBlockUtilsTests.cpp
 gtest_CppBlockUtilsTests_CXXFLAGS = $(AM_CXXFLAGS)


### PR DESCRIPTION
When disabling the GUI but enabling tests, the code still builds the GUI-specific library. Rearrange files to fully decouple the GUI-specific library from the unit tests.

Note that this might warrant a full refactor one day. As things stand, a lot of code could be in the GUI-specific or CLI-specific libraries, but must go into a common library for the sake of unit testing. This isn't optimal. But, it works for now.