### PR TITLE
Fix GUI/client build issues

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -22,7 +22,32 @@ if BUILD_CLIENT
 endif
 
 copy-script:
+# Creating redistributable binaries is a horror show with Autotools. GCC can use
+# $ORIGIN to make searching for libraries relative via RPATH. libtool refuses to
+# support $ORIGIN. The elder gods punish all who dare question their decision.
+#
+# The "ideal" method is to just dump everything into a standard folder that the
+# system will search (e.g., /usr/local/lib). This isn't always ideal, or even
+# possible. The workaround: Let Automake do its thing and then use an external
+# tool to tell libraries to use RPATH to search local locations.
+# SOURCE 1: https://wiki.debian.org/RpathIssue
+# SOURCE 2: https://www.mikeash.com/pyblog/friday-qa-2009-11-06-linking-and-install-names.html
+# SOURCE 3: https://github.com/conda/conda-build/issues/279
+# SOURCE 4: https://longwei.github.io/rpath_origin/
+if ! BUILD_DARWIN
+	patchelf --set-rpath \$$ORIGIN:\$$ORIGIN/cppForSwig/.libs:\$$ORIGIN/lib:\$$ORIGIN/../lib cppForSwig/ArmoryDB
+	patchelf --set-rpath \$$ORIGIN:\$$ORIGIN/lib:\$$ORIGIN/../lib cppForSwig/.libs/libArmoryCommon.so
+	patchelf --set-rpath \$$ORIGIN:\$$ORIGIN/lib:\$$ORIGIN/../lib cppForSwig/.libs/libArmoryCLI.so
+if BUILD_CLIENT
+	patchelf --set-rpath \$$ORIGIN:\$$ORIGIN/lib:\$$ORIGIN/../lib cppForSwig/.libs/libArmoryGUI.so
+	patchelf --set-rpath \$$ORIGIN:\$$ORIGIN/lib:\$$ORIGIN/../lib cppForSwig/.libs/libCppBlockUtils.so
+endif
+endif
 	cp cppForSwig/ArmoryDB ./ArmoryDB
+
+# Copy libwebsockets instance over to keep components happy.
+	mkdir -p lib
+	cp -R $(LWS_LIB_LOC)/libwebsockets.so* ./lib/
 
 # SWIG code and requirements.
 if BUILD_CLIENT
@@ -58,19 +83,13 @@ endif
 	mkdir -p $(DESTDIR)$(prefix)/bin
 # Sometimes, uninstall-old deletes a valid ArmoryDB. Copy again to be safe.
 	cp ArmoryDB $(DESTDIR)$(prefix)/bin
+	cp -R $(LWS_LIB_LOC)/libwebsockets.so* $(DESTDIR)$(prefix)/lib/
 
-# On macOS, The linker hard-codes the locations of dependent shared libraries
-# linked in libraries and binaries. This means Armory.app won't be portable
-# because, by default, attempts to load the link shared libraries will fail. The
-# workaround: Let Automake do its thing and then use an external tool (installed
-# by Xcode) to tell libraries where to actually find shared libraries they need.
-# In addition, while not necessary, change the shared library IDs so that
-# they're not absolute. (Strangely, some frameworks are also hard-coded inside
-# the shared libraries, but they don't cause problems. Just ignore them.)
-# Finally, delete a redundant instance of libCppBlockUtils.
-# SOURCE 1: https://www.mikeash.com/pyblog/friday-qa-2009-11-06-linking-and-install-names.html
-# SOURCE 2: https://github.com/conda/conda-build/issues/279
-# Alt target name (useful for debugging?): @executable_path/py/usr/local/lib/liblmdb.0.dylib
+# See the earlier comment about Autotools, redistributables, and RPATH. (Linux
+# uses patchelf, Macs use install_name_tool, which is installed by Xcode.) While
+# not strictly necessary, change the Mac's shared library IDs so that they're
+# not absolute. (Strangely, some frameworks are also hard-coded inside the
+# shared libraries, but they don't cause problems. Just ignore them.)
 if BUILD_DARWIN
 	install_name_tool -change $(DESTDIR)$(prefix)/lib/libArmoryCommon.0.dylib @loader_path/../libArmoryCommon.0.dylib $(DESTDIR)$(prefix)/lib/armory/_CppBlockUtils.so
 	install_name_tool -change $(DESTDIR)$(prefix)/lib/libcryptopp.0.dylib @loader_path/libcryptopp.0.dylib $(DESTDIR)$(prefix)/lib/libArmoryCommon.0.dylib
@@ -96,9 +115,7 @@ endif
 
 # No need to install test binaries.
 if BUILD_TESTS
-	rm -f $(DESTDIR)$(prefix)/bin/ContainerTests
-	rm -f $(DESTDIR)$(prefix)/bin/CppBlockUtilsTests
-	rm -f $(DESTDIR)$(prefix)/bin/DB1kIterTest
+	rm -f $(DESTDIR)$(prefix)/bin/*Tests
 endif
 
 # Skip Linux-specific steps on OSX.
@@ -118,6 +135,7 @@ uninstall-hook: uninstall-old
 
 clean-local:
 	rm -f ArmoryDB
+	rm -f lib/*
 	rm -f CppBlockUtils.py
 	rm -f _CppBlockUtils.so
 	rm -f CppBlockUtils.pyc

--- a/configure.ac
+++ b/configure.ac
@@ -68,9 +68,8 @@ else
   CXXFLAGS="$CXXFLAGS -O2"
 fi
 
-# Even if the GUI is disabled, build GUI elements if tests are enabled.
+# For now, the GUI is considered synonymous with the client. This may change.
 AS_IF([test "x$with_gui" = "xyes"], [build_client=yes],
-	[test "x$want_tests" = "xyes"], [build_client=yes],
 	[build_client=no])
 AM_CONDITIONAL([BUILD_CLIENT], [test x$build_client = xyes])
 

--- a/configure.ac
+++ b/configure.ac
@@ -5,10 +5,7 @@ AM_INIT_AUTOMAKE([1.11 subdir-objects foreign -Wall -Werror])
 
 AM_PROG_AR
 
-# Disable shared libraries due to Crypto++ having issues with shared builds
-# pre-6.0. Once Crypto++ is tossed, shared will be fine again.
-LT_INIT([pic-only])
-AC_DISABLE_SHARED
+LT_INIT()
 
 AC_CANONICAL_HOST
 
@@ -52,8 +49,13 @@ AC_ARG_WITH([own-lws],
 AS_IF([test $with_own_lws != no], [],
 	[AC_MSG_ERROR([A custom version of libwebsockets must be defined. /usr/local is an acceptable location.])]) 
 
+# Even if libraries don't directly use LWS, they may rely on libraries that do
+# rely on LWS. This causes the "child" libraries to rely on LWS too! Be sure to
+# use the rpath equivalent in LDFLAGS for all affected libraries, "children" and
+# "parent".
 AC_SUBST([LWS_CFLAGS], ["-I$with_own_lws/include"])
-AC_SUBST([LWS_LDFLAGS], ["-L$with_own_lws/lib"])
+AC_SUBST([LWSLDFLAGS], ["-L$with_own_lws/lib -R $with_own_lws/lib"])
+AC_SUBST([LWS_LIB_LOC], ["$with_own_lws/lib"])
 LIBS="-lwebsockets $LIBS"
 
 # Check for protobuf (protoc in particular is required)
@@ -129,7 +131,8 @@ fi
 
 AC_SUBST([CXX_STANDARD], $CXX_STANDARD)
 
-LDFLAGS="${LDFLAGS} -static"
+# Tinkering with LDFLAGS hopefully won't be needed, but just in case....
+#LDFLAGS="${LDFLAGS} -static"
 
 dnl Determine build OS and do other OS-specific things.
 case $host in

--- a/cppForSwig/Makefile.am
+++ b/cppForSwig/Makefile.am
@@ -47,16 +47,12 @@ INCLUDE_FILES = -Ibech32/ref/c++ -Ilmdb/libraries/liblmdb \
 	-Ilibbtc/include -Ilibbtc/src/secp256k1/include \
 	$(LWS_CFLAGS)
 
-# Files should *not* be marked as "common" if at all possible.
+# Files should *not* be marked as "common" if at all possible. Also, a refactor
+# might not hurt one of these days. Some of the "common" files could be GUI/CLI
+# files but are "common" for the sake of unit testing. In an ideal world, the
+# unit tests would be split into multiple files as needed. One day....
 ARMORYDB_SOURCE_FILES = main.cpp
-ARMORYGUI_SOURCE_FILES = AsyncClient.cpp \
-	CoinSelection.cpp \
-	ClientClasses.cpp \
-	SwigClient.cpp \
-	TransactionBatch.cpp \
-	WalletManager.cpp \
-	Wallets.cpp \
-	WebSocketClient.cpp
+ARMORYGUI_SOURCE_FILES = TransactionBatch.cpp
 ARMORYCLI_SOURCE_FILES = BDM_mainthread.cpp \
 	BDM_Server.cpp \
 	BitcoinP2P.cpp \
@@ -90,10 +86,13 @@ ARMORYCOMMON_SOURCE_FILES = Accounts.cpp \
 	Addresses.cpp \
 	AssetEncryption.cpp \
 	Assets.cpp \
+	AsyncClient.cpp \
 	BinaryData.cpp \
 	BIP32_Node.cpp \
 	BlockDataManagerConfig.cpp \
 	BtcUtils.cpp \
+	ClientClasses.cpp \
+	CoinSelection.cpp \
 	DecryptedDataContainer.cpp \
 	DerivationScheme.cpp \
 	EncryptionUtils.cpp \
@@ -103,14 +102,19 @@ ARMORYCOMMON_SOURCE_FILES = Accounts.cpp \
 	Script.cpp \
 	Signer.cpp \
 	SocketObject.cpp \
+	StoredBlockObj.cpp \
+	SwigClient.cpp \
 	Transactions.cpp \
 	TxClasses.cpp \
 	TxEvalState.cpp \
 	txio.cpp \
 	UniversalTimer.cpp \
+	WalletManager.cpp \
+	Wallets.cpp \
+	WebSocketClient.cpp \
+	WebSocketMessage.cpp \
 	bech32/ref/c++/bech32.cpp \
-	bech32/ref/c++/segwit_addr.cpp \
-	WebSocketMessage.cpp
+	bech32/ref/c++/segwit_addr.cpp
 
 PROTOBUF_PROTO = protobuf/AddressBook.proto \
 	protobuf/AddressData.proto \

--- a/cppForSwig/Makefile.am
+++ b/cppForSwig/Makefile.am
@@ -41,8 +41,6 @@ protobuf/%.pb.cc protobuf/%.pb.h: protobuf/%.proto
 #	@test -f protoc
 	protoc --cpp_out=protobuf --proto_path=protobuf $<
 
-# NOTE: /usr/local/include reflects local installs of libwebsockets. This may
-# be removed later.
 INCLUDE_FILES = -Ibech32/ref/c++ -Ilmdb/libraries/liblmdb \
 	-Ilibbtc/include -Ilibbtc/src/secp256k1/include \
 	$(LWS_CFLAGS)
@@ -143,11 +141,10 @@ PROTOBUF_H = protobuf/AddressBook.pb.h \
 	protobuf/NodeStatus.pb.h \
 	protobuf/Utxo.pb.h
 
+# Protobuf files required for distribution but not installation.
 dist_noinst_DATA = $(PROTOBUF_PROTO)
 
-# libArmoryCommon - Required by all Armory programs/libraries.
-# Includes any files required by the common files.
-
+# LMDB (DB used by Armory)
 lib_LTLIBRARIES += liblmdb.la
 liblmdb_la_SOURCES = lmdb/libraries/liblmdb/lmdbpp.cpp \
 		lmdb/libraries/liblmdb/mdb.c \
@@ -162,9 +159,10 @@ libArmoryCommon_la_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES)
 libArmoryCommon_la_CXXFLAGS = $(AM_CXXFLAGS) -D__STDC_LIMIT_MACROS
 libArmoryCommon_la_LIBADD = liblmdb.la \
 				cryptopp/libcryptopp.la \
-				libbtc/libbtc.la libbtc/src/secp256k1/libsecp256k1.la \
+				libbtc/libbtc.la \
+				libbtc/src/secp256k1/libsecp256k1.la \
 				-lpthread -lprotobuf
-libArmoryCommon_la_LDFLAGS = $(LDFLAGS) $(PROTOBUF_FLAGS)
+libArmoryCommon_la_LDFLAGS = $(LDFLAGS) $(LWSLDFLAGS) $(PROTOBUF_FLAGS)
 
 # Command-line functionality library
 lib_LTLIBRARIES += libArmoryCLI.la
@@ -174,18 +172,22 @@ libArmoryCLI_la_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES) \
 libArmoryCLI_la_CXXFLAGS = $(AM_CXXFLAGS) -Ilmdb/libraries/liblmdb -D__STDC_LIMIT_MACROS
 libArmoryCLI_la_LIBADD = $(LIBBTC) \
 			 libArmoryCommon.la \
+			 cryptopp/libcryptopp.la \
+			 libbtc/libbtc.la \
 			 -lpthread
-libArmoryCLI_la_LDFLAGS = $(LDFLAGS) $(LWS_LDFLAGS)
+libArmoryCLI_la_LDFLAGS = $(LDFLAGS) $(LWSLDFLAGS)
 
-#ArmoryDB
+# ArmoryDB binary
 bin_PROGRAMS += ArmoryDB
 ArmoryDB_SOURCES = $(ARMORYDB_SOURCE_FILES)
 ArmoryDB_CXXFLAGS = $(AM_CXXFLAGS) -D__STDC_LIMIT_MACROS
 ArmoryDB_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES)
 ArmoryDB_LDADD = libArmoryCommon.la \
 		 libArmoryCLI.la \
-		 -lpthread -lprotobuf
-ArmoryDB_LDFLAGS = -static $(LWS_LDFLAGS) $(LDFLAGS)
+		 cryptopp/libcryptopp.la \
+		 libbtc/libbtc.la \
+		 -lpthread -lprotobuf -lwebsockets
+ArmoryDB_LDFLAGS = $(LWSLDFLAGS) $(LDFLAGS) -static
 
 if BUILD_CLIENT
 # Common GUI functionality library
@@ -196,7 +198,7 @@ libArmoryGUI_la_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES) \
 libArmoryGUI_la_CXXFLAGS = $(AM_CXXFLAGS) -D__STDC_LIMIT_MACROS
 libArmoryGUI_la_LIBADD = libArmoryCommon.la cryptopp/libcryptopp.la \
 			-lpthread
-libArmoryGUI_la_LDFLAGS = $(LDFLAGS) $(PYTHON_LDFLAGS)
+libArmoryGUI_la_LDFLAGS = $(LDFLAGS) $(LWSLDFLAGS) $(PYTHON_LDFLAGS) -shared
 
 #libCppBlockUtils - SWIG library.
 # "shared" LDFLAG due to SWIG requirements.
@@ -208,7 +210,7 @@ libCppBlockUtils_la_CXXFLAGS = $(AM_CXXFLAGS) -Ilmdb/libraries/liblmdb \
 				-D__STDC_LIMIT_MACROS
 libCppBlockUtils_la_LIBADD = libArmoryCommon.la libArmoryGUI.la \
 				cryptopp/libcryptopp.la -lpthread
-libCppBlockUtils_la_LDFLAGS = $(LDFLAGS) $(PYTHON_LDFLAGS) -shared
+libCppBlockUtils_la_LDFLAGS = $(LDFLAGS) $(LWSLDFLAGS) $(PYTHON_LDFLAGS) -shared
 
 #custom rules
 CppBlockUtils_wrap.cxx: CppBlockUtils.i

--- a/cppForSwig/Makefile.tests.include
+++ b/cppForSwig/Makefile.tests.include
@@ -10,7 +10,7 @@ lib_LTLIBRARIES += gtest/libgtest.la
 gtest_libgtest_la_CXXFLAGS = $(AM_CXXFLAGS)
 gtest_libgtest_la_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES)
 gtest_libgtest_la_SOURCES = gtest/TestUtils.cpp gtest/gtest-all.cc
-gtest_libgtest_la_LIBADD = libArmoryCommon.la libArmoryCLI.la libArmoryGUI.la
+gtest_libgtest_la_LIBADD = libArmoryCommon.la libArmoryCLI.la
 gtest_libgtest_la_LDFLAGS = $(AM_LDFLAGS) $(LDFLAGS) -shared
 
 # ContainerTests
@@ -40,7 +40,7 @@ gtest_SupernodeTests_LDADD = gtest/libgtest.la
 gtest_SupernodeTests_LDFLAGS = $(AM_LDFLAGS) $(LDFLAGS) -static
 TESTS += gtest/SupernodeTests
 
-# CppBlockUtilsTests - Contains the bulk of the tests (CLI or GUI)
+# CppBlockUtilsTests - Contains the bulk of the tests
 bin_PROGRAMS += gtest/CppBlockUtilsTests
 gtest_CppBlockUtilsTests_SOURCES = gtest/CppBlockUtilsTests.cpp
 gtest_CppBlockUtilsTests_CXXFLAGS = $(AM_CXXFLAGS)

--- a/cppForSwig/Makefile.tests.include
+++ b/cppForSwig/Makefile.tests.include
@@ -79,6 +79,6 @@ gtest_WalletTests_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES) -DUNIT_TESTS
 gtest_WalletTests_LDADD = gtest/libgtest.la libbtc/libbtc.la libArmoryCommon.la \
 		 libArmoryCLI.la \
 		 cryptopp/libcryptopp.la \
-		 libbtc/libbtc.la -lprotobuf
+		 libbtc/libbtc.la  liblmdb.la -lprotobuf
 gtest_WalletTests_LDFLAGS = $(AM_LDFLAGS) $(LWSLDFLAGS) $(LDFLAGS) -static
 TESTS += gtest/WalletTests

--- a/cppForSwig/Makefile.tests.include
+++ b/cppForSwig/Makefile.tests.include
@@ -1,6 +1,14 @@
 # Makefile .include for Bitcoin Armory - Armory tests
 
-# "#include <tr1/tuple>" causes a build error on OSX without this flag.
+# Here are some general notes to explain various code design issues.
+#
+# - For whatever reasons, user variables with underscores (e.g., LWS_LDFLAGS)
+#   leads to complaints about GNU extensions. Use variables without underscores.
+# - A lot of the libraries in LDADD/LIBADD aren't actually required by the
+#   binaries. They're required by the linked libraries. Be sure to include them
+#   in any new binaries.
+
+# "#include <tr1/tuple>" causes a build error on macOS without this flag.
 if BUILD_DARWIN
 AM_CXXFLAGS += -DGTEST_USE_OWN_TR1_TUPLE=1
 endif
@@ -10,16 +18,21 @@ lib_LTLIBRARIES += gtest/libgtest.la
 gtest_libgtest_la_CXXFLAGS = $(AM_CXXFLAGS)
 gtest_libgtest_la_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES)
 gtest_libgtest_la_SOURCES = gtest/TestUtils.cpp gtest/gtest-all.cc
-gtest_libgtest_la_LIBADD = libArmoryCommon.la libArmoryCLI.la
-gtest_libgtest_la_LDFLAGS = $(AM_LDFLAGS) $(LDFLAGS) -shared
+gtest_libgtest_la_LIBADD = libArmoryCommon.la libArmoryCLI.la \
+				cryptopp/libcryptopp.la \
+				libbtc/libbtc.la
+gtest_libgtest_la_LDFLAGS = $(AM_LDFLAGS) $(LWSLDFLAGS) $(LDFLAGS)
 
 # ContainerTests
 bin_PROGRAMS += gtest/ContainerTests
 gtest_ContainerTests_SOURCES = gtest/ContainerTests.cpp
 gtest_ContainerTests_CXXFLAGS = $(AM_CXXFLAGS)
 gtest_ContainerTests_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES)
-gtest_ContainerTests_LDADD = gtest/libgtest.la
-gtest_ContainerTests_LDFLAGS = $(AM_LDFLAGS) $(LDFLAGS) -static
+gtest_ContainerTests_LDADD = gtest/libgtest.la libArmoryCommon.la \
+		 libArmoryCLI.la \
+		 cryptopp/libcryptopp.la \
+		 libbtc/libbtc.la -lprotobuf
+gtest_ContainerTests_LDFLAGS = $(AM_LDFLAGS) $(LWSLDFLAGS) $(LDFLAGS) -static
 TESTS += gtest/ContainerTests
 
 # DB1kIterTest
@@ -27,8 +40,11 @@ bin_PROGRAMS += gtest/DB1kIterTest
 gtest_DB1kIterTest_SOURCES = gtest/DB1kIterTest.cpp
 gtest_DB1kIterTest_CXXFLAGS = $(AM_CXXFLAGS)
 gtest_DB1kIterTest_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES)
-gtest_DB1kIterTest_LDADD = gtest/libgtest.la
-gtest_DB1kIterTest_LDFLAGS = $(AM_LDFLAGS) $(LDFLAGS) -static
+gtest_DB1kIterTest_LDADD = gtest/libgtest.la libArmoryCommon.la \
+		 libArmoryCLI.la \
+		 cryptopp/libcryptopp.la \
+		 libbtc/libbtc.la -lprotobuf
+gtest_DB1kIterTest_LDFLAGS = $(AM_LDFLAGS) $(LWSLDFLAGS) $(LDFLAGS) -static
 TESTS += gtest/DB1kIterTest
 
 # SupernodeTests
@@ -36,8 +52,11 @@ bin_PROGRAMS += gtest/SupernodeTests
 gtest_SupernodeTests_SOURCES = gtest/SupernodeTests.cpp
 gtest_SupernodeTests_CXXFLAGS = $(AM_CXXFLAGS)
 gtest_SupernodeTests_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES) -DUNIT_TESTS
-gtest_SupernodeTests_LDADD = gtest/libgtest.la
-gtest_SupernodeTests_LDFLAGS = $(AM_LDFLAGS) $(LDFLAGS) -static
+gtest_SupernodeTests_LDADD = gtest/libgtest.la libArmoryCommon.la \
+		 libArmoryCLI.la \
+		 cryptopp/libcryptopp.la \
+		 libbtc/libbtc.la -lprotobuf
+gtest_SupernodeTests_LDFLAGS = $(AM_LDFLAGS) $(LWSLDFLAGS) $(LDFLAGS) -static
 TESTS += gtest/SupernodeTests
 
 # CppBlockUtilsTests - Contains the bulk of the tests
@@ -45,8 +64,11 @@ bin_PROGRAMS += gtest/CppBlockUtilsTests
 gtest_CppBlockUtilsTests_SOURCES = gtest/CppBlockUtilsTests.cpp
 gtest_CppBlockUtilsTests_CXXFLAGS = $(AM_CXXFLAGS)
 gtest_CppBlockUtilsTests_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES)
-gtest_CppBlockUtilsTests_LDADD = gtest/libgtest.la
-gtest_CppBlockUtilsTests_LDFLAGS = $(AM_LDFLAGS) $(LDFLAGS) -static
+gtest_CppBlockUtilsTests_LDADD = gtest/libgtest.la libArmoryCommon.la \
+		 libArmoryCLI.la \
+		 cryptopp/libcryptopp.la \
+		 libbtc/libbtc.la liblmdb.la -lprotobuf
+gtest_CppBlockUtilsTests_LDFLAGS = $(AM_LDFLAGS) $(LWSLDFLAGS) $(LDFLAGS) -static
 TESTS += gtest/CppBlockUtilsTests
 
 # WalletTests
@@ -54,6 +76,9 @@ bin_PROGRAMS += gtest/WalletTests
 gtest_WalletTests_SOURCES = gtest/WalletTests.cpp
 gtest_WalletTests_CXXFLAGS = $(AM_CXXFLAGS)
 gtest_WalletTests_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES) -DUNIT_TESTS
-gtest_WalletTests_LDADD = gtest/libgtest.la libbtc/libbtc.la
-gtest_WalletTests_LDFLAGS = $(AM_LDFLAGS) $(LDFLAGS) -static
+gtest_WalletTests_LDADD = gtest/libgtest.la libbtc/libbtc.la libArmoryCommon.la \
+		 libArmoryCLI.la \
+		 cryptopp/libcryptopp.la \
+		 libbtc/libbtc.la -lprotobuf
+gtest_WalletTests_LDFLAGS = $(AM_LDFLAGS) $(LWSLDFLAGS) $(LDFLAGS) -static
 TESTS += gtest/WalletTests


### PR DESCRIPTION
When disabling the GUI but enabling tests, the code still builds the GUI-specific library. Rearrange files to fully decouple the GUI-specific library from the unit tests.

Note that this might warrant a full refactor one day. As things stand, a lot of code could be in the GUI-specific or CLI-specific libraries, but must go into a common library for the sake of unit testing. This isn't optimal. But, it works for now.