### PR TITLE
Remove .gitmodules file

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "cppForSwig/fcgi"]
-	path = cppForSwig/fcgi
-	url = https://github.com/goatpig/libfcgi.git


### PR DESCRIPTION
Armory no longer has any Git submodules. Remove .gitmodules file.