### PR TITLE
Update dpkgfiles to support building raspberry pi armhf .deb

### DIFF
--- a/dpkgfiles/controlarmhf
+++ b/dpkgfiles/controlarmhf
@@ -1,0 +1,17 @@
+Source: armory
+Section: net
+Priority: extra
+Maintainer: goatpig <moothecowlord@gmail.com>
+Build-Depends: python (>= 2.6), debhelper (>= 7), pyqt4-dev-tools, swig, libqtcore4, libqt4-dev, python-qt4, python-dev, python-psutil, hardening-wrapper
+Standards-Version: 3.8.3
+
+Package: armory
+Architecture: armhf
+Depends: python (>= 2.6), python-qt4, python-psutil, xdg-utils
+Description: Advanced Bitcoin Wallet Management Software
+ Armory is advanced program for managing multiple Bitcoin wallets with the 
+ highest level of security available.  Use top-of-the-line wallet encryption,
+ print permanent paper backups of your wallets, and store your Bitcoins on 
+ an offline computer for maximum security from online threats.  Armory is 
+ open-source software, partially licensed under the AGPLv3 license and partially 
+ under the MIT license. 

--- a/dpkgfiles/controlarmhf
+++ b/dpkgfiles/controlarmhf
@@ -2,7 +2,7 @@ Source: armory
 Section: net
 Priority: extra
 Maintainer: goatpig <moothecowlord@gmail.com>
-Build-Depends: python (>= 2.6), debhelper (>= 7), pyqt4-dev-tools, swig, libqtcore4, libqt4-dev, python-qt4, python-dev, python-psutil, hardening-wrapper
+Build-Depends: python (>= 2.6), debhelper (>= 7), pyqt4-dev-tools, swig, libqtcore4, libqt4-dev, python-qt4, python-dev, python-psutil
 Standards-Version: 3.8.3
 
 Package: armory

--- a/dpkgfiles/make_deb_package.py
+++ b/dpkgfiles/make_deb_package.py
@@ -110,11 +110,8 @@ for f in dpkgfiles:
 
 # Finally, all the magic happens here
 if args.cross:
-   print 'Attempting armhf cross compile for Raspberry Pi'
-   # We need these build options to stop dpkg/configure testing for options that gcc <4.9 (e.g. raspbian toolchain) doesn't support, and then failing
-   # Requires hardening-wrapper package to work too.
-   deb_build_options = 'hardening=-stackprotectorstrong reproducible=-timeless'
-   execAndWait('export PATH="$PATH:%s" DEB_BUILD_OPTIONS="%s" CROSS_COMPILING="armhf" EXTRA_PYTHON="%s"; dpkg-buildpackage -t arm-linux-gnueabihf -d -rfakeroot -uc -us %s' % (args.toolchain, deb_build_options, args.extrapython, jobParam))
+   print 'Attempting armhf cross compile for Raspberry Pi' 
+   execAndWait('export PATH="$PATH:%s" CROSS_COMPILING="armhf" EXTRA_PYTHON="%s"; dpkg-buildpackage -t arm-linux-gnueabihf -d -rfakeroot -uc -us %s' % (args.toolchain, args.extrapython, jobParam))
 else:
    print 'Attempting normal build for debian'
    execAndWait('dpkg-buildpackage -rfakeroot -uc -us %s' % jobParam)

--- a/dpkgfiles/rules
+++ b/dpkgfiles/rules
@@ -10,9 +10,24 @@
 #export DH_VERBOSE=1
 
 %:
-	dh $@
+	dh $@ --with autoreconf --parallel
 
 override_dh_auto_test:
 
 override_dh_usrlocal:
 
+ifeq ($(CROSS_COMPILING), armhf)
+override_dh_autoreconf:
+	dh_autoreconf ./autogen.sh
+
+override_dh_auto_build:
+	dh_auto_build -- EXTRA_PYTHON_INCLUDES=-I$(EXTRA_PYTHON)
+
+override_dh_auto_install:
+	dh_auto_install -- EXTRA_PYTHON_INCLUDES=-I$(EXTRA_PYTHON)
+
+# We'd need to require install of multiarch packages for this to work when cross compiling.
+override_dh_makeshlibs override_dh_shlibdeps:
+
+endif
+	

--- a/dpkgfiles/rules
+++ b/dpkgfiles/rules
@@ -9,12 +9,17 @@
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
 
+ifeq ($(CROSS_COMPILING), armhf)
+# RPi's toolchain (gcc <4.9) can't handle these flags, so strip them. Stops failure in configure stage.
+export DEB_CFLAGS_MAINT_STRIP=-fstack-protector-strong
+export DEB_CXXFLAGS_MAINT_STRIP=-fstack-protector-strong
+export DEB_CPPFLAGS_MAINT_STRIP=-Wdate-time
+endif
+
 %:
 	dh $@ --with autoreconf --parallel
 
-override_dh_auto_test:
-
-override_dh_usrlocal:
+override_dh_auto_test override_dh_usrlocal:
 
 ifeq ($(CROSS_COMPILING), armhf)
 override_dh_autoreconf:

--- a/dpkgfiles/rules
+++ b/dpkgfiles/rules
@@ -10,10 +10,12 @@
 #export DH_VERBOSE=1
 
 ifeq ($(CROSS_COMPILING), armhf)
-# RPi's toolchain (gcc <4.9) can't handle these flags, so strip them. Stops failure in configure stage.
+ifeq ($(OLDGCC), 1)
+# Common RPi toolchain (gcc <4.9) can't handle these flags, so strip them. Stops failure in configure stage.
 export DEB_CFLAGS_MAINT_STRIP=-fstack-protector-strong
 export DEB_CXXFLAGS_MAINT_STRIP=-fstack-protector-strong
 export DEB_CPPFLAGS_MAINT_STRIP=-Wdate-time
+endif
 endif
 
 %:


### PR DESCRIPTION
~~Requires new build dependency "hardening-wrapper" when making armhf debian package with RPi toolchain.
If I have time I'll see if I can get it to play nice with different build option variables and without hardening-wrapper. Normal builds should run fine without it at least.~~ 
**hardening-wrapper is gone!** :heavy_check_mark: 
Tested with debhelper v9 compat rules in effect. It'd be nice to set that but would in theory need to increase the debhelper dependency version to match.

My python is pretty scrappy at best but improvements welcomed all over.

Normal use of  ```dpkgfiles/make_deb_package.py``` is retained as is.
Raspberry Pi builds are enabled by running
```
dpkgfiles/make_deb_package.py --cross=armhf \ 
--toolchain-path=/home/armory/RPi/tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin \
--extra-python-includes=/home/armory/RPi/usr/include
```
(Short flags available)
Substitute paths for toolchain and the extrapython path for real ones. Validates enough to know if a directory exists but it is not smart enough to know if the directory actually contains the files needed.

I have yet to test the packaged deb files on real hardware, but compiles completed fine to the best of my knowledge.