### PR TITLE
Fix default P2P ports for testnet & regtest.

### DIFF
--- a/cppForSwig/BlockDataManagerConfig.cpp
+++ b/cppForSwig/BlockDataManagerConfig.cpp
@@ -126,7 +126,7 @@ void BlockDataManagerConfig::selectNetwork(const string &netname)
          fcgiPort_ = portToString(FCGI_PORT_TESTNET);
 
       if (!customBtcPort_)
-         btcPort_ = portToString(NODE_PORT_MAINNET);
+         btcPort_ = portToString(NODE_PORT_TESTNET);
    }
    else if (netname == "Regtest")
    {
@@ -144,7 +144,7 @@ void BlockDataManagerConfig::selectNetwork(const string &netname)
          fcgiPort_ = portToString(FCGI_PORT_REGTEST);
 
       if (!customBtcPort_)
-         btcPort_ = portToString(NODE_PORT_MAINNET);
+         btcPort_ = portToString(NODE_PORT_REGTEST);
    }
 }
 


### PR DESCRIPTION
Commit 1682b1922a68a5930720afabc2b9f1e9f509fae7 broke the P2P port for testnet and regtest. Fix the ports.