### PR TITLE
Allow WebSocketClient to use individual BlockDataManagerConfig objects for setup

### DIFF
--- a/cppForSwig/AsyncClient.cpp
+++ b/cppForSwig/AsyncClient.cpp
@@ -72,10 +72,12 @@ void BlockDataViewer::addPublicKey(const SecureBinaryData& pubkey)
 
 ///////////////////////////////////////////////////////////////////////////////
 shared_ptr<BlockDataViewer> BlockDataViewer::getNewBDV(const string& addr,
-   const string& port, shared_ptr<RemoteCallback> callbackPtr)
+   const string& port, const string& datadir, const bool& ephemeralPeers,
+   shared_ptr<RemoteCallback> callbackPtr)
 {
    //create socket object
-   auto sockptr = make_shared<WebSocketClient>(addr, port, callbackPtr);
+   auto sockptr = make_shared<WebSocketClient>(addr, port, datadir,
+      ephemeralPeers, callbackPtr);
 
    //instantiate bdv object
    BlockDataViewer* bdvPtr = new BlockDataViewer(sockptr);

--- a/cppForSwig/AsyncClient.h
+++ b/cppForSwig/AsyncClient.h
@@ -304,7 +304,9 @@ namespace AsyncClient
       std::shared_ptr<SocketPrototype> getSocketObject(void) const { return sock_; }
 
       static std::shared_ptr<BlockDataViewer> getNewBDV(
-         const std::string& addr, const std::string& port, std::shared_ptr<RemoteCallback>);
+         const std::string& addr, const std::string& port,
+         const std::string& datadir, const bool& ephemeralPeers,
+         std::shared_ptr<RemoteCallback> callbackPtr);
 
       void getLedgerDelegateForWallets(
          std::function<void(ReturnMessage<LedgerDelegate>)>);

--- a/cppForSwig/Server.cpp
+++ b/cppForSwig/Server.cpp
@@ -186,18 +186,19 @@ int WebSocketServer::callback(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-void WebSocketServer::start(BlockDataManagerThread* bdmT, bool async)
+void WebSocketServer::start(BlockDataManagerThread* bdmT,
+   const string& datadir, const bool& ephemeralPeers, const bool& async)
 {
    shutdownPromise_ = promise<bool>();
    shutdownFuture_ = shutdownPromise_.get_future();
    auto instance = getInstance();
 
    //init auth peer object
-   if (!BlockDataManagerConfig::ephemeralPeers_)
+   if (!ephemeralPeers)
    {
       string peerFilename(SERVER_AUTH_PEER_FILENAME);
       instance->authorizedPeers_ = make_shared<AuthorizedPeers>(
-         BlockDataManagerConfig::getDataDir(), peerFilename);
+         datadir, peerFilename);
    }
    else
    {

--- a/cppForSwig/Server.h
+++ b/cppForSwig/Server.h
@@ -168,18 +168,20 @@ public:
    WebSocketServer(void);
 
    static int callback(
-      struct lws *wsi, enum lws_callback_reasons reason, 
+      struct lws *wsi, enum lws_callback_reasons reason,
       void *user, void *in, size_t len);
 
-   static void start(BlockDataManagerThread* bdmT, bool async);
+   static void start(BlockDataManagerThread* bdmT,
+      const std::string& datadir, const bool& ephemeralPeers,
+      const bool& async);
    static void shutdown(void);
    static void waitOnShutdown(void);
    static SecureBinaryData getPublicKey(void);
 
-   static void write(const uint64_t&, const uint32_t&, 
+   static void write(const uint64_t&, const uint32_t&,
       std::shared_ptr<::google::protobuf::Message>);
-   
-   std::shared_ptr<std::map<uint64_t, ClientConnection>> 
+
+   std::shared_ptr<std::map<uint64_t, ClientConnection>>
       getConnectionStateMap(void) const;
    void addId(const uint64_t&, struct lws* ptr);
    void eraseId(const uint64_t&);

--- a/cppForSwig/SwigClient.cpp
+++ b/cppForSwig/SwigClient.cpp
@@ -44,10 +44,11 @@ const BlockDataViewer& BlockDataViewer::operator=(const BlockDataViewer& rhs)
 
 ///////////////////////////////////////////////////////////////////////////////
 shared_ptr<BlockDataViewer> BlockDataViewer::getNewBDV(const string& addr,
-   const string& port, shared_ptr<RemoteCallback> callbackPtr)
+   const string& port, const string& datadir, const bool& ephemeralPeers,
+   shared_ptr<RemoteCallback> callbackPtr)
 {
-   auto&& bdvAsync = 
-      AsyncClient::BlockDataViewer::getNewBDV(addr, port, callbackPtr);
+   auto&& bdvAsync = AsyncClient::BlockDataViewer::getNewBDV(addr, port,
+      datadir, ephemeralPeers, callbackPtr);
    auto bdvPtr = new BlockDataViewer(*bdvAsync);
    shared_ptr<BlockDataViewer> bdvSharedPtr;
    bdvSharedPtr.reset(bdvPtr);

--- a/cppForSwig/SwigClient.h
+++ b/cppForSwig/SwigClient.h
@@ -183,7 +183,9 @@ namespace SwigClient
       const std::string& getID(void) const;
 
       static std::shared_ptr<BlockDataViewer> getNewBDV(
-         const std::string& addr, const std::string& port, std::shared_ptr<RemoteCallback>);
+         const std::string& addr, const std::string& port,
+         const std::string& datadir, const bool& ephemeralPeers,
+         std::shared_ptr<RemoteCallback> callbackPtr);
 
       LedgerDelegate getLedgerDelegateForWallets(void);
       LedgerDelegate getLedgerDelegateForLockboxes(void);

--- a/cppForSwig/WebSocketClient.cpp
+++ b/cppForSwig/WebSocketClient.cpp
@@ -25,19 +25,19 @@ static struct lws_protocols protocols[] = {
 };
 
 ////////////////////////////////////////////////////////////////////////////////
-WebSocketClient::WebSocketClient(
-   const std::string& addr, const std::string& port,
-   std::shared_ptr<RemoteCallback> cbPtr) :
+WebSocketClient::WebSocketClient(const string& addr, const string& port,
+   const string& datadir, const bool& ephemeralPeers,
+   shared_ptr<RemoteCallback> cbPtr) :
    SocketPrototype(addr, port, false), callbackPtr_(cbPtr)
 {
    count_.store(0, std::memory_order_relaxed);
    requestID_.store(0, std::memory_order_relaxed);
 
    std::string filename(CLIENT_AUTH_PEER_FILENAME);
-   if (!BlockDataManagerConfig::ephemeralPeers_)
+   if (!ephemeralPeers)
    {
       authPeers_ = make_shared<AuthorizedPeers>(
-         BlockDataManagerConfig::getDataDir(), filename);
+         datadir, filename);
    }
    else
    {

--- a/cppForSwig/WebSocketClient.h
+++ b/cppForSwig/WebSocketClient.h
@@ -140,6 +140,7 @@ private:
 
 public:
    WebSocketClient(const std::string& addr, const std::string& port,
+      const std::string& datadir, const bool& ephemeralPeers,
       std::shared_ptr<RemoteCallback> cbPtr);
 
    ~WebSocketClient()

--- a/cppForSwig/gtest/CppBlockUtilsTests.cpp
+++ b/cppForSwig/gtest/CppBlockUtilsTests.cpp
@@ -10226,13 +10226,15 @@ TEST_F(WebSocketTests, WebSocketStack)
    clients_ = nullptr;
 
    theBDMt_ = new BlockDataManagerThread(config);
-   WebSocketServer::start(theBDMt_, true);
+   WebSocketServer::start(theBDMt_, BlockDataManagerConfig::getDataDir(),
+      BlockDataManagerConfig::ephemeralPeers_, true);
 
    theBDMt_->start(config.initMode_);
 
    auto pCallback = make_shared<DBTestUtils::UTCallback>();
    auto&& bdvObj = SwigClient::BlockDataViewer::getNewBDV(
-      "127.0.0.1", config.listenPort_, pCallback);
+      "127.0.0.1", config.listenPort_, BlockDataManagerConfig::getDataDir(),
+      BlockDataManagerConfig::ephemeralPeers_, pCallback);
    bdvObj->connectToRemote();
    bdvObj->registerWithDB(NetworkConfig::getMagicBytes());
 
@@ -10473,7 +10475,8 @@ TEST_F(WebSocketTests, WebSocketStack_Reconnect)
    clients_ = nullptr;
 
    theBDMt_ = new BlockDataManagerThread(config);
-   WebSocketServer::start(theBDMt_, true);
+   WebSocketServer::start(theBDMt_, BlockDataManagerConfig::getDataDir(),
+      BlockDataManagerConfig::ephemeralPeers_, true);
 
    auto createNAddresses = [](unsigned count)->vector<BinaryData>
    {
@@ -10499,7 +10502,8 @@ TEST_F(WebSocketTests, WebSocketStack_Reconnect)
    {
       auto pCallback = make_shared<DBTestUtils::UTCallback>();
       auto&& bdvObj = SwigClient::BlockDataViewer::getNewBDV(
-         "127.0.0.1", config.listenPort_, pCallback);
+         "127.0.0.1", config.listenPort_, BlockDataManagerConfig::getDataDir(),
+         BlockDataManagerConfig::ephemeralPeers_, pCallback);
       bdvObj->connectToRemote();
       bdvObj->registerWithDB(NetworkConfig::getMagicBytes());
 
@@ -10623,7 +10627,8 @@ TEST_F(WebSocketTests, WebSocketStack_Reconnect)
 
       auto pCallback = make_shared<DBTestUtils::UTCallback>();
       auto&& bdvObj = SwigClient::BlockDataViewer::getNewBDV(
-         "127.0.0.1", config.listenPort_, pCallback);
+         "127.0.0.1", config.listenPort_, BlockDataManagerConfig::getDataDir(),
+         BlockDataManagerConfig::ephemeralPeers_, pCallback);
       bdvObj->connectToRemote();
       bdvObj->registerWithDB(NetworkConfig::getMagicBytes());
 
@@ -10707,7 +10712,8 @@ TEST_F(WebSocketTests, WebSocketStack_Reconnect)
    }
 
    auto&& bdvObj2 = SwigClient::BlockDataViewer::getNewBDV(
-      "127.0.0.1", config.listenPort_, nullptr);
+      "127.0.0.1", config.listenPort_, BlockDataManagerConfig::getDataDir(),
+      BlockDataManagerConfig::ephemeralPeers_, nullptr);
    bdvObj2->connectToRemote();
 
    bdvObj2->shutdown(config.cookie_);
@@ -10734,12 +10740,14 @@ TEST_F(WebSocketTests, GrabAddrLedger_PostReg)
    clients_ = nullptr;
 
    theBDMt_ = new BlockDataManagerThread(config);
-   WebSocketServer::start(theBDMt_, true);
+   WebSocketServer::start(theBDMt_, BlockDataManagerConfig::getDataDir(),
+      BlockDataManagerConfig::ephemeralPeers_, true);
    theBDMt_->start(config.initMode_);
 
    auto pCallback = make_shared<DBTestUtils::UTCallback>();
    auto&& bdvObj = SwigClient::BlockDataViewer::getNewBDV(
-      "127.0.0.1", config.listenPort_, pCallback);
+      "127.0.0.1", config.listenPort_, BlockDataManagerConfig::getDataDir(),
+      BlockDataManagerConfig::ephemeralPeers_, pCallback);
    bdvObj->connectToRemote();
    bdvObj->registerWithDB(NetworkConfig::getMagicBytes());
 
@@ -10796,13 +10804,15 @@ TEST_F(WebSocketTests, WebSocketStack_ManyZC)
    clients_ = nullptr;
 
    theBDMt_ = new BlockDataManagerThread(config);
-   WebSocketServer::start(theBDMt_, true);
+   WebSocketServer::start(theBDMt_, BlockDataManagerConfig::getDataDir(),
+      BlockDataManagerConfig::ephemeralPeers_, true);
 
    theBDMt_->start(config.initMode_);
 
    auto pCallback = make_shared<DBTestUtils::UTCallback>();
    auto&& bdvObj = SwigClient::BlockDataViewer::getNewBDV(
-      "127.0.0.1", config.listenPort_, pCallback);
+      "127.0.0.1", config.listenPort_, BlockDataManagerConfig::getDataDir(),
+      BlockDataManagerConfig::ephemeralPeers_, pCallback);
    bdvObj->connectToRemote();
    bdvObj->registerWithDB(NetworkConfig::getMagicBytes());
    auto& bdvID = bdvObj->getID();

--- a/cppForSwig/gtest/SupernodeTests.cpp
+++ b/cppForSwig/gtest/SupernodeTests.cpp
@@ -3052,7 +3052,8 @@ TEST_F(WebSocketTests, WebSocketStack_ParallelAsync)
    clients_ = nullptr;
 
    theBDMt_ = new BlockDataManagerThread(config);
-   WebSocketServer::start(theBDMt_, true);
+   WebSocketServer::start(theBDMt_, BlockDataManagerConfig::getDataDir(),
+      BlockDataManagerConfig::ephemeralPeers_, true);
    auto&& serverPubkey = WebSocketServer::getPublicKey();
 
    auto createNAddresses = [](unsigned count)->vector<BinaryData>
@@ -3084,7 +3085,8 @@ TEST_F(WebSocketTests, WebSocketStack_ParallelAsync)
    {
       auto pCallback = make_shared<DBTestUtils::UTCallback>();
       auto&& bdvObj = SwigClient::BlockDataViewer::getNewBDV(
-         "127.0.0.1", config.listenPort_, pCallback);
+         "127.0.0.1", config.listenPort_,  BlockDataManagerConfig::getDataDir(),
+         BlockDataManagerConfig::ephemeralPeers_,pCallback);
       bdvObj->addPublicKey(serverPubkey);
       bdvObj->connectToRemote();
       bdvObj->registerWithDB(NetworkConfig::getMagicBytes());
@@ -3117,7 +3119,8 @@ TEST_F(WebSocketTests, WebSocketStack_ParallelAsync)
 
       auto pCallback = make_shared<DBTestUtils::UTCallback>();
       auto bdvObj = AsyncClient::BlockDataViewer::getNewBDV(
-         "127.0.0.1", config.listenPort_, pCallback);
+         "127.0.0.1", config.listenPort_,  BlockDataManagerConfig::getDataDir(),
+         BlockDataManagerConfig::ephemeralPeers_,pCallback);
       bdvObj->addPublicKey(serverPubkey);
       bdvObj->connectToRemote();
       bdvObj->registerWithDB(NetworkConfig::getMagicBytes());
@@ -3442,7 +3445,8 @@ TEST_F(WebSocketTests, WebSocketStack_ParallelAsync)
    }
 
    auto&& bdvObj2 = SwigClient::BlockDataViewer::getNewBDV(
-      "127.0.0.1", config.listenPort_, nullptr);
+      "127.0.0.1", config.listenPort_, BlockDataManagerConfig::getDataDir(),
+      BlockDataManagerConfig::ephemeralPeers_, nullptr);
    bdvObj2->addPublicKey(serverPubkey);
    bdvObj2->connectToRemote();
 
@@ -3470,7 +3474,8 @@ TEST_F(WebSocketTests, WebSocketStack_ZcUpdate)
    clients_ = nullptr;
 
    theBDMt_ = new BlockDataManagerThread(config);
-   WebSocketServer::start(theBDMt_, true);
+   WebSocketServer::start(theBDMt_, BlockDataManagerConfig::getDataDir(),
+      BlockDataManagerConfig::ephemeralPeers_, true);
 
    vector<BinaryData> scrAddrVec;
    scrAddrVec.push_back(TestChain::scrAddrA);
@@ -3481,7 +3486,8 @@ TEST_F(WebSocketTests, WebSocketStack_ZcUpdate)
 
    auto pCallback = make_shared<DBTestUtils::UTCallback>();
    auto bdvObj = AsyncClient::BlockDataViewer::getNewBDV(
-      "127.0.0.1", config.listenPort_, pCallback);
+      "127.0.0.1", config.listenPort_, BlockDataManagerConfig::getDataDir(),
+      BlockDataManagerConfig::ephemeralPeers_, pCallback);
    bdvObj->connectToRemote();
    bdvObj->registerWithDB(NetworkConfig::getMagicBytes());
 
@@ -3622,7 +3628,8 @@ TEST_F(WebSocketTests, WebSocketStack_ZcUpdate)
 
    //cleanup
    auto&& bdvObj2 = SwigClient::BlockDataViewer::getNewBDV(
-      "127.0.0.1", config.listenPort_, nullptr);
+      "127.0.0.1", config.listenPort_, BlockDataManagerConfig::getDataDir(),
+      BlockDataManagerConfig::ephemeralPeers_, nullptr);
    bdvObj2->connectToRemote();
 
    bdvObj2->shutdown(config.cookie_);

--- a/cppForSwig/main.cpp
+++ b/cppForSwig/main.cpp
@@ -74,7 +74,8 @@ int main(int argc, char* argv[])
    if (!bdmConfig.checkChain_)
    {
       //process incoming connections
-      server.start(&bdmThread, false);
+      server.start(&bdmThread, BlockDataManagerConfig::getDataDir()
+         , BlockDataManagerConfig::ephemeralPeers_, false);
    }
    else
    {


### PR DESCRIPTION
Code may wish to use customized locations for data, or to have direct access to ephemeral peer configuration. Add the capabilities.