### PR TITLE
Skip C4996 warnings when compiling for Windows

### DIFF
--- a/cppForSwig/protobuf_win/protobuf_win.vcxproj
+++ b/cppForSwig/protobuf_win/protobuf_win.vcxproj
@@ -119,7 +119,7 @@
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>../protobuf/src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <DisableSpecificWarnings>4146;4703;</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4146;4703;4996;</DisableSpecificWarnings>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>


### PR DESCRIPTION
Due to Visual Studio settings, C4996 warnings are treated as errors. Skip the warnings, which are annoying but harmless.