### PR TITLE
Add UNIT_TESTS compiler flag

### DIFF
--- a/cppForSwig/Makefile.am
+++ b/cppForSwig/Makefile.am
@@ -17,6 +17,12 @@ LIBSECP256K1 = libbtc/src/secp256k1/libsecp256k1.la
 DIST_SUBDIRS = libbtc chacha20poly1305
 SUBDIRS = libbtc chacha20poly1305 $(MAYBE_BUILD)
 
+# Unit test flags.
+UNIT_TEST_CXXFLAGS=
+if BUILD_TESTS
+UNIT_TEST_CXXFLAGS += -DUNIT_TESTS
+endif
+
 # Flag used to determine if the code will *only* use libbtc, and not Crypto++.
 LIBBTC_FLAGS =
 
@@ -186,7 +192,7 @@ libArmoryCommon_la_SOURCES = $(ARMORYCOMMON_SOURCE_FILES)
 nodist_libArmoryCommon_la_SOURCES = $(PROTOBUF_CC) $(PROTOBUF_H)
 libArmoryCommon_la_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES)
 libArmoryCommon_la_CXXFLAGS = $(AM_CXXFLAGS) $(LIBBTC_FLAGS) \
-			      -D__STDC_LIMIT_MACROS
+			      $(UNIT_TEST_CXXFLAGS) -D__STDC_LIMIT_MACROS
 libArmoryCommon_la_LIBADD = $(LIBLMDB) \
 				$(LIBCRYPTOPP) \
 				$(LIBBTC) \
@@ -200,7 +206,7 @@ libArmoryCLI_la_SOURCES = $(ARMORYCLI_SOURCE_FILES)
 libArmoryCLI_la_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES) \
 			$(PYTHON_CFLAGS)
 libArmoryCLI_la_CXXFLAGS = $(AM_CXXFLAGS) $(LIBBTC_FLAGS) \
-			   -Ilmdb/libraries/liblmdb -D__STDC_LIMIT_MACROS
+			   $(UNIT_TEST_CXXFLAGS) -Ilmdb/libraries/liblmdb -D__STDC_LIMIT_MACROS
 libArmoryCLI_la_LIBADD = $(LIBBTC) \
 			 $(LIBCHACHA20POLY1305) \
 			 $(LIBARMORYCOMMON) \
@@ -212,7 +218,8 @@ libArmoryCLI_la_LDFLAGS = $(LDFLAGS) $(LWSLDFLAGS)
 # ArmoryDB binary
 bin_PROGRAMS += ArmoryDB
 ArmoryDB_SOURCES = $(ARMORYDB_SOURCE_FILES)
-ArmoryDB_CXXFLAGS = $(AM_CXXFLAGS) $(LIBBTC_FLAGS) -D__STDC_LIMIT_MACROS
+ArmoryDB_CXXFLAGS = $(AM_CXXFLAGS) $(LIBBTC_FLAGS) $(UNIT_TEST_CXXFLAGS) \
+			-D__STDC_LIMIT_MACROS
 ArmoryDB_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES)
 ArmoryDB_LDADD = $(LIBARMORYCOMMON) \
 		 $(LIBARMORYCLI) \
@@ -228,7 +235,7 @@ if BUILD_CLIENT
 lib_LTLIBRARIES += $(LIBARMORYGUI)
 libArmoryGUI_la_SOURCES = $(ARMORYGUI_SOURCE_FILES)
 libArmoryGUI_la_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES) $(PYTHON_CFLAGS)
-libArmoryGUI_la_CXXFLAGS = $(AM_CXXFLAGS) -D__STDC_LIMIT_MACROS
+libArmoryGUI_la_CXXFLAGS = $(AM_CXXFLAGS) $(UNIT_TEST_CXXFLAGS) -D__STDC_LIMIT_MACROS
 libArmoryGUI_la_LIBADD = $(LIBARMORYCOMMON) $(LIBCRYPTOPP) \
 			-lpthread
 libArmoryGUI_la_LDFLAGS = $(LDFLAGS) $(LWSLDFLAGS) $(PYTHON_LDFLAGS) -shared
@@ -240,7 +247,7 @@ libCppBlockUtils_la_SOURCES = CppBlockUtils_wrap.cxx
 libCppBlockUtils_la_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES) \
 				$(PYTHON_CFLAGS)
 libCppBlockUtils_la_CXXFLAGS = $(AM_CXXFLAGS) -Ilmdb/libraries/liblmdb \
-				-D__STDC_LIMIT_MACROS
+				$(UNIT_TEST_CXXFLAGS) -D__STDC_LIMIT_MACROS
 libCppBlockUtils_la_LIBADD = $(LIBARMORYCOMMON) $(LIBARMORYGUI) \
 				$(LIBCRYPTOPP) -lpthread
 libCppBlockUtils_la_LDFLAGS = $(LDFLAGS) $(LWSLDFLAGS) $(PYTHON_LDFLAGS) -shared

--- a/cppForSwig/Makefile.tests.include
+++ b/cppForSwig/Makefile.tests.include
@@ -15,7 +15,7 @@ endif
 
 # Standard gtest library
 lib_LTLIBRARIES += gtest/libgtest.la
-gtest_libgtest_la_CXXFLAGS = $(AM_CXXFLAGS) $(LIBBTC_FLAGS)
+gtest_libgtest_la_CXXFLAGS = $(AM_CXXFLAGS) $(UNIT_TEST_CXXFLAGS) $(LIBBTC_FLAGS)
 gtest_libgtest_la_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES)
 gtest_libgtest_la_SOURCES = gtest/TestUtils.cpp gtest/gtest-all.cc
 gtest_libgtest_la_LIBADD = $(LIBARMORYCOMMON) $(LIBARMORYCLI) \
@@ -26,7 +26,7 @@ gtest_libgtest_la_LDFLAGS = $(AM_LDFLAGS) $(LWSLDFLAGS) $(LDFLAGS)
 # ContainerTests
 bin_PROGRAMS += gtest/ContainerTests
 gtest_ContainerTests_SOURCES = gtest/ContainerTests.cpp
-gtest_ContainerTests_CXXFLAGS = $(AM_CXXFLAGS) $(LIBBTC_FLAGS)
+gtest_ContainerTests_CXXFLAGS = $(AM_CXXFLAGS) $(UNIT_TEST_CXXFLAGS) $(LIBBTC_FLAGS)
 gtest_ContainerTests_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES)
 gtest_ContainerTests_LDADD = gtest/libgtest.la $(LIBARMORYCOMMON) \
 		 $(LIBARMORYCLI) \
@@ -38,7 +38,7 @@ TESTS += gtest/ContainerTests
 # DB1kIterTest
 bin_PROGRAMS += gtest/DB1kIterTest
 gtest_DB1kIterTest_SOURCES = gtest/DB1kIterTest.cpp
-gtest_DB1kIterTest_CXXFLAGS = $(AM_CXXFLAGS) $(LIBBTC_FLAGS)
+gtest_DB1kIterTest_CXXFLAGS = $(AM_CXXFLAGS) $(UNIT_TEST_CXXFLAGS) $(LIBBTC_FLAGS)
 gtest_DB1kIterTest_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES)
 gtest_DB1kIterTest_LDADD = gtest/libgtest.la $(LIBARMORYCOMMON) \
 		 $(LIBARMORYCLI) \
@@ -53,7 +53,7 @@ TESTS += gtest/DB1kIterTest
 # BIP151RekeyTest
 bin_PROGRAMS += gtest/BIP151RekeyTest
 gtest_BIP151RekeyTest_SOURCES = gtest/BIP151RekeyTest.cpp
-gtest_BIP151RekeyTest_CXXFLAGS = $(AM_CXXFLAGS)
+gtest_BIP151RekeyTest_CXXFLAGS = $(AM_CXXFLAGS) $(UNIT_TEST_CXXFLAGS)
 gtest_BIP151RekeyTest_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES)
 gtest_BIP151RekeyTest_LDADD = gtest/libgtest.la $(LIBBTC) $(LIBCRYPTOPP) \
 			$(LIBCHACHA20POLY1305)
@@ -63,8 +63,8 @@ TESTS += gtest/BIP151RekeyTest
 # SupernodeTests
 bin_PROGRAMS += gtest/SupernodeTests
 gtest_SupernodeTests_SOURCES = gtest/SupernodeTests.cpp
-gtest_SupernodeTests_CXXFLAGS = $(AM_CXXFLAGS) $(LIBBTC_FLAGS)
-gtest_SupernodeTests_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES) -DUNIT_TESTS
+gtest_SupernodeTests_CXXFLAGS = $(AM_CXXFLAGS) $(UNIT_TEST_CXXFLAGS) $(LIBBTC_FLAGS)
+gtest_SupernodeTests_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES)
 gtest_SupernodeTests_LDADD = gtest/libgtest.la \
 			$(LIBARMORYCOMMON) \
 			$(LIBARMORYCLI) \
@@ -79,7 +79,7 @@ TESTS += gtest/SupernodeTests
 # CppBlockUtilsTests - Contains the bulk of the tests
 bin_PROGRAMS += gtest/CppBlockUtilsTests
 gtest_CppBlockUtilsTests_SOURCES = gtest/CppBlockUtilsTests.cpp
-gtest_CppBlockUtilsTests_CXXFLAGS = $(AM_CXXFLAGS) $(LIBBTC_FLAGS)
+gtest_CppBlockUtilsTests_CXXFLAGS = $(AM_CXXFLAGS) $(UNIT_TEST_CXXFLAGS) $(LIBBTC_FLAGS)
 gtest_CppBlockUtilsTests_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES)
 gtest_CppBlockUtilsTests_LDADD = gtest/libgtest.la \
 			$(LIBARMORYCOMMON) \
@@ -95,8 +95,8 @@ TESTS += gtest/CppBlockUtilsTests
 # WalletTests
 bin_PROGRAMS += gtest/WalletTests
 gtest_WalletTests_SOURCES = gtest/WalletTests.cpp
-gtest_WalletTests_CXXFLAGS = $(AM_CXXFLAGS) $(LIBBTC_FLAGS)
-gtest_WalletTests_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES) -DUNIT_TESTS
+gtest_WalletTests_CXXFLAGS = $(AM_CXXFLAGS) $(UNIT_TEST_CXXFLAGS) $(LIBBTC_FLAGS)
+gtest_WalletTests_CPPFLAGS = $(AM_CPPFLAGS) $(INCLUDE_FILES)
 gtest_WalletTests_LDADD = gtest/libgtest.la \
 			$(LIBBTC) \
 			$(LIBARMORYCOMMON) \


### PR DESCRIPTION
Flag is used to enable certain changes in the code when compiling unit tests. Note that compiling code with --enable-tests will now affect the final binary. Remember to disable unit tests when running Armory outside of a unit test environment.