### PR TITLE
*NIX fixup

### DIFF
--- a/cppForSwig/Makefile.am
+++ b/cppForSwig/Makefile.am
@@ -104,6 +104,7 @@ ARMORYCOMMON_SOURCE_FILES = Accounts.cpp \
 	AssetEncryption.cpp \
 	Assets.cpp \
 	AsyncClient.cpp \
+	AuthorizedPeers.cpp \
 	BinaryData.cpp \
 	BIP32_Node.cpp \
 	BlockDataManagerConfig.cpp \
@@ -217,6 +218,7 @@ ArmoryDB_LDADD = $(LIBARMORYCOMMON) \
 		 $(LIBARMORYCLI) \
 		 $(LIBCRYPTOPP) \
 		 $(LIBBTC) \
+		 $(LIBCHACHA20POLY1305) \
 		 $(LIBLMDB) \
 		 -lpthread -lprotobuf -lwebsockets
 ArmoryDB_LDFLAGS = $(LWSLDFLAGS) $(LDFLAGS) -static

--- a/cppForSwig/Makefile.tests.include
+++ b/cppForSwig/Makefile.tests.include
@@ -44,6 +44,7 @@ gtest_DB1kIterTest_LDADD = gtest/libgtest.la $(LIBARMORYCOMMON) \
 		 $(LIBARMORYCLI) \
 		 $(LIBCRYPTOPP) \
 		 $(LIBBTC) \
+		 $(LIBCHACHA20POLY1305) \
 		 $(LIBLMDB) \
 		 -lprotobuf
 gtest_DB1kIterTest_LDFLAGS = $(AM_LDFLAGS) $(LWSLDFLAGS) $(LDFLAGS) -static
@@ -70,6 +71,7 @@ gtest_SupernodeTests_LDADD = gtest/libgtest.la \
 			$(LIBCRYPTOPP) \
 			$(LIBLMDB) \
 			$(LIBBTC) \
+			$(LIBCHACHA20POLY1305) \
 			-lprotobuf
 gtest_SupernodeTests_LDFLAGS = $(AM_LDFLAGS) $(LWSLDFLAGS) $(LDFLAGS) -static
 TESTS += gtest/SupernodeTests
@@ -101,6 +103,7 @@ gtest_WalletTests_LDADD = gtest/libgtest.la \
 			$(LIBARMORYCLI) \
 			$(LIBCRYPTOPP) \
 			$(LIBBTC) \
+			$(LIBCHACHA20POLY1305) \
 			$(LIBLMDB) \
 			-lprotobuf
 gtest_WalletTests_LDFLAGS = $(AM_LDFLAGS) $(LWSLDFLAGS) $(LDFLAGS) -static

--- a/cppForSwig/WalletManager.h
+++ b/cppForSwig/WalletManager.h
@@ -47,8 +47,8 @@ private:
    uint64_t spendableBalance_;
 
 private:
-   static void decorateUTXOs(shared_ptr<AssetWallet> const, vector<UTXO>&);
-   static function<vector<UTXO>(uint64_t)> getFetchLambdaFromWalletContainer(
+   static void decorateUTXOs(std::shared_ptr<AssetWallet> const, std::vector<UTXO>&);
+   static std::function<std::vector<UTXO>(uint64_t)> getFetchLambdaFromWalletContainer(
       WalletContainer* const walletContainer);
 
    static std::function<std::vector<UTXO>(uint64_t)> getFetchLambdaFromLockbox(

--- a/cppForSwig/gtest/DB1kIterTest.cpp
+++ b/cppForSwig/gtest/DB1kIterTest.cpp
@@ -35,9 +35,9 @@ protected:
       gentx_ = READHEX(MAINNET_GENESIS_TX_HASH_HEX);
       zeros_ = READHEX("00000000");
 
-      blkdir_ = string("./blkfiletest");
-      homedir_ = string("./fakehomedir");
-      ldbdir_ = string("./ldbtestdir");
+      blkdir_ = std::string("./blkfiletest");
+      homedir_ = std::string("./fakehomedir");
+      ldbdir_ = std::string("./ldbtestdir");
 
       rmdir(blkdir_);
       rmdir(homedir_);
@@ -87,7 +87,7 @@ protected:
       rmdir("./ldbtestdir");
       mkdir("./ldbtestdir");
 #else
-      string delstr = ldbdir_ + "/*";
+      std::string delstr = ldbdir_ + "/*";
       rmdir(delstr);
 #endif
       LOGENABLESTDOUT();
@@ -102,10 +102,10 @@ protected:
    BinaryData gentx_;
    BinaryData zeros_;
 
-   string blkdir_;
-   string homedir_;
-   string ldbdir_;
-   string blk0dat_;
+   std::string blkdir_;
+   std::string homedir_;
+   std::string ldbdir_;
+   std::string blk0dat_;
 
    BinaryData wallet1id;
    BinaryData wallet2id;
@@ -119,7 +119,7 @@ TEST_F(DB1kIter, DbInit1kIter)
    theBDMt_->start(config.initMode_);
    auto&& bdvID = DBTestUtils::registerBDV(clients_, magic_);
 
-   vector<BinaryData> scrAddrVec;
+   std::vector<BinaryData> scrAddrVec;
    scrAddrVec.push_back(TestChain::scrAddrA);
    scrAddrVec.push_back(TestChain::scrAddrB);
    scrAddrVec.push_back(TestChain::scrAddrC);
@@ -127,12 +127,12 @@ TEST_F(DB1kIter, DbInit1kIter)
    scrAddrVec.push_back(TestChain::scrAddrE);
    scrAddrVec.push_back(TestChain::scrAddrF);
 
-   const vector<BinaryData> lb1ScrAddrs
+   const std::vector<BinaryData> lb1ScrAddrs
    {
       TestChain::lb1ScrAddr,
       TestChain::lb1ScrAddrP2SH
    };
-   const vector<BinaryData> lb2ScrAddrs
+   const std::vector<BinaryData> lb2ScrAddrs
    {
       TestChain::lb2ScrAddr,
       TestChain::lb2ScrAddrP2SH
@@ -157,7 +157,7 @@ TEST_F(DB1kIter, DbInit1kIter)
 
    for (unsigned i = 0; i<1000; i++)
    {
-      cout << "iter: " << i << endl;
+      std::cout << "iter: " << i << std::endl;
       initBDM();
       auto bdm = theBDMt_->bdm();
       bdm->doInitialSyncOnLoad_Rebuild(fakeprog);
@@ -177,14 +177,14 @@ TEST_F(DB1kIter, DbInit1kIter)
 TEST_F(DB1kIter, DbInit1kIter_WithSignals)
 {
 
-   vector<BinaryData> scrAddrVec;
+   std::vector<BinaryData> scrAddrVec;
 
-   const vector<BinaryData> lb1ScrAddrs
+   const std::vector<BinaryData> lb1ScrAddrs
    {
       TestChain::lb1ScrAddr,
       TestChain::lb1ScrAddrP2SH
    };
-   const vector<BinaryData> lb2ScrAddrs
+   const std::vector<BinaryData> lb2ScrAddrs
    {
       TestChain::lb2ScrAddr,
       TestChain::lb2ScrAddrP2SH
@@ -242,7 +242,7 @@ TEST_F(DB1kIter, DbInit1kIter_WithSignals)
       fread(rawZC.getPtr(), 259, 1, ff);
       fclose(ff);
       DBTestUtils::ZcVector rawZcVec;
-      rawZcVec.push_back(move(rawZC), 1300000000);
+      rawZcVec.push_back(std::move(rawZC), 1300000000);
 
       BinaryData ZChash = READHEX(TestChain::zcTxHash256);
 
@@ -441,7 +441,7 @@ TEST_F(DB1kIter, DbInit1kIter_WithSignals)
       delete clients_;
       delete theBDMt_;
 
-      cout << i << endl;
+      std::cout << i << std::endl;
 
       rmdir(blkdir_);
       rmdir(homedir_);

--- a/cppForSwig/gtest/TestUtils.h
+++ b/cppForSwig/gtest/TestUtils.h
@@ -76,8 +76,8 @@
 #define READHEX BinaryData::CreateFromHex
 
 #if ! defined(_MSC_VER) && ! defined(__MINGW32__)
-   void rmdir(string src);
-   void mkdir(string newdir);
+   void rmdir(std::string src);
+   void mkdir(std::string newdir);
 #endif
 
 namespace TestUtils


### PR DESCRIPTION
The code doesn't compile for *NIX systems. Re-enable compilation.

Note that BIP151RekeyTest is still broken. The values placed under rekeyNeeded() may be incorrect, and there may be other issues. The purpose of this PR is just to get the code to compile again.