### PR TITLE
Add TX virtual size call / Correct TX weight

### DIFF
--- a/armoryengine/Transaction.py
+++ b/armoryengine/Transaction.py
@@ -3252,8 +3252,8 @@ def getFeeForTx(txHash):
          for i in range(tx.getNumTxOut()):
             valOut += tx.getTxOutCopy(i).getValue()
          fee = valIn - valOut
-         txWeight = tx.getTxWeight()
-         fee_byte = fee / float(txWeight)
+         txVirtSize = tx.getTxVirtSize()
+         fee_byte = fee / float(txVirtSize)
          return fee, fee_byte
       except:
          LOGERROR('Couldn\'t get tx fee. Ignore this message in Fullnode') 

--- a/cppForSwig/CoinSelection.cpp
+++ b/cppForSwig/CoinSelection.cpp
@@ -1035,8 +1035,10 @@ void UtxoSelection::computeSizeAndFee(
       throw CoinSelectionException("targetVal > value");
 
    size_ = 10 + txOutSize + txInSize;
-   if (sw)
+   if (sw) {
       size_ += 2 + witnessSize_ + utxoVec_.size();
+   }
+   computeVirtSize(sw);
 
    targetVal = payStruct.spendVal_ + fee_;
    changeVal = value_ - targetVal;
@@ -1070,6 +1072,21 @@ void UtxoSelection::computeSizeAndFee(
          return;
       }
    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Function that calculates the selection's virtual size (the size actually used
+// to calculate fees).
+void UtxoSelection::computeVirtSize(const bool& segwit)
+{
+   size_t numerator{0};
+   if(segwit) {
+      numerator = 3*(size_ - witnessSize_) + size_;
+   }
+   else {
+      numerator = 4*size_;
+   }
+   virtSize_ = std::ceil(static_cast<float>(numerator) / 4.0f);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cppForSwig/CoinSelection.h
+++ b/cppForSwig/CoinSelection.h
@@ -137,6 +137,7 @@ struct PaymentStruct
 ////////////////////////////////////////////////////////////////////////////////
 struct UtxoSelection
 {
+public:
    std::vector<UTXO> utxoVec_;
 
    uint64_t value_ = 0;
@@ -145,6 +146,7 @@ struct UtxoSelection
 
    size_t size_ = 0;
    size_t witnessSize_ = 0;
+   size_t virtSize_ = 0;
    float bumpPct_ = 0.0f;
 
    bool hasChange_ = false;
@@ -158,6 +160,10 @@ struct UtxoSelection
 
    void computeSizeAndFee(const PaymentStruct&);
    void shuffle(void);
+
+private:
+   void computeVirtSize(const bool& segwit);
+
 };
 
 

--- a/cppForSwig/TxClasses.cpp
+++ b/cppForSwig/TxClasses.cpp
@@ -465,16 +465,38 @@ bool Tx::isRBF() const
 }
 
 /////////////////////////////////////////////////////////////////////////////
-size_t Tx::getTxWeight() const
+// Get the virtual size of the TX. Used in Bitcoin to determine minimum fees.
+size_t Tx::getTxVirtSize() const
 {
    auto size = getSize();
-   
+
    if (offsetsWitness_.size() > 1)
    {
       auto witnessSize = *offsetsWitness_.rbegin() - *offsetsWitness_.begin();
       float witnessDiscount = float(witnessSize) * 0.75f;
 
       size -= size_t(witnessDiscount);
+   }
+
+   return size;
+}
+
+// Get the weight of the Tx.
+size_t Tx::getTxWeight(void) const
+{
+   return (getTxBaseSize() * 3) + getSize();
+}
+
+// Get the base size of the TX. Used for weight & virt size calculations.
+size_t Tx::getTxBaseSize() const
+{
+   auto size = getSize();
+
+   if (offsetsWitness_.size() > 1)
+   {
+      auto witnessSize = *offsetsWitness_.rbegin() - *offsetsWitness_.begin();
+
+      size -= witnessSize;
    }
 
    return size;

--- a/cppForSwig/TxClasses.h
+++ b/cppForSwig/TxClasses.h
@@ -327,7 +327,8 @@ public:
    void setTxTime(uint32_t txtime) { txTime_ = txtime; }
    uint32_t getTxTime(void) const { return txTime_; }
 
-   //returns tx weight in bytes
+   // Get TX virtual size, which is what is used when calculating fee/byte.
+   size_t getTxVirtSize(void) const;
    size_t getTxWeight(void) const;
 
 private:
@@ -351,6 +352,8 @@ private:
 
    bool isRBF_ = false;
    bool isChainedZc_ = false;
+
+   size_t getTxBaseSize() const;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/qtdialogs.py
+++ b/qtdialogs.py
@@ -5136,7 +5136,7 @@ def extractTxInfo(pytx, rcvTime=None):
       pytx = ustx.pytxObj.copy()
 
    txHash = pytx.getHash()
-   txSize, txWeight, sumTxIn, txTime, txBlk, txIdx = [None] * 6
+   txSize, txVirtSize, sumTxIn, txTime, txBlk, txIdx = [None] * 6
 
    txOutToList = pytx.makeRecipientsList()
    sumTxOut = sum([t[1] for t in txOutToList])
@@ -5146,7 +5146,7 @@ def extractTxInfo(pytx, rcvTime=None):
       txcpp = TheBDM.bdv().getTxByHash(txHash)
       if txcpp.isInitialized():
          hgt = txcpp.getBlockHeight()
-         txWeight = txcpp.getTxWeight()
+         txVirtSize = txcpp.getTxVirtSize()
          if hgt <= TheBDM.getTopBlockHeight():
             headref = TheBDM.bdv().blockchain().getHeaderByHeight(hgt)
             txTime = unixTimeToFormatStr(headref.getTimestamp())
@@ -5234,7 +5234,7 @@ def extractTxInfo(pytx, rcvTime=None):
       sumTxIn = None
 
    return [txHash, txOutToList, sumTxOut, txinFromList, sumTxIn, \
-           txTime, txBlk, txIdx, txSize, txWeight]
+           txTime, txBlk, txIdx, txSize, txVirtSize]
 
 ################################################################################
 class DlgDispTxInfo(ArmoryDialog):


### PR DESCRIPTION
- The virtual size of a TX can be useful info to have, as it's what is used to calculate the fee when fee/byte is used. Allow users to get the virtual size.
- The current TX weight call is actually the TX virtual size. Correct the call to provide the actual weight.