### PR TITLE
Fix *NIX build issue

### DIFF
--- a/cppForSwig/Makefile.am
+++ b/cppForSwig/Makefile.am
@@ -216,7 +216,7 @@ CppBlockUtils_wrap.cxx: CppBlockUtils.i
 endif
 
 MOSTLYCLEANFILES = $(PROTOBUF_CC) $(PROTOBUF_H)
-BUILT_SOURCES = $(PROTOBUF_H)
+BUILT_SOURCES = $(PROTOBUF_CC)
 
 clean-local:
 	rm -f CppBlockUtils.py


### PR DESCRIPTION
Ubutnu 18.10 no longer builds Protobuf files. Modify the BUILT_SOURCES Makefile variable to enforce creation of Protobuf .cc files.