### PR TITLE
Disable macOS Dark Mode

### DIFF
--- a/osxbuild/Info.plist
+++ b/osxbuild/Info.plist
@@ -11,5 +11,6 @@
   <key>NSPrincipalClass</key> <string>NSApplication</string>
   <key>LSMinimumSystemVersion</key> <string>10.8.0</string>
   <key>LSAppNapIsDisabled</key> <true/>
+  <key>NSRequiresAquaSystemAppearance</key> <true/>
 </dict>
 </plist>


### PR DESCRIPTION
While untested, it's likely that Armory will look awful on Macs in Dark Mode. Apple has provided a temporary (?) solution allowing Dark Mode to be explicitly disabled. Chances are that a permanent solution will be possible only with a Qt 5 patch.

See https://developer.apple.com/documentation/appkit/nsappearancecustomization/choosing_a_specific_appearance_for_your_app and https://bugreports.qt.io/browse/QTBUG-68891 for more info.