### PR TITLE
Fix make_unique usage when compiling for -std=c++14

### DIFF
--- a/cppForSwig/make_unique.h
+++ b/cppForSwig/make_unique.h
@@ -1,17 +1,27 @@
 #ifndef _H_MAKE_UNIQUE
 #define _H_MAKE_UNIQUE
 
-
+// Pre-C++14 compilers don't have access to make_unique. Use a workaround on
+// those compilers. Once VS2017 is a required compiler, we can start to rely
+// solely on __cplusplus, but for now, we must use _MSC_VER on Windows.
 #ifndef _WIN32
 #include <memory>
-#if __cplusplus < 201402L
-
+#if __cplusplus >= 201402L
+#define make_unique std::make_unique
+#else
 template<typename T, typename... Args> std::unique_ptr<T> make_unique(Args&&... args)
 {
    return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
 }
 #endif
-#else 
+#else
+#if _MSC_VER < 1900
+template<typename T, typename... Args> std::unique_ptr<T> make_unique(Args&&... args)
+{
+   return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+}
+#else
 #define make_unique std::make_unique
+#endif
 #endif
 #endif


### PR DESCRIPTION
Currently, Armory is compiled with -std=c++11. One day, this will presumably switch to -std=c++14. When C++14 is activated, the workaround for make_unique usage causes errors. Improve C++ compiler detection to ensure that C++14 compilers use the standard make_unique.