### PR TITLE
Autotools changes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -47,7 +47,11 @@ endif
 
 # Copy libwebsockets instance over to keep components happy.
 	mkdir -p lib
+if BUILD_DARWIN
+	cp -L $(LWS_LIB_LOC)/libwebsockets.dylib ./lib/
+else
 	cp -R $(LWS_LIB_LOC)/libwebsockets.so* ./lib/
+endif
 
 # SWIG code and requirements.
 if BUILD_CLIENT
@@ -92,24 +96,28 @@ endif
 # shared libraries, but they don't cause problems. Just ignore them.)
 if BUILD_DARWIN
 	install_name_tool -change $(DESTDIR)$(prefix)/lib/libArmoryCommon.0.dylib @loader_path/../libArmoryCommon.0.dylib $(DESTDIR)$(prefix)/lib/armory/_CppBlockUtils.so
-	install_name_tool -change $(DESTDIR)$(prefix)/lib/libcryptopp.0.dylib @loader_path/libcryptopp.0.dylib $(DESTDIR)$(prefix)/lib/libArmoryCommon.0.dylib
-	install_name_tool -change $(DESTDIR)$(prefix)/lib/libcryptopp.0.dylib @loader_path/libcryptopp.0.dylib $(DESTDIR)$(prefix)/lib/libArmoryCLI.0.dylib
 	install_name_tool -change $(DESTDIR)$(prefix)/lib/libArmoryCommon.0.dylib @loader_path/libArmoryCommon.0.dylib $(DESTDIR)$(prefix)/lib/libArmoryCLI.0.dylib
 	install_name_tool -id @rpath/libCppBlockUtils.0.dylib $(DESTDIR)$(prefix)/lib/armory/_CppBlockUtils.so
 	install_name_tool -id @rpath/libfcgi.0.dylib $(DESTDIR)$(prefix)/lib/libfcgi.0.dylib
 	install_name_tool -id @rpath/libArmoryCommon.0.dylib $(DESTDIR)$(prefix)/lib/libArmoryCommon.0.dylib
 	install_name_tool -id @rpath/libArmoryCLI.0.dylib $(DESTDIR)$(prefix)/lib/libArmoryCLI.0.dylib
 	install_name_tool -id @rpath/libArmoryGUI.0.dylib $(DESTDIR)$(prefix)/lib/libArmoryGUI.0.dylib
-	install_name_tool -id @rpath/libcryptopp.0.dylib $(DESTDIR)$(prefix)/lib/libcryptopp.0.dylib
 	install_name_tool -change $(DESTDIR)$(prefix)/lib/libArmoryCommon.0.dylib @loader_path/../lib/libArmoryCommon.0.dylib $(DESTDIR)$(prefix)/bin/ArmoryDB
 	install_name_tool -change $(DESTDIR)$(prefix)/lib/libArmoryCLI.0.dylib @loader_path/../lib/libArmoryCLI.0.dylib $(DESTDIR)$(prefix)/bin/ArmoryDB
+if USE_CRYPTOPP
+	install_name_tool -change $(DESTDIR)$(prefix)/lib/libcryptopp.0.dylib @loader_path/libcryptopp.0.dylib $(DESTDIR)$(prefix)/lib/libArmoryCommon.0.dylib
+	install_name_tool -change $(DESTDIR)$(prefix)/lib/libcryptopp.0.dylib @loader_path/libcryptopp.0.dylib $(DESTDIR)$(prefix)/lib/libArmoryCLI.0.dylib
+	install_name_tool -id @rpath/libcryptopp.0.dylib $(DESTDIR)$(prefix)/lib/libcryptopp.0.dylib
 	install_name_tool -change $(DESTDIR)$(prefix)/lib/libcryptopp.0.dylib @loader_path/../lib/libcryptopp.0.dylib $(DESTDIR)$(prefix)/bin/ArmoryDB
+endif
 if BUILD_CLIENT
 	rm -f $(DESTDIR)$(prefix)/lib/libCppBlockUtils.*
 	install_name_tool -change $(DESTDIR)$(prefix)/lib/libArmoryGUI.0.dylib @loader_path/../libArmoryGUI.0.dylib $(DESTDIR)$(prefix)/lib/armory/_CppBlockUtils.so
 	install_name_tool -change $(DESTDIR)$(prefix)/lib/libArmoryCommon.0.dylib @loader_path/libArmoryCommon.0.dylib $(DESTDIR)$(prefix)/lib/libArmoryGUI.0.dylib
+if USE_CRYPTOPP
 	install_name_tool -change $(DESTDIR)$(prefix)/lib/libcryptopp.0.dylib @loader_path/libcryptopp.0.dylib $(DESTDIR)$(prefix)/lib/libArmoryGUI.0.dylib
 	install_name_tool -change $(DESTDIR)$(prefix)/lib/libcryptopp.0.dylib @loader_path/../libcryptopp.0.dylib $(DESTDIR)$(prefix)/lib/armory/_CppBlockUtils.so
+endif
 endif
 endif
 

--- a/configure.ac
+++ b/configure.ac
@@ -45,6 +45,13 @@ AC_ARG_WITH([own-lws],
 		[pass path of your own lws binary and headers @<:@default=no@:>@]),
 		[with_own_lws="$withval"], [with_own_lws=no])
 
+# Crypto++ usage. Armory defaults to using libbtc for most crypto. However, a
+# legacy transition period where Crypto++ can be used instead is in effect.
+AC_ARG_WITH([cryptopp],
+		AS_HELP_STRING([--with-cryptopp],
+		[use Crypto++ instead of libbtc for crypto functions @<:@default=no@:>@]),
+		[with_cryptopp="$withval"], [with_cryptopp=no])
+
 # Force user to define which LWS they wish to use.
 AS_IF([test $with_own_lws != no], [],
 	[AC_MSG_ERROR([A custom version of libwebsockets must be defined. /usr/local is an acceptable location.])]) 
@@ -223,6 +230,7 @@ AC_CONFIG_FILES(Makefile
 
 AM_CONDITIONAL([BUILD_BENCH], [test x$want_benchmark = xyes])
 AM_CONDITIONAL([BUILD_TESTS], [test "x$want_tests" = "xyes"])
+AM_CONDITIONAL([USE_CRYPTOPP], [test x$with_cryptopp = xyes])
 
 dnl ac_configure_args can only be set once and affects all subdirs.
 dnl Place all params here.
@@ -232,7 +240,8 @@ dnl libbtc - --disable-wallet --disable-tools
 dnl libsecp256k1 (libbtc) - --disable-shared --with-pic --with-bignum=no
 dnl NB: --disable-wallet left off for now. Upstream issues kill debug builds.
 ac_configure_args="${orig_config_args} --disable-tools --disable-shared --with-pic --with-bignum=no"
-AC_CONFIG_SUBDIRS([cppForSwig/cryptopp cppForSwig/libbtc])
+AC_CONFIG_SUBDIRS([cppForSwig/libbtc])
+AM_COND_IF([USE_CRYPTOPP], [AC_CONFIG_SUBDIRS([cppForSwig/cryptopp])], [])
 
 AC_OUTPUT
 
@@ -252,3 +261,4 @@ echo "  with benchmarks = $want_benchmark"
 echo "  debug symbols   = $want_debug"
 echo "  with GUI/client = $build_client"
 echo "  custom lws path = $with_own_lws"
+echo "  use Crypto++    = $with_cryptopp"

--- a/cppForSwig/Makefile.am
+++ b/cppForSwig/Makefile.am
@@ -6,9 +6,28 @@ TESTS =
 BENCH =
 
 LIBBTC = libbtc/libbtc.la
+LIBCHACHA20POLY1305 = chacha20poly1305/.libs/libchacha20poly1305.la
+LIBCPPBLOCKUTILS = libCppBlockUtils.la
+LIBARMORYCOMMON = libArmoryCommon.la
+LIBARMORYGUI = libArmoryGUI.la
+LIBARMORYCLI = libArmoryCLI.la
+LIBCRYPTOPP =
+LIBLMDB = liblmdb.la
+LIBSECP256K1 = libbtc/src/secp256k1/libsecp256k1.la
 
-DIST_SUBDIRS = cryptopp libbtc
-SUBDIRS = cryptopp libbtc $(MAYBE_BUILD)
+DIST_SUBDIRS = libbtc
+SUBDIRS = libbtc $(MAYBE_BUILD)
+
+# Flag used to determine if the code will *only* use libbtc, and not Crypto++.
+LIBBTC_FLAGS =
+
+if USE_CRYPTOPP
+DIST_SUBDIRS += cryptopp
+SUBDIRS += cryptopp
+LIBCRYPTOPP += cryptopp/libcryptopp.la
+else
+LIBBTC_FLAGS += -DLIBBTC_ONLY
+endif
 
 SWIG_FLAGS = -c++ -python -threads
 AM_CXXFLAGS =
@@ -94,7 +113,6 @@ ARMORYCOMMON_SOURCE_FILES = Accounts.cpp \
 	DecryptedDataContainer.cpp \
 	DerivationScheme.cpp \
 	EncryptionUtils.cpp \
-	EncryptionUtils_libbtc.cpp \
 	KDF.cpp \
 	NetworkConfig.cpp \
 	log.cpp \
@@ -116,6 +134,10 @@ ARMORYCOMMON_SOURCE_FILES = Accounts.cpp \
 	WebSocketMessage.cpp \
 	bech32/ref/c++/bech32.cpp \
 	bech32/ref/c++/segwit_addr.cpp
+
+if ! USE_CRYPTOPP
+ARMORYCOMMON_SOURCE_FILES += EncryptionUtils_libbtc.cpp
+endif
 
 PROTOBUF_PROTO = protobuf/AddressBook.proto \
 	protobuf/AddressData.proto \
@@ -148,71 +170,73 @@ PROTOBUF_H = protobuf/AddressBook.pb.h \
 dist_noinst_DATA = $(PROTOBUF_PROTO)
 
 # LMDB (DB used by Armory)
-lib_LTLIBRARIES += liblmdb.la
+lib_LTLIBRARIES += $(LIBLMDB)
 liblmdb_la_SOURCES = lmdb/libraries/liblmdb/lmdbpp.cpp \
 		lmdb/libraries/liblmdb/mdb.c \
 		lmdb/libraries/liblmdb/midl.c
 liblmdb_la_CPPFLAGS = -Ilmdb/libraries/liblmdb -fPIC
 
 # Common functionality across GUI and command line
-lib_LTLIBRARIES += libArmoryCommon.la
+lib_LTLIBRARIES += $(LIBARMORYCOMMON)
 libArmoryCommon_la_SOURCES = $(ARMORYCOMMON_SOURCE_FILES)
 nodist_libArmoryCommon_la_SOURCES = $(PROTOBUF_CC) $(PROTOBUF_H)
 libArmoryCommon_la_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES)
-libArmoryCommon_la_CXXFLAGS = $(AM_CXXFLAGS) -D__STDC_LIMIT_MACROS
-libArmoryCommon_la_LIBADD = liblmdb.la \
-				cryptopp/libcryptopp.la \
-				libbtc/libbtc.la \
-				libbtc/src/secp256k1/libsecp256k1.la \
+libArmoryCommon_la_CXXFLAGS = $(AM_CXXFLAGS) $(LIBBTC_FLAGS) \
+			      -D__STDC_LIMIT_MACROS
+libArmoryCommon_la_LIBADD = $(LIBLMDB) \
+				$(LIBCRYPTOPP) \
+				$(LIBBTC) \
+				$(LIBSECP256K1) \
 				-lpthread -lprotobuf
 libArmoryCommon_la_LDFLAGS = $(LDFLAGS) $(LWSLDFLAGS) $(PROTOBUF_FLAGS)
 
 # Command-line functionality library
-lib_LTLIBRARIES += libArmoryCLI.la
+lib_LTLIBRARIES += $(LIBARMORYCLI)
 libArmoryCLI_la_SOURCES = $(ARMORYCLI_SOURCE_FILES)
 libArmoryCLI_la_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES) \
 			$(PYTHON_CFLAGS)
-libArmoryCLI_la_CXXFLAGS = $(AM_CXXFLAGS) -Ilmdb/libraries/liblmdb -D__STDC_LIMIT_MACROS
+libArmoryCLI_la_CXXFLAGS = $(AM_CXXFLAGS) $(LIBBTC_FLAGS) \
+			   -Ilmdb/libraries/liblmdb -D__STDC_LIMIT_MACROS
 libArmoryCLI_la_LIBADD = $(LIBBTC) \
-			 libArmoryCommon.la \
-			 cryptopp/libcryptopp.la \
-			 libbtc/libbtc.la \
+			 $(LIBARMORYCOMMON) \
+			 $(LIBCRYPTOPP) \
+			 $(LIBBTC) \
 			 -lpthread
 libArmoryCLI_la_LDFLAGS = $(LDFLAGS) $(LWSLDFLAGS)
 
 # ArmoryDB binary
 bin_PROGRAMS += ArmoryDB
 ArmoryDB_SOURCES = $(ARMORYDB_SOURCE_FILES)
-ArmoryDB_CXXFLAGS = $(AM_CXXFLAGS) -D__STDC_LIMIT_MACROS
+ArmoryDB_CXXFLAGS = $(AM_CXXFLAGS) $(LIBBTC_FLAGS) -D__STDC_LIMIT_MACROS
 ArmoryDB_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES)
-ArmoryDB_LDADD = libArmoryCommon.la \
-		 libArmoryCLI.la \
-		 cryptopp/libcryptopp.la \
-		 libbtc/libbtc.la \
+ArmoryDB_LDADD = $(LIBARMORYCOMMON) \
+		 $(LIBARMORYCLI) \
+		 $(LIBCRYPTOPP) \
+		 $(LIBBTC) \
 		 -lpthread -lprotobuf -lwebsockets
 ArmoryDB_LDFLAGS = $(LWSLDFLAGS) $(LDFLAGS) -static
 
 if BUILD_CLIENT
 # Common GUI functionality library
-lib_LTLIBRARIES += libArmoryGUI.la
+lib_LTLIBRARIES += $(LIBARMORYGUI)
 libArmoryGUI_la_SOURCES = $(ARMORYGUI_SOURCE_FILES)
 libArmoryGUI_la_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES) \
 			$(PYTHON_CFLAGS)
 libArmoryGUI_la_CXXFLAGS = $(AM_CXXFLAGS) -D__STDC_LIMIT_MACROS
-libArmoryGUI_la_LIBADD = libArmoryCommon.la cryptopp/libcryptopp.la \
+libArmoryGUI_la_LIBADD = $(LIBARMORYCOMMON) $(LIBCRYPTOPP) \
 			-lpthread
 libArmoryGUI_la_LDFLAGS = $(LDFLAGS) $(LWSLDFLAGS) $(PYTHON_LDFLAGS) -shared
 
 #libCppBlockUtils - SWIG library.
 # "shared" LDFLAG due to SWIG requirements.
-lib_LTLIBRARIES += libCppBlockUtils.la
+lib_LTLIBRARIES += $(LIBCPPBLOCKUTILS)
 libCppBlockUtils_la_SOURCES = CppBlockUtils_wrap.cxx
 libCppBlockUtils_la_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES) \
 				$(PYTHON_CFLAGS)
 libCppBlockUtils_la_CXXFLAGS = $(AM_CXXFLAGS) -Ilmdb/libraries/liblmdb \
 				-D__STDC_LIMIT_MACROS
-libCppBlockUtils_la_LIBADD = libArmoryCommon.la libArmoryGUI.la \
-				cryptopp/libcryptopp.la -lpthread
+libCppBlockUtils_la_LIBADD = $(LIBARMORYCOMMON) $(LIBARMORYGUI) \
+				$(LIBCRYPTOPP) -lpthread
 libCppBlockUtils_la_LDFLAGS = $(LDFLAGS) $(LWSLDFLAGS) $(PYTHON_LDFLAGS) -shared
 
 #custom rules

--- a/cppForSwig/Makefile.tests.include
+++ b/cppForSwig/Makefile.tests.include
@@ -15,70 +15,70 @@ endif
 
 # Standard gtest library
 lib_LTLIBRARIES += gtest/libgtest.la
-gtest_libgtest_la_CXXFLAGS = $(AM_CXXFLAGS)
+gtest_libgtest_la_CXXFLAGS = $(AM_CXXFLAGS) $(LIBBTC_FLAGS)
 gtest_libgtest_la_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES)
 gtest_libgtest_la_SOURCES = gtest/TestUtils.cpp gtest/gtest-all.cc
-gtest_libgtest_la_LIBADD = libArmoryCommon.la libArmoryCLI.la \
-				cryptopp/libcryptopp.la \
-				libbtc/libbtc.la
+gtest_libgtest_la_LIBADD = $(LIBARMORYCOMMON) $(LIBARMORYCLI) \
+				$(LIBCRYPTOPP) \
+				$(LIBBTC)
 gtest_libgtest_la_LDFLAGS = $(AM_LDFLAGS) $(LWSLDFLAGS) $(LDFLAGS)
 
 # ContainerTests
 bin_PROGRAMS += gtest/ContainerTests
 gtest_ContainerTests_SOURCES = gtest/ContainerTests.cpp
-gtest_ContainerTests_CXXFLAGS = $(AM_CXXFLAGS)
+gtest_ContainerTests_CXXFLAGS = $(AM_CXXFLAGS) $(LIBBTC_FLAGS)
 gtest_ContainerTests_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES)
-gtest_ContainerTests_LDADD = gtest/libgtest.la libArmoryCommon.la \
-		 libArmoryCLI.la \
-		 cryptopp/libcryptopp.la \
-		 libbtc/libbtc.la -lprotobuf
+gtest_ContainerTests_LDADD = gtest/libgtest.la $(LIBARMORYCOMMON) \
+		 $(LIBARMORYCLI) \
+		 $(LIBCRYPTOPP) \
+		 $(LIBBTC) -lprotobuf
 gtest_ContainerTests_LDFLAGS = $(AM_LDFLAGS) $(LWSLDFLAGS) $(LDFLAGS) -static
 TESTS += gtest/ContainerTests
 
 # DB1kIterTest
 bin_PROGRAMS += gtest/DB1kIterTest
 gtest_DB1kIterTest_SOURCES = gtest/DB1kIterTest.cpp
-gtest_DB1kIterTest_CXXFLAGS = $(AM_CXXFLAGS)
+gtest_DB1kIterTest_CXXFLAGS = $(AM_CXXFLAGS) $(LIBBTC_FLAGS)
 gtest_DB1kIterTest_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES)
-gtest_DB1kIterTest_LDADD = gtest/libgtest.la libArmoryCommon.la \
-		 libArmoryCLI.la \
-		 cryptopp/libcryptopp.la \
-		 libbtc/libbtc.la -lprotobuf
+gtest_DB1kIterTest_LDADD = gtest/libgtest.la $(LIBARMORYCOMMON) \
+		 $(LIBARMORYCLI) \
+		 $(LIBCRYPTOPP) \
+		 $(LIBBTC) -lprotobuf
 gtest_DB1kIterTest_LDFLAGS = $(AM_LDFLAGS) $(LWSLDFLAGS) $(LDFLAGS) -static
 TESTS += gtest/DB1kIterTest
 
 # SupernodeTests
 bin_PROGRAMS += gtest/SupernodeTests
 gtest_SupernodeTests_SOURCES = gtest/SupernodeTests.cpp
-gtest_SupernodeTests_CXXFLAGS = $(AM_CXXFLAGS)
+gtest_SupernodeTests_CXXFLAGS = $(AM_CXXFLAGS) $(LIBBTC_FLAGS)
 gtest_SupernodeTests_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES) -DUNIT_TESTS
-gtest_SupernodeTests_LDADD = gtest/libgtest.la libArmoryCommon.la \
-		 libArmoryCLI.la \
-		 cryptopp/libcryptopp.la \
-		 libbtc/libbtc.la -lprotobuf
+gtest_SupernodeTests_LDADD = gtest/libgtest.la $(LIBARMORYCOMMON) \
+		 $(LIBARMORYCLI) \
+		 $(LIBCRYPTOPP) \
+		 $(LIBBTC) -lprotobuf
 gtest_SupernodeTests_LDFLAGS = $(AM_LDFLAGS) $(LWSLDFLAGS) $(LDFLAGS) -static
 TESTS += gtest/SupernodeTests
 
 # CppBlockUtilsTests - Contains the bulk of the tests
 bin_PROGRAMS += gtest/CppBlockUtilsTests
 gtest_CppBlockUtilsTests_SOURCES = gtest/CppBlockUtilsTests.cpp
-gtest_CppBlockUtilsTests_CXXFLAGS = $(AM_CXXFLAGS)
+gtest_CppBlockUtilsTests_CXXFLAGS = $(AM_CXXFLAGS) $(LIBBTC_FLAGS)
 gtest_CppBlockUtilsTests_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES)
-gtest_CppBlockUtilsTests_LDADD = gtest/libgtest.la libArmoryCommon.la \
-		 libArmoryCLI.la \
-		 cryptopp/libcryptopp.la \
-		 libbtc/libbtc.la liblmdb.la -lprotobuf
+gtest_CppBlockUtilsTests_LDADD = gtest/libgtest.la $(LIBARMORYCOMMON) \
+		 $(LIBARMORYCLI) \
+		 $(LIBCRYPTOPP) \
+		 $(LIBBTC) $(LIBLMDB) -lprotobuf
 gtest_CppBlockUtilsTests_LDFLAGS = $(AM_LDFLAGS) $(LWSLDFLAGS) $(LDFLAGS) -static
 TESTS += gtest/CppBlockUtilsTests
 
 # WalletTests
 bin_PROGRAMS += gtest/WalletTests
 gtest_WalletTests_SOURCES = gtest/WalletTests.cpp
-gtest_WalletTests_CXXFLAGS = $(AM_CXXFLAGS)
+gtest_WalletTests_CXXFLAGS = $(AM_CXXFLAGS) $(LIBBTC_FLAGS)
 gtest_WalletTests_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES) -DUNIT_TESTS
-gtest_WalletTests_LDADD = gtest/libgtest.la libbtc/libbtc.la libArmoryCommon.la \
-		 libArmoryCLI.la \
-		 cryptopp/libcryptopp.la \
-		 libbtc/libbtc.la  liblmdb.la -lprotobuf
+gtest_WalletTests_LDADD = gtest/libgtest.la $(LIBBTC) $(LIBARMORYCOMMON) \
+		 $(LIBARMORYCLI) \
+		 $(LIBCRYPTOPP) \
+		 $(LIBBTC)  $(LIBLMDB) -lprotobuf
 gtest_WalletTests_LDFLAGS = $(AM_LDFLAGS) $(LWSLDFLAGS) $(LDFLAGS) -static
 TESTS += gtest/WalletTests


### PR DESCRIPTION
- For crypto functionality, disable Crypto++ by default. (No more bombardment of the command line with compiler warnings!) "--with-cryptopp" can be used when configuring to enable Crypto++ (i.e., stick with old functionality). This is meant only for a transition period, and only for people afraid of "new" code (i.e., basically what Bitcoin Core uses). It will be removed eventually (v0.98?).
- Make Automake files a bit easier to read, and a little more modular. Will make BIP 150/151 code integration a little easier.

There seems to be some sort of recursion bug when the Crypto++ version is built. All the code compiles, the tests pass, etc. The make system just decides to attempt to reconfigure everything. This doesn't affect the default setup. A future commit will deal with this bug.