### PR TITLE
Minor fix for non-client (ArmoryDB-only) builds

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -11,13 +11,13 @@ EXTRA_DIST = *.py *.md LICENSE LICENSE-ATI LICENSE-MIT \
 
 ACLOCAL_AMFLAGS = -I build-aux/m4
 
-lrelease:
 if BUILD_CLIENT
+lrelease:
 	lrelease lang/*.ts
 endif
 
-qrc_img_resources.py: imgList.xml
 if BUILD_CLIENT
+qrc_img_resources.py: imgList.xml
 	pyrcc4 -o qrc_img_resources.py imgList.xml
 endif
 
@@ -155,6 +155,8 @@ uninstall-hook: uninstall-old
 clean-local:
 	rm -f ArmoryDB
 	rm -f lib/*
+if BUILD_CLIENT
 	rm -f CppBlockUtils.py
 	rm -f _CppBlockUtils.so
 	rm -f CppBlockUtils.pyc
+endif

--- a/cppForSwig/Makefile.am
+++ b/cppForSwig/Makefile.am
@@ -119,7 +119,6 @@ ARMORYCOMMON_SOURCE_FILES = Accounts.cpp \
 	CoinSelection.cpp \
 	DecryptedDataContainer.cpp \
 	DerivationScheme.cpp \
-	EncryptionUtils.cpp \
 	hkdf.cpp \
 	KDF.cpp \
 	log.cpp \
@@ -145,6 +144,8 @@ ARMORYCOMMON_SOURCE_FILES = Accounts.cpp \
 
 if ! USE_CRYPTOPP
 ARMORYCOMMON_SOURCE_FILES += EncryptionUtils_libbtc.cpp
+else
+ARMORYCOMMON_SOURCE_FILES += EncryptionUtils.cpp
 endif
 
 PROTOBUF_PROTO = protobuf/AddressBook.proto \


### PR DESCRIPTION
When building ArmoryDB standalone, an error occurs after copying the ArmoryDB binary to the root directory. While the error doesn't affect ArmoryDB, it may prevent important follow-ups from occurring. Fix up the Autotools files as needed.

Also, change the Autotools files to force the selection of either Crypto++ or libbtc for use in EncryptionUtils.