### PR TITLE
BIP 150/151 warning cleanup

### DIFF
--- a/cppForSwig/BIP150_151.cpp
+++ b/cppForSwig/BIP150_151.cpp
@@ -102,7 +102,7 @@ isOutgoing_(sessOut)
 // IN:  peerPubKey  (The peer's public key - Assume the key is validated)
 // OUT: N/A
 // RET: -1 if not successful, 0 if successful.
-const int BIP151Session::genSymKeys(const uint8_t* peerPubKey)
+int BIP151Session::genSymKeys(const uint8_t* peerPubKey)
 {
    int retVal = -1;
    btc_key sessionECDHKey;
@@ -167,7 +167,7 @@ const int BIP151Session::genSymKeys(const uint8_t* peerPubKey)
 // IN:  None
 // OUT: None
 // RET: True if a rekey is required, false if not.
-const bool BIP151Session::rekeyNeeded(const size_t& sz) const
+bool BIP151Session::rekeyNeeded(const size_t& sz) const
 {
    bool retVal = false;
 
@@ -187,8 +187,8 @@ const bool BIP151Session::rekeyNeeded(const size_t& sz) const
 // IN:  peerPubKey  (The peer's public key - Needs to be validated)
 // OUT: None
 // RET: -1 if failure, 0 if success.
-const int BIP151Session::symKeySetup(const uint8_t* peerPubKey,
-                                     const size_t& peerPubKeySize)
+int BIP151Session::symKeySetup(const uint8_t* peerPubKey,
+   const size_t& peerPubKeySize)
 {
    int retVal = -1;
 
@@ -276,12 +276,9 @@ void BIP151Session::calcSessionID(const btc_key& sesECDHKey)
 // OUT: None
 // RET: N/A
 void BIP151Session::sessionRekey(const bool& bip151Rekey,
-                                 const uint8_t* reqIDKey,
-                                 const size_t& reqIDKeySize,
-                                 const uint8_t* resIDKey,
-                                 const size_t& resIDKeySize,
-                                 const uint8_t* oppositeSessionKey,
-                                 const size_t& oppositeSessionKeySize)
+   const uint8_t* reqIDKey, const size_t& reqIDKeySize,
+   const uint8_t* resIDKey, const size_t& resIDKeySize,
+   const uint8_t* oppositeSessionKey, const size_t& oppositeSessionKeySize)
 {
    switch(cipherType_)
    {
@@ -339,8 +336,7 @@ void BIP151Session::sessionRekey(const bool& bip151Rekey,
 //      inMsgSize - incoming message size. Must be 33 bytes.
 // OUT: None
 // RET: 0 if rekey, any other value if not rekey.
-const int BIP151Session::inMsgIsRekey(const uint8_t* inMsg,
-                                      const size_t& inMsgSize)
+int BIP151Session::inMsgIsRekey(const uint8_t* inMsg, const size_t& inMsgSize)
 {
    int retVal = -1;
    if(inMsgSize == BIP151PUBKEYSIZE)
@@ -363,10 +359,8 @@ const int BIP151Session::inMsgIsRekey(const uint8_t* inMsg,
 //                   cipher will include the Poly1305 tag.
 // OUT: cipherData - The encrypted plaintext data and the Poly1305 tag.
 // RET: -1 if failure, 0 if success
-const int BIP151Session::encPayload(uint8_t* cipherData,
-                                    const size_t cipherSize,
-                                    const uint8_t* plainData,
-                                    const size_t plainSize)
+int BIP151Session::encPayload(uint8_t* cipherData, const size_t cipherSize,
+   const uint8_t* plainData, const size_t plainSize)
 {
    int retVal = -1;
    assert(cipherSize >= (plainSize + POLY1305MACLEN));
@@ -406,10 +400,8 @@ const int BIP151Session::encPayload(uint8_t* cipherData,
 // OUT: plainData - The decrypted ciphertext data but no Poly1305 tag.
 // RET: -1 if failure, 0 if success. If the decrypted length is bigger than
 // than the potential max clear text size, return the decrypted length instead
-const int BIP151Session::decPayload(const uint8_t* cipherData,
-                                    const size_t cipherSize,
-                                    uint8_t* plainData,
-                                    const size_t plainSize)
+int BIP151Session::decPayload(const uint8_t* cipherData,
+   const size_t cipherSize, uint8_t* plainData, const size_t plainSize)
 {
    int retVal = -1;
    uint32_t decryptedLen = 0;
@@ -450,12 +442,12 @@ const int BIP151Session::decPayload(const uint8_t* cipherData,
 // IN:  keySize - The size of the key to be updated.
 // OUT: keyToUpdate - The updated key (ChaCha20 or Poly1305).
 // RET: None
-void BIP151Session::chacha20Poly1305Rekey(
-   uint8_t* keyToUpdate, const size_t& keySize, 
-   const bool& bip151Rekey,
+void BIP151Session::chacha20Poly1305Rekey(uint8_t* keyToUpdate,
+   const size_t& keySize, const bool& bip151Rekey,
    const uint8_t* bip150ReqIDKey, const size_t& bip150ReqIDKeySize,
    const uint8_t* bip150ResIDKey, const size_t& bip150ResIDKeySize,
-   const uint8_t* oppositeChannelCipherKey, const size_t& oppositeChannelCipherKeySize)
+   const uint8_t* oppositeChannelCipherKey,
+   const size_t& oppositeChannelCipherKeySize)
 {
    assert(keySize == BIP151PRVKEYSIZE);
 
@@ -503,7 +495,7 @@ void BIP151Session::chacha20Poly1305Rekey(
 // IN:  inCipher - The incoming cipher type.
 // OUT: None
 // RET: -1 if failure, 0 if success
-const int BIP151Session::setCipherType(const BIP151SymCiphers& inCipher)
+int BIP151Session::setCipherType(const BIP151SymCiphers& inCipher)
 {
    int retVal = -1;
    if(isCipherValid(inCipher) == true)
@@ -525,7 +517,7 @@ const int BIP151Session::setCipherType(const BIP151SymCiphers& inCipher)
 // IN:  inCipher - The incoming cipher type.
 // OUT: None
 // RET: True if valid, false if not valid.
-const bool BIP151Session::isCipherValid(const BIP151SymCiphers& inCipher)
+bool BIP151Session::isCipherValid(const BIP151SymCiphers& inCipher)
 {
    // For now, this is simple. Just check for ChaChaPoly1305.
    bool retVal = false;
@@ -559,9 +551,8 @@ void BIP151Session::gettempECDHPubKey(btc_pubkey* tempECDHPubKey)
 //      inCipher - The cipher type to send.
 // OUT: initBuffer - The buffer with the encinit data.
 // RET: -1 if failure, 0 if success
-const int BIP151Session::getEncinitData(uint8_t* initBuffer,
-                                        const size_t& initBufferSize,
-                                        const BIP151SymCiphers& inCipher)
+int BIP151Session::getEncinitData(uint8_t* initBuffer,
+   const size_t& initBufferSize, const BIP151SymCiphers& inCipher)
 {
    int retVal = -1;
    if(setCipherType(inCipher) != 0)
@@ -605,8 +596,8 @@ const int BIP151Session::getEncinitData(uint8_t* initBuffer,
 // IN:  ackBufferSize - The size of the output buffer.
 // OUT: ackBuffer - The buffer with the encinit data.
 // RET: -1 if failure, 0 if success
-const int BIP151Session::getEncackData(uint8_t* ackBuffer,
-                                       const size_t& ackBufferSize)
+int BIP151Session::getEncackData(uint8_t* ackBuffer,
+   const size_t& ackBufferSize)
 {
    int retVal = -1;
 
@@ -651,7 +642,7 @@ const int BIP151Session::getEncackData(uint8_t* ackBuffer,
 // IN:  None
 // OUT: None
 // RET: A const string with the session ID hex string.
-const std::string BIP151Session::getSessionIDHex() const
+std::string BIP151Session::getSessionIDHex() const
 {
    // It's safe to get the session ID before it's established. It'll just return
    // all 0's.
@@ -679,9 +670,8 @@ BIP151Connection::BIP151Connection(AuthPeersLambdas& authkeys) :
 //      inSymECDHPrivKeyOut - ECDH private key for the outbound channel.
 // OUT: None
 // RET: N/A
-BIP151Connection::BIP151Connection(
-   btc_key* inSymECDHPrivKeyIn, btc_key* inSymECDHPrivKeyOut, 
-   AuthPeersLambdas& authkeys) :
+BIP151Connection::BIP151Connection(btc_key* inSymECDHPrivKeyIn,
+   btc_key* inSymECDHPrivKeyOut, AuthPeersLambdas& authkeys) :
    inSes_(inSymECDHPrivKeyIn, false), outSes_(inSymECDHPrivKeyOut, true),
    bip150SM_(&inSes_, &outSes_, authkeys)
 {
@@ -696,9 +686,8 @@ BIP151Connection::BIP151Connection(
 //      outDir - Boolean indicating if the message is outgoing or incoming.
 // OUT: None
 // RET: -1 if unsuccessful, 0 if successful.
-const int BIP151Connection::processEncinit(const uint8_t* inMsg,
-                                           const size_t& inMsgSize,
-                                           const bool outDir)
+int BIP151Connection::processEncinit(const uint8_t* inMsg,
+   const size_t& inMsgSize, const bool outDir)
 {
    
    int retVal = -1;
@@ -752,9 +741,8 @@ const int BIP151Connection::processEncinit(const uint8_t* inMsg,
 //      outDir - Boolean indicating if the message is outgoing or incoming.
 // OUT: None
 // RET: -1 if unsuccessful, 0 if successful.
-const int BIP151Connection::processEncack(const uint8_t* inMsg,
-                                          const size_t& inMsgSize,
-                                          const bool outDir)
+int BIP151Connection::processEncack(const uint8_t* inMsg,
+   const size_t& inMsgSize, const bool outDir)
 {
    int retVal = -1;
    if(inMsgSize != BIP151PUBKEYSIZE)
@@ -831,10 +819,8 @@ const int BIP151Connection::processEncack(const uint8_t* inMsg,
 // OUT: cipherData - The encrypted buffer. Must be 16 bytes larger than the
 //                   plaintext buffer.
 // RET: -1 if failure, 0 if success.
-const int BIP151Connection::assemblePacket(const uint8_t* plainData,
-                                           const size_t& plainSize,
-                                           uint8_t* cipherData,
-                                           const size_t& cipherSize)
+int BIP151Connection::assemblePacket(const uint8_t* plainData,
+   const size_t& plainSize, uint8_t* cipherData, const size_t& cipherSize)
 {
    int retVal = -1;
 
@@ -858,10 +844,8 @@ const int BIP151Connection::assemblePacket(const uint8_t* plainData,
 //                  than the ciphertext buffer.
 // RET: -1 if failure, 0 if success. If the decrypted length is bigger than
 // than the potential max clear text size, return the decrypted length instead
-const int BIP151Connection::decryptPacket(const uint8_t* cipherData,
-                                          const size_t& cipherSize,
-                                          uint8_t* plainData,
-                                          const size_t& plainSize)
+int BIP151Connection::decryptPacket(const uint8_t* cipherData,
+   const size_t& cipherSize, uint8_t* plainData, const size_t& plainSize)
 {
    int result = inSes_.decPayload(cipherData, cipherSize, plainData, plainSize);
    if (result != 0)
@@ -877,9 +861,8 @@ const int BIP151Connection::decryptPacket(const uint8_t* cipherData,
 //      inCipher - The cipher type to get.
 // OUT: encinitBuf - The data to go into an encinit messsage.
 // RET: -1 if not successful, 0 if successful.
-const int BIP151Connection::getEncinitData(uint8_t* encinitBuf,
-                                           const size_t& encinitBufSize,
-                                           const BIP151SymCiphers& inCipher)
+int BIP151Connection::getEncinitData(uint8_t* encinitBuf,
+   const size_t& encinitBufSize, const BIP151SymCiphers& inCipher)
 {
    outSes_.setEncinitSeen();
    return outSes_.getEncinitData(encinitBuf, encinitBufSize, inCipher);
@@ -891,8 +874,8 @@ const int BIP151Connection::getEncinitData(uint8_t* encinitBuf,
 // IN:  encackBufSize - encack data buffer size. Must be >=33 bytes.
 // OUT: encackBuf - The data to go into an encack messsage.
 // RET: -1 if not successful, 0 if successful.
-const int BIP151Connection::getEncackData(uint8_t* encackBuf,
-                                          const size_t& encackBufSize)
+int BIP151Connection::getEncackData(uint8_t* encackBuf,
+   const size_t& encackBufSize)
 {
    inSes_.setEncackSeen();
    int retVal = inSes_.getEncackData(encackBuf, encackBufSize);
@@ -906,8 +889,8 @@ const int BIP151Connection::getEncackData(uint8_t* encackBuf,
 //                   be >=64 bytes.
 // OUT: encackMsg - The data to go into the encack rekey messsage.
 // RET: -1 if failure, 0 if successful.
-const int BIP151Connection::bip151RekeyConn(uint8_t* encackBuf,
-                                            const size_t& encackSize)
+int BIP151Connection::bip151RekeyConn(uint8_t* encackBuf,
+   const size_t& encackSize)
 {
    assert(encackSize >= 64);
 
@@ -958,9 +941,8 @@ const uint8_t* BIP151Connection::getSessionID(const bool& dirIsOut)
 // OUT: None
 // RET: -1 if unsuccessful (code setup), 0 if successful, 1 if unsuccessful
 //      (bad hash).
-const int BIP151Connection::processAuthchallenge(const uint8_t* inMsg,
-                                                 const size_t& inMsgSize,
-                                                 const bool& requesterSent)
+int BIP151Connection::processAuthchallenge(const uint8_t* inMsg,
+   const size_t& inMsgSize, const bool& requesterSent)
 {
    int retVal = -1;
    if(inMsgSize != BIP151PRVKEYSIZE)
@@ -983,10 +965,9 @@ const int BIP151Connection::processAuthchallenge(const uint8_t* inMsg,
 // RET: -1 if unsuccessful, 0 if successful.
 // RET: -1 if unsuccessful (code setup), 0 if successful, 1 if unsuccessful
 //      (bad signature).
-const int BIP151Connection::processAuthreply(const uint8_t* inMsg,
-                                             const size_t& inMsgSize,
-                                             const bool& requesterSent,
-                                             const bool& goodChallenge)
+int BIP151Connection::processAuthreply(const uint8_t* inMsg,
+   const size_t& inMsgSize, const bool& requesterSent,
+   const bool& goodChallenge)
 {
    int retVal = -1;
    if(inMsgSize != BIP151PRVKEYSIZE*2)
@@ -1007,8 +988,8 @@ const int BIP151Connection::processAuthreply(const uint8_t* inMsg,
 // OUT: None
 // RET: -1 if unsuccessful (code setup), 0 if successful, 1 if unsuccessful
 //      (bad hash).
-const int BIP151Connection::processAuthpropose(const uint8_t* inMsg,
-                                               const size_t& inMsgSize)
+int BIP151Connection::processAuthpropose(const uint8_t* inMsg,
+   const size_t& inMsgSize)
 {
    int retVal = -1;
    if(inMsgSize != BIP151PRVKEYSIZE)
@@ -1036,11 +1017,9 @@ const int BIP151Connection::processAuthpropose(const uint8_t* inMsg,
 //                    if the responder is getting AUTHCHALLENGE data.
 // OUT: authchallengeBuffer - The buffer with the authchallenge data.
 // RET: -1 if failure, 0 if success, 1 if AUTHPROPOSE validation was a failure.
-const int BIP151Connection::getAuthchallengeData(uint8_t* authchallengeBuf,
-                                                 const size_t& authchallengeBufSize,
-                                                 const std::string& targetIPPort,
-                                                 const bool& requesterSent,
-                                                 const bool& goodPropose)
+int BIP151Connection::getAuthchallengeData(uint8_t* authchallengeBuf,
+   const size_t& authchallengeBufSize, const std::string& targetIPPort,
+   const bool& requesterSent, const bool& goodPropose)
 {
    return bip150SM_.getAuthchallengeData(authchallengeBuf,
                                          authchallengeBufSize,
@@ -1057,10 +1036,9 @@ const int BIP151Connection::getAuthchallengeData(uint8_t* authchallengeBuf,
 //      goodChallenge - Indicates if AUTHCHALLENGE was validated.
 // OUT: authreplyBuffer - The buffer with the authreply data.
 // RET: -1 if failure, 0 if success, 1 if AUTHREPLY validation was a failure.
-const int BIP151Connection::getAuthreplyData(uint8_t* authreplyBuf,
-                                             const size_t& authreplyBufSize,
-                                             const bool& responderSent,
-                                             const bool& goodChallenge)
+int BIP151Connection::getAuthreplyData(uint8_t* authreplyBuf,
+   const size_t& authreplyBufSize, const bool& responderSent,
+   const bool& goodChallenge)
 {
    return bip150SM_.getAuthreplyData(authreplyBuf,
                                      authreplyBufSize,
@@ -1073,8 +1051,8 @@ const int BIP151Connection::getAuthreplyData(uint8_t* authreplyBuf,
 // IN:  authproposeBufferSize - The size of the output buffer.
 // OUT: authproposeBuffer - The buffer with the authpropose data.
 // RET: -1 if failure, 0 if success
-const int BIP151Connection::getAuthproposeData(uint8_t* authproposeBuf,
-                                               const size_t& authproposeBufSize)
+int BIP151Connection::getAuthproposeData(uint8_t* authproposeBuf,
+   const size_t& authproposeBufSize)
 {
    return bip150SM_.getAuthproposeData(authproposeBuf,
                                        authproposeBufSize);
@@ -1086,8 +1064,7 @@ const int BIP151Connection::getAuthproposeData(uint8_t* authproposeBuf,
 //                   be >=48 bytes.
 // OUT: encackMsg - The data to go into the encack rekey messsage.
 // RET: -1 if failure, 0 if successful.
-const int BIP151Connection::getRekeyBuf(uint8_t* encackBuf,
-                                        const size_t& encackSize)
+int BIP151Connection::getRekeyBuf(uint8_t* encackBuf, const size_t& encackSize)
 {
    int retVal = -1;
 
@@ -1124,8 +1101,8 @@ void BIP151Connection::bip150HandshakeRekey()
 //      name - the ip:port or domain name
 // OUT: None
 // RET: true if the key/name pair matches, otherwise false
-bool BIP151Connection::havePublicKey(
-   const BinaryDataRef& pubkey, const std::string& name) const
+bool BIP151Connection::havePublicKey(const BinaryDataRef& pubkey,
+   const std::string& name) const
 {
    return bip150SM_.havePublicKey(pubkey, name);
 }
@@ -1146,8 +1123,7 @@ BIP151Message::BIP151Message() {}
 //      inPayloadSize - The payload size.
 // OUT: None
 // RET: None
-BIP151Message::BIP151Message(uint8_t* plaintextData,
-                             uint32_t plaintextDataSize)
+BIP151Message::BIP151Message(uint8_t* plaintextData, uint32_t plaintextDataSize)
 {
    setEncStruct(plaintextData, plaintextDataSize);
 }
@@ -1161,10 +1137,8 @@ BIP151Message::BIP151Message(uint8_t* plaintextData,
 //      inPayloadSize - The payload size.
 // OUT: None
 // RET: None
-BIP151Message::BIP151Message(const uint8_t* inCmd,
-                             const size_t& inCmdSize,
-                             const uint8_t* inPayload,
-                             const size_t& inPayloadSize)
+BIP151Message::BIP151Message(const uint8_t* inCmd, const size_t& inCmdSize,
+   const uint8_t* inPayload, const size_t& inPayloadSize)
 {
    setEncStructData(inCmd, inCmdSize, inPayload, inPayloadSize);
 }
@@ -1179,9 +1153,8 @@ BIP151Message::BIP151Message(const uint8_t* inCmd,
 // OUT: None
 // RET: None
 void BIP151Message::setEncStructData(const uint8_t* inCmd,
-                                     const size_t& inCmdSize,
-                                     const uint8_t* inPayload,
-                                     const size_t& inPayloadSize)
+   const size_t& inCmdSize, const uint8_t* inPayload,
+   const size_t& inPayloadSize)
 {
    cmd_.copyFrom(inCmd, inCmdSize);
    payload_.copyFrom(inPayload, inPayloadSize);
@@ -1194,8 +1167,8 @@ void BIP151Message::setEncStructData(const uint8_t* inCmd,
 //      plaintextDataSize - The size of the decrypted message payload.
 // OUT: None
 // RET: -1 if failure, 0 if success
-const int BIP151Message::setEncStruct(uint8_t* plaintextData,
-                                      const uint32_t& plaintextDataSize)
+int BIP151Message::setEncStruct(uint8_t* plaintextData,
+   const uint32_t& plaintextDataSize)
 {
    int retVal = -1;
    BinaryReader inData(plaintextData, plaintextDataSize);
@@ -1227,8 +1200,7 @@ const int BIP151Message::setEncStruct(uint8_t* plaintextData,
 //      finalStructSize - The final size of the written struct.
 // RET: None
 void BIP151Message::getEncStructMsg(uint8_t* outStruct,
-                                    const size_t& outStructSize,
-                                    size_t& finalStructSize)
+   const size_t& outStructSize, size_t& finalStructSize)
 {
    assert(outStructSize >= messageSizeHint());
 
@@ -1256,8 +1228,7 @@ void BIP151Message::getEncStructMsg(uint8_t* outStruct,
 //                   be >=48 bytes.
 // OUT: encackMsg - The data to go into the encack rekey messsage.
 // RET: None
-void BIP151Message::getCmd(uint8_t* cmdBuf,
-                           const size_t& cmdBufSize)
+void BIP151Message::getCmd(uint8_t* cmdBuf, const size_t& cmdBufSize)
 {
    assert(cmd_.getSize() <= cmdBufSize);
    std::copy(cmd_.getPtr(), cmd_.getPtr() + cmd_.getSize(), cmdBuf);
@@ -1270,7 +1241,7 @@ void BIP151Message::getCmd(uint8_t* cmdBuf,
 // OUT: encackMsg - The data to go into the encack rekey messsage.
 // RET: None
 void BIP151Message::getPayload(uint8_t* payloadBuf,
-                               const size_t& payloadBufSize)
+   const size_t& payloadBufSize)
 {
    assert(payload_.getSize() <= payloadBufSize);
    std::copy(payload_.getPtr(), payload_.getPtr() + payload_.getSize(),
@@ -1284,7 +1255,7 @@ void BIP151Message::getPayload(uint8_t* payloadBuf,
 // IN:  None
 // OUT: None
 // RET: The maximum possible size for the struct.
-const size_t BIP151Message::messageSizeHint()
+size_t BIP151Message::messageSizeHint()
 {
    // Hint: Operand order is the same order as what's found in the struct.
    return 4 + BtcUtils::calcVarIntSize(cmd_.getSize()) + cmd_.getSize() + 4 + \
@@ -1315,9 +1286,8 @@ void startupBIP150CTX(const uint32_t& ipVer, bool publicRequester)
 //      outgoingSes - 151 connection's outgoing session.
 // OUT: None
 // RET: N/A
-BIP150StateMachine::BIP150StateMachine(
-   BIP151Session* incomingSes, BIP151Session* outgoingSes,
-   AuthPeersLambdas& authkeys) :
+BIP150StateMachine::BIP150StateMachine(BIP151Session* incomingSes,
+   BIP151Session* outgoingSes, AuthPeersLambdas& authkeys) :
    curState_(BIP150State::INACTIVE), inSes_(incomingSes), outSes_(outgoingSes),
    authKeys_(authkeys)
 {}
@@ -1339,11 +1309,9 @@ BIP150StateMachine::BIP150StateMachine(
 // OUT: buf - The data to go into an AUTHCHALLENGE messsage.
 // RET: -1 if not successful, 0 if successful, 1 if AUTHPROPOSE validation was
 //      a failure.
-const int BIP150StateMachine::getAuthchallengeData(uint8_t* buf,
-                                                   const size_t& bufSize,
-                                                   const std::string& targetIPPort,
-                                                   const bool& requesterSent,
-                                                   const bool& goodPropose)
+int BIP150StateMachine::getAuthchallengeData(uint8_t* buf,
+   const size_t& bufSize, const std::string& targetIPPort,
+   const bool& requesterSent, const bool& goodPropose)
 {
    int retVal = -1;
    BIP151Session* checkSes;
@@ -1443,10 +1411,8 @@ const int BIP150StateMachine::getAuthchallengeData(uint8_t* buf,
 // OUT: buf - The data to go into an AUTHREPLY messsage.
 // RET: -1 if not successful, 0 if successful, 1 if AUTHCHALLENGE validation
 //      was a failure.
-const int BIP150StateMachine::getAuthreplyData(uint8_t* buf,
-                                               const size_t& bufSize,
-                                               const bool& responderSent,
-                                               const bool& goodChallenge)
+int BIP150StateMachine::getAuthreplyData(uint8_t* buf, const size_t& bufSize,
+   const bool& responderSent, const bool& goodChallenge)
 {
    int retVal = -1;
    if(responderSent == true)
@@ -1543,8 +1509,7 @@ const int BIP150StateMachine::getAuthreplyData(uint8_t* buf,
 // IN:  bufSize - AUTHPROPOSE data buffer size. Must be >=32 bytes.
 // OUT: buf - The data to go into an AUTHPROPOSE messsage.
 // RET: -1 if not successful, 0 if successful.
-const int BIP150StateMachine::getAuthproposeData(uint8_t* buf,
-                                                 const size_t& bufSize)
+int BIP150StateMachine::getAuthproposeData(uint8_t* buf, const size_t& bufSize)
 {
    int retVal = -1;
 
@@ -1591,8 +1556,8 @@ const int BIP150StateMachine::getAuthproposeData(uint8_t* buf,
 // OUT: None
 // RET: -1 if unsuccessful (bad code setup), 0 if successful, 1 if unsuccessful
 //      (unable to verify hash).
-const int BIP150StateMachine::processAuthchallenge(const BinaryData& inData,
-                                                   const bool& requesterSent)
+int BIP150StateMachine::processAuthchallenge(const BinaryData& inData,
+   const bool& requesterSent)
 {
    int retVal = -1;
    assert(inData.getSize() == BIP151PRVKEYSIZE);
@@ -1654,9 +1619,8 @@ const int BIP150StateMachine::processAuthchallenge(const BinaryData& inData,
 // OUT: None
 // RET: -1 if unsuccessful (bad code setup), 0 if successful, 1 if unsuccessful
 //      (unable to verify signature).
-const int BIP150StateMachine::processAuthreply(BinaryData& inData,
-                                               const bool& responderSent,
-                                               const bool& goodChallenge)
+int BIP150StateMachine::processAuthreply(BinaryData& inData,
+   const bool& responderSent, const bool& goodChallenge)
 {
    int retVal = -1;
    assert(inData.getSize() == BIP151PRVKEYSIZE*2);
@@ -1739,7 +1703,7 @@ const int BIP150StateMachine::processAuthreply(BinaryData& inData,
 // OUT: None
 // RET: -1 if unsuccessful (bad code setup), 0 if successful, 1 if unsuccessful
 //      (unable to verify signature).
-const int BIP150StateMachine::processAuthpropose(const BinaryData& inData)
+int BIP150StateMachine::processAuthpropose(const BinaryData& inData)
 {
    int retVal = -1;
    assert(inData.getSize() == BIP151PRVKEYSIZE);
@@ -1804,7 +1768,7 @@ const int BIP150StateMachine::processAuthpropose(const BinaryData& inData)
 // IN:  None
 // OUT: None
 // RET: A string with the fingerprint.
-const std::string BIP150StateMachine::getBIP150Fingerprint()
+std::string BIP150StateMachine::getBIP150Fingerprint()
 {
    // Hash the ID pub key.
    uint256 hashStep1;
@@ -1837,9 +1801,8 @@ const std::string BIP150StateMachine::getBIP150Fingerprint()
 //                     receiver (false).
 // OUT: outHash - The resultant hash. Must be >= 32 bytes.
 // RET: -1 if not successful, 0 if successful.
-const int BIP150StateMachine::buildHashData(uint8_t* outHash,
-                                            const uint8_t* pubKey,
-                                            const bool& willSendHash)
+int BIP150StateMachine::buildHashData(uint8_t* outHash, const uint8_t* pubKey,
+   const bool& willSendHash)
 {
    int retVal = -1;
 
@@ -1908,7 +1871,7 @@ void BIP150StateMachine::resetSM()
 // IN:  None
 // OUT: outVal - The error state value to return.
 // RET: None
-const int BIP150StateMachine::errorSM(const int& outVal)
+int BIP150StateMachine::errorSM(const int& outVal)
 {
    curState_ = BIP150State::ERR_STATE;
    std::memset(chosenAuthPeerKey.pubkey, 0, BIP151PUBKEYSIZE);

--- a/cppForSwig/BIP150_151.h
+++ b/cppForSwig/BIP150_151.h
@@ -129,9 +129,9 @@ private:
 
    void calcChaCha20Poly1305Keys(const btc_key& sesECDHKey);
    void calcSessionID(const btc_key& sesECDHKey);
-   const int verifyCipherType();
+   int verifyCipherType();
    void gettempECDHPubKey(btc_pubkey* tempECDHPubKey);
-   const int genSymKeys(const uint8_t* peerECDHPubKey);
+   int genSymKeys(const uint8_t* peerECDHPubKey);
    void chacha20Poly1305Rekey(
       uint8_t* keyToUpdate, const size_t& keySize,
       const bool& bip151Rekey,
@@ -145,52 +145,47 @@ public:
    // Constructor manually setting the ECDH setup prv key. USE WITH CAUTION.
    BIP151Session(btc_key* inSymECDHPrivKey, const bool& sessOut);
    // Set up the symmetric keys needed for the session.
-   const int symKeySetup(const uint8_t* peerPubKey,
-                         const size_t& peerKeyPubSize);
+   int symKeySetup(const uint8_t* peerPubKey, const size_t& peerKeyPubSize);
    void sessionRekey(const bool& bip151Rekey,
-                     const uint8_t* reqIDKey,
-                     const size_t& reqIDKeySize,
-                     const uint8_t* resIDKey,
-                     const size_t& resIDKeySize,
-                     const uint8_t* oppositeSessionKey,
-                     const size_t& oppositeSessionKeySize);
+      const uint8_t* reqIDKey, const size_t& reqIDKeySize,
+      const uint8_t* resIDKey, const size_t& resIDKeySize,
+      const uint8_t* oppositeSessionKey, const size_t& oppositeSessionKeySize);
    // "Smart" ciphertype set. Checks to make sure it's valid.
-   const int setCipherType(const BIP151SymCiphers& inCipher);
+   int setCipherType(const BIP151SymCiphers& inCipher);
    void setEncinitSeen() { encinit_ = true; }
    void setEncackSeen() { encack_ = true; }
-   const bool encinitSeen() const { return encinit_; }
-   const bool encackSeen() const { return encack_; }
+   bool encinitSeen() const { return encinit_; }
+   bool encackSeen() const { return encack_; }
    const uint8_t* getSessionID() const { return sessionID_.data(); }
-   const std::string getSessionIDHex() const;
-   const bool handshakeComplete() const { return (encinit_ == true && \
-                                                  encack_ == true); }
-   const uint32_t getBytesOnCurKeys() const { return bytesOnCurKeys_; }
+   std::string getSessionIDHex() const;
+   bool handshakeComplete() const {
+      return (encinit_ == true && encack_ == true);
+   }
+   uint32_t getBytesOnCurKeys() const { return bytesOnCurKeys_; }
    void setOutgoing() { isOutgoing_ = true; }
-   const bool getOutgoing() const { return isOutgoing_; }
-   const bool getSeqNum() const { return seqNum_; }
-   const BIP151SymCiphers getCipherType() const { return cipherType_; }
-   const int inMsgIsRekey(const uint8_t* inMsg, const size_t& inMsgSize);
-   const bool rekeyNeeded(const size_t& sz) const;
+   bool getOutgoing() const { return isOutgoing_; }
+   bool getSeqNum() const { return seqNum_; }
+   BIP151SymCiphers getCipherType() const { return cipherType_; }
+   int inMsgIsRekey(const uint8_t* inMsg, const size_t& inMsgSize);
+   bool rekeyNeeded(const size_t& sz) const;
    void addBytes(const uint32_t& sentBytes) { bytesOnCurKeys_ += sentBytes; }
-   const int getEncinitData(uint8_t* initBuffer,
-                            const size_t& initBufferSize,
-                            const BIP151SymCiphers& inCipher);
-   const int getEncackData(uint8_t* ackBuffer, const size_t& ackBufferSize);
-   const bool isCipherValid(const BIP151SymCiphers& inCipher);
+   int getEncinitData(uint8_t* initBuffer, const size_t& initBufferSize,
+      const BIP151SymCiphers& inCipher);
+   int getEncackData(uint8_t* ackBuffer, const size_t& ackBufferSize);
+   bool isCipherValid(const BIP151SymCiphers& inCipher);
    void incSeqNum() { ++seqNum_; };
    chachapolyaead_ctx* getSessionCtxPtr() { return &sessionCTX_; };
-   const int encPayload(uint8_t* cipherData, const size_t cipherSize,
-                        const uint8_t* plainData, const size_t plainSize);
-   const int decPayload(const uint8_t* cipherData, const size_t cipherSize,
-                        uint8_t* plainData, const size_t plainSize);
+   int encPayload(uint8_t* cipherData, const size_t cipherSize,
+      const uint8_t* plainData, const size_t plainSize);
+   int decPayload(const uint8_t* cipherData, const size_t cipherSize,
+      uint8_t* plainData, const size_t plainSize);
 };
 
 class BIP150StateMachine
 {
 private:
-   const int buildHashData(uint8_t* outHash,
-                           const uint8_t* pubKey,
-                           const bool& willSendHash);
+   int buildHashData(uint8_t* outHash, const uint8_t* pubKey,
+      const bool& willSendHash);
    inline void resetSM();
 
    // Design note: There will be only one pub/prv ID key for the system. Making
@@ -206,28 +201,23 @@ private:
    AuthPeersLambdas authKeys_;
 
 public:
-   BIP150StateMachine(
-      BIP151Session* incomingSes, BIP151Session* outgoingSes, AuthPeersLambdas&);
+   BIP150StateMachine(BIP151Session* incomingSes, BIP151Session* outgoingSes,
+      AuthPeersLambdas& authkeys);
 
-   const int processAuthchallenge(const BinaryData& inData,
-                                  const bool& requesterSent);
-   const int processAuthreply(BinaryData& inData,
-                              const bool& responderSent,
-                              const bool& goodChallenge);
-   const int processAuthpropose(const BinaryData& inData);
-   const int getAuthchallengeData(uint8_t* buf,
-                                  const size_t& bufSize,
-                                  const std::string& targetIPPort,
-                                  const bool& requesterSent,
-                                  const bool& goodPropose);
-   const int getAuthreplyData(uint8_t* buf,
-                              const size_t& bufSize,
-                              const bool& responderSent,
-                              const bool& goodChallenge);
-   const int getAuthproposeData(uint8_t* buf, const size_t& bufSize);
-   const std::string getBIP150Fingerprint();
-   const BIP150State getBIP150State() const { return curState_; }
-   const int errorSM(const int& outVal);
+   int processAuthchallenge(const BinaryData& inData,
+      const bool& requesterSent);
+   int processAuthreply(BinaryData& inData, const bool& responderSent,
+      const bool& goodChallenge);
+   int processAuthpropose(const BinaryData& inData);
+   int getAuthchallengeData(uint8_t* buf, const size_t& bufSize,
+      const std::string& targetIPPort, const bool& requesterSent,
+      const bool& goodPropose);
+   int getAuthreplyData(uint8_t* buf, const size_t& bufSize,
+      const bool& responderSent, const bool& goodChallenge);
+   int getAuthproposeData(uint8_t* buf, const size_t& bufSize);
+   std::string getBIP150Fingerprint();
+   BIP150State getBIP150State() const { return curState_; }
+   int errorSM(const int& outVal);
    void rekey(void);
 //   const void clearErrorState() { curState_ = BIP150State::INACTIVE; }
    BinaryDataRef getOwnPubKey(void) const;
@@ -241,7 +231,7 @@ private:
    BIP151Session outSes_;
    BIP150StateMachine bip150SM_;
 
-   const int getRekeyBuf(uint8_t* encackBuf, const size_t& encackSize);
+   int getRekeyBuf(uint8_t* encackBuf, const size_t& encackSize);
    bool goodPropose_ = false;
 
 public:
@@ -249,46 +239,44 @@ public:
    BIP151Connection(AuthPeersLambdas&);
 
    // Constructor manually setting the ECDH setup prv keys. USE WITH CAUTION.
-   BIP151Connection(
-      btc_key* inSymECDHPrivKeyIn, btc_key* inSymECDHPrivKeyOut, AuthPeersLambdas&);
+   BIP151Connection(btc_key* inSymECDHPrivKeyIn, btc_key* inSymECDHPrivKeyOut,
+      AuthPeersLambdas& authkeys);
 
-   const int assemblePacket(const uint8_t* plainData, const size_t& plainSize,
-                            uint8_t* cipherData, const size_t& cipherSize);
-   const int decryptPacket(const uint8_t* cipherData, const size_t& cipherSize,
-                           uint8_t* plainData, const size_t& plainSize);
-   const int processEncinit(const uint8_t* inMsg, const size_t& inMsgSize,
-                            const bool outDir);
-   const int processEncack(const uint8_t* inMsg, const size_t& inMsgSize,
-                           const bool outDir);
-   const int getEncinitData(uint8_t* encinitBuf, const size_t& encinitBufSize,
-                            const BIP151SymCiphers& inCipher);
-   const int getEncackData(uint8_t* encackBuf, const size_t& encBufSize);
-   const bool rekeyNeeded(const size_t& sz) { return outSes_.rekeyNeeded(sz); }
-   const int bip151RekeyConn(uint8_t* encackBuf, const size_t& encackSize);
+   int assemblePacket(const uint8_t* plainData, const size_t& plainSize,
+      uint8_t* cipherData, const size_t& cipherSize);
+   int decryptPacket(const uint8_t* cipherData, const size_t& cipherSize,
+      uint8_t* plainData, const size_t& plainSize);
+   int processEncinit(const uint8_t* inMsg, const size_t& inMsgSize,
+      const bool outDir);
+   int processEncack(const uint8_t* inMsg, const size_t& inMsgSize,
+      const bool outDir);
+   int getEncinitData(uint8_t* encinitBuf, const size_t& encinitBufSize,
+      const BIP151SymCiphers& inCipher);
+   int getEncackData(uint8_t* encackBuf, const size_t& encBufSize);
+   bool rekeyNeeded(const size_t& sz) { return outSes_.rekeyNeeded(sz); }
+   int bip151RekeyConn(uint8_t* encackBuf, const size_t& encackSize);
    void rekeyOuterSession(void) { outSes_.sessionRekey(true, nullptr, 0, nullptr, 0, nullptr, 0); }
    const uint8_t* getSessionID(const bool& dirIsOut);
-   const bool connectionComplete() const { return(inSes_.handshakeComplete() == true &&
-                                                  outSes_.handshakeComplete() == true); }
+   bool connectionComplete() const {
+      return(inSes_.handshakeComplete() == true &&
+         outSes_.handshakeComplete() == true);
+   }
 
    // BIP 150-related calls.
-   const int processAuthchallenge(const uint8_t* inMsg, const size_t& inMsgSize,
-                                  const bool& requesterSent);
-   const int processAuthreply(const uint8_t* inMsg, const size_t& inMsgSize,
-                              const bool& requesterSent, const bool& goodChallenge);
-   const int processAuthpropose(const uint8_t* inMsg, const size_t& inMsgSize);
-   const int getAuthchallengeData(uint8_t* authchallengeBuf,
-                                  const size_t& authchallengeBufSize,
-                                  const std::string& targetIPPort,
-                                  const bool& requesterSent,
-                                  const bool& goodPropose);
-   const int getAuthreplyData(uint8_t* authreplyBuf,
-                              const size_t& authreplyBufSize,
-                              const bool& responderSent,
-                              const bool& goodChallenge);
-   const int getAuthproposeData(uint8_t* authproposeBuf,
-                                const size_t& authproposeBufSize);
-   const BIP150State getBIP150State() const { return bip150SM_.getBIP150State(); }
-   const std::string getBIP150Fingerprint() { return bip150SM_.getBIP150Fingerprint(); }
+   int processAuthchallenge(const uint8_t* inMsg, const size_t& inMsgSize,
+      const bool& requesterSent);
+   int processAuthreply(const uint8_t* inMsg, const size_t& inMsgSize,
+      const bool& requesterSent, const bool& goodChallenge);
+   int processAuthpropose(const uint8_t* inMsg, const size_t& inMsgSize);
+   int getAuthchallengeData(uint8_t* authchallengeBuf,
+      const size_t& authchallengeBufSize, const std::string& targetIPPort,
+      const bool& requesterSent, const bool& goodPropose);
+   int getAuthreplyData(uint8_t* authreplyBuf, const size_t& authreplyBufSize,
+      const bool& responderSent, const bool& goodChallenge);
+   int getAuthproposeData(uint8_t* authproposeBuf,
+      const size_t& authproposeBufSize);
+   BIP150State getBIP150State() const { return bip150SM_.getBIP150State(); }
+   std::string getBIP150Fingerprint() { return bip150SM_.getBIP150Fingerprint(); }
 
    void bip150HandshakeRekey(void);
    void setGoodPropose(void) { goodPropose_ = true; }
@@ -309,19 +297,18 @@ public:
    BIP151Message();
    BIP151Message(uint8_t* plaintextData, uint32_t plaintextDataSize);
    BIP151Message(const uint8_t* inCmd, const size_t& inCmdSize,
-                 const uint8_t* inPayload, const size_t& inPayloadSize);
+      const uint8_t* inPayload, const size_t& inPayloadSize);
    void setEncStructData(const uint8_t* inCmd, const size_t& inCmdSize,
-                         const uint8_t* inPayload, const size_t& inPayloadSize);
-   const int setEncStruct(uint8_t* plaintextData,
-                          const uint32_t& plaintextDataSize);
+      const uint8_t* inPayload, const size_t& inPayloadSize);
+   int setEncStruct(uint8_t* plaintextData, const uint32_t& plaintextDataSize);
    void getEncStructMsg(uint8_t* outStruct, const size_t& outStructSize,
-                        size_t& finalStructSize);
+      size_t& finalStructSize);
    void getCmd(uint8_t* cmdBuf, const size_t& cmdBufSize);
-   const size_t getCmdSize() const { return cmd_.getSize(); }
+   size_t getCmdSize() const { return cmd_.getSize(); }
    const uint8_t* getCmdPtr() const { return cmd_.getPtr(); }
    void getPayload(uint8_t* payloadBuf, const size_t& payloadBufSize);
-   const size_t getPayloadSize() const { return payload_.getSize(); }
+   size_t getPayloadSize() const { return payload_.getSize(); }
    const uint8_t* getPayloadPtr() const { return payload_.getPtr(); }
-   const size_t messageSizeHint();
+   size_t messageSizeHint();
 };
 #endif // BIP150_151_H


### PR DESCRIPTION
On clang, there are a lot of warnings. Clean up the warnings and make the code a bit more readable.