### PR TITLE
Autotools fixup

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -228,6 +228,7 @@ export LDFLAGS
 
 AM_CONDITIONAL([HAVE_CLANG], [test x$CLANG = xyes])
 AM_CONDITIONAL([BUILD_DARWIN], [test x$BUILD_OS = xdarwin])
+AM_CONDITIONAL([BUILD_LINUX], [test x$BUILD_OS = xlinux])
 
 AC_CONFIG_FILES(Makefile
 		cppForSwig/Makefile

--- a/cppForSwig/Makefile.am
+++ b/cppForSwig/Makefile.am
@@ -232,6 +232,9 @@ ArmoryDB_LDADD = $(LIBARMORYCOMMON) \
 		 $(LIBLMDB) \
 		 -lpthread -lprotobuf -lwebsockets
 ArmoryDB_LDFLAGS = $(LWSLDFLAGS) $(LDFLAGS) -static
+if BUILD_LINUX
+ArmoryDB_LDFLAGS += -ldl
+endif
 
 # KeyManager binary
 bin_PROGRAMS += BIP150KeyManager


### PR DESCRIPTION
On Linux, the linker flag "-ldl" is required now for ArmoryDB. Add it.