### PR TITLE
Fix MacOS-specific BIP 151 handshake issue

### DIFF
--- a/cppForSwig/WebSocketClient.cpp
+++ b/cppForSwig/WebSocketClient.cpp
@@ -782,7 +782,9 @@ void WebSocketClient::promptUser(
       if (this->userPromptLambda_(key_copy, name))
       {
          //the lambda returns true, the user accepted the key, add it to peers
-         this->authPeers_->addPeer(key_copy, name);
+         std::vector<std::string> nameVec;
+         nameVec.push_back(name);
+         this->authPeers_->addPeer(key_copy, nameVec);
          serverPubkeyProm_->set_value(true);
       }
       else


### PR DESCRIPTION
Fix a function invocation issue that is somehow worked around on Windows and Linux, and somehow affects only domain names and not IP addresses.