### PR TITLE
libbtc fix

### DIFF
--- a/cppForSwig/libbtc/src/random.c
+++ b/cppForSwig/libbtc/src/random.c
@@ -26,7 +26,7 @@
 
 #include <btc/random.h>
 
-#ifndef _MSC_VER
+#ifdef HAVE_CONFIG_H
 #include "libbtc-config.h"
 #endif
 


### PR DESCRIPTION
In certain instances, build systems can make bad assumptions about a libbtc-config.h being present. Fix the assumption.