### PR TITLE
Fix Windows compilation errors

### DIFF
--- a/cppForSwig/Win_TranslatePath.h
+++ b/cppForSwig/Win_TranslatePath.h
@@ -1,4 +1,6 @@
+#define NOMINMAX
 #include <windows.h>
+#undef NOMINMAX
 #include <io.h>
 #include <string>
 


### PR DESCRIPTION
Windows doesn't like compiling std::min() and std::max(). (See https://stackoverflow.com/a/4914108 for more info.) Use a workaround to fix errors when compiling in VS2017.