### PR TITLE
Update regtest RPC port

### DIFF
--- a/cppForSwig/bdmenums.h
+++ b/cppForSwig/bdmenums.h
@@ -24,6 +24,7 @@
 
 #define RPC_PORT_MAINNET 8332
 #define RPC_PORT_TESTNET 18332
+#define RPC_PORT_REGTEST 18443
 
 enum BDMPhase
 {


### PR DESCRIPTION
As of Core 0.16, the regtest RPC port is 18443. Add it.