### PR TITLE
Allow override of BIP 150 public mode flag

### DIFF
--- a/cppForSwig/AsyncClient.cpp
+++ b/cppForSwig/AsyncClient.cpp
@@ -73,11 +73,12 @@ void BlockDataViewer::addPublicKey(const SecureBinaryData& pubkey)
 ///////////////////////////////////////////////////////////////////////////////
 shared_ptr<BlockDataViewer> BlockDataViewer::getNewBDV(const string& addr,
    const string& port, const string& datadir, const bool& ephemeralPeers,
+   const bool& overrideBIP150VerMode, const bool& newBIP150VerMode,
    shared_ptr<RemoteCallback> callbackPtr)
 {
    //create socket object
    auto sockptr = make_shared<WebSocketClient>(addr, port, datadir,
-      ephemeralPeers, callbackPtr);
+      ephemeralPeers, overrideBIP150VerMode, newBIP150VerMode, callbackPtr);
 
    //instantiate bdv object
    BlockDataViewer* bdvPtr = new BlockDataViewer(sockptr);

--- a/cppForSwig/AsyncClient.h
+++ b/cppForSwig/AsyncClient.h
@@ -308,6 +308,7 @@ namespace AsyncClient
       static std::shared_ptr<BlockDataViewer> getNewBDV(
          const std::string& addr, const std::string& port,
          const std::string& datadir, const bool& ephemeralPeers,
+         const bool& overrideBIP150VerMode, const bool& newBIP150VerMode,
          std::shared_ptr<RemoteCallback> callbackPtr);
 
       void getLedgerDelegateForWallets(

--- a/cppForSwig/BIP150_151.h
+++ b/cppForSwig/BIP150_151.h
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 //                                                                            //
-//  Copyright (C) 2018, goatpig                                               //
+//  Copyright (C) 2018-2019, goatpig                                          //
 //  Distributed under the MIT license                                         //
 //  See LICENSE-MIT or https://opensource.org/licenses/MIT                    //
 //                                                                            //
@@ -61,6 +61,8 @@ extern "C" {
 #define BIP151PUBKEYSIZE 33
 #define ENCINITMSGSIZE 34
 
+extern bool publicRequester;
+
 // Match against BIP 151 spec, although "INVALID" is our addition.
 enum class BIP151SymCiphers : uint8_t {CHACHA20POLY1305_OPENSSH = 0x00,
                                        INVALID};
@@ -86,8 +88,9 @@ enum class BIP150State : uint8_t {INACTIVE = 0x00,
 void startupBIP151CTX();
 void shutdownBIP151CTX();
 
-// Global function used to load up the key DBs. CALL AFTER BIP 151 IS INITIALIZED.
-void startupBIP150CTX(const uint32_t& ipVer, bool publicRequester);
+// Global function used to load up the key DBs. Takes the IP version and a flag
+// indicating if verification is done only by the client (false by default).
+void startupBIP150CTX(const uint32_t& ipVer, const bool& pubReq = false);
 
 struct AuthPeersLambdas
 {
@@ -197,12 +200,13 @@ private:
    BIP151Session* outSes_;
    btc_pubkey chosenAuthPeerKey;
    btc_pubkey chosenChallengeKey;
+   bool usePublicRequester_;
 
    AuthPeersLambdas authKeys_;
 
 public:
    BIP150StateMachine(BIP151Session* incomingSes, BIP151Session* outgoingSes,
-      AuthPeersLambdas& authkeys);
+      AuthPeersLambdas& authkeys, const bool& publicRequester = false);
 
    int processAuthchallenge(const BinaryData& inData,
       const bool& requesterSent);
@@ -236,11 +240,11 @@ private:
 
 public:
    // Default constructor - Used when initiating contact with a peer.
-   BIP151Connection(AuthPeersLambdas&);
+   BIP151Connection(AuthPeersLambdas&, const bool& publicRequester = false);
 
    // Constructor manually setting the ECDH setup prv keys. USE WITH CAUTION.
    BIP151Connection(btc_key* inSymECDHPrivKeyIn, btc_key* inSymECDHPrivKeyOut,
-      AuthPeersLambdas& authkeys);
+      AuthPeersLambdas& authkeys, const bool& publicRequester = false);
 
    int assemblePacket(const uint8_t* plainData, const size_t& plainSize,
       uint8_t* cipherData, const size_t& cipherSize);

--- a/cppForSwig/ClientClasses.cpp
+++ b/cppForSwig/ClientClasses.cpp
@@ -19,7 +19,7 @@ using namespace ::Codec_BDVCommand;
 ///////////////////////////////////////////////////////////////////////////////
 void ClientClasses::initLibrary()
 {
-   startupBIP150CTX(4, false);
+   startupBIP150CTX(4);
    startupBIP151CTX();
    btc_ecc_start();
 }

--- a/cppForSwig/Server.cpp
+++ b/cppForSwig/Server.cpp
@@ -31,6 +31,13 @@ WebSocketServer::WebSocketServer()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+WebSocketServer::WebSocketServer(const bool& bip150AuthMode) :
+   bip150AuthMode_(bip150AuthMode)
+{
+   clients_ = make_shared<Clients>();
+}
+
+///////////////////////////////////////////////////////////////////////////////
 static struct lws_protocols protocols[] = {
    /* first protocol must always be HTTP handler */
 
@@ -615,7 +622,8 @@ shared_ptr<map<uint64_t, ClientConnection>>
 void WebSocketServer::addId(const uint64_t& id, struct lws* ptr)
 {
    auto&& lbds = getAuthPeerLambda();
-   auto&& write_pair = make_pair(id, ClientConnection(ptr, id, lbds));
+   auto&& write_pair = make_pair(id, ClientConnection(ptr, id, lbds,
+      bip150AuthMode_));
    clientStateMap_.insert(move(write_pair));
 }
 

--- a/cppForSwig/Server.h
+++ b/cppForSwig/Server.h
@@ -104,10 +104,11 @@ private:
    void processAEADHandshake(BinaryData);
 
 public:
-   ClientConnection(struct lws *wsi, uint64_t id, AuthPeersLambdas& lbds) :
-      wsiPtr_(wsi), id_(id)
+   ClientConnection(struct lws *wsi, uint64_t id, AuthPeersLambdas& lbds,
+      const bool& bip150AuthMode) : wsiPtr_(wsi), id_(id)
    {
-      bip151Connection_ = std::make_shared<BIP151Connection>(lbds);
+      bip151Connection_ = std::make_shared<BIP151Connection>(lbds,
+         bip150AuthMode);
 
       writeLock_ = std::make_shared<std::atomic<unsigned>>();
       writeLock_->store(0);
@@ -151,6 +152,7 @@ private:
    BlockingQueue<uint64_t> clientConnectionInterruptQueue_;
 
    std::shared_ptr<AuthorizedPeers> authorizedPeers_;
+   const bool bip150AuthMode_ = ::publicRequester;
 
 private:
    void webSocketService(int port);
@@ -165,7 +167,8 @@ private:
    void clientInterruptThread(void);
 
 public:
-   WebSocketServer(void);
+   WebSocketServer();
+   WebSocketServer(const bool& bip150AuthMode);
 
    static int callback(
       struct lws *wsi, enum lws_callback_reasons reason,

--- a/cppForSwig/SwigClient.cpp
+++ b/cppForSwig/SwigClient.cpp
@@ -48,7 +48,7 @@ shared_ptr<BlockDataViewer> BlockDataViewer::getNewBDV(const string& addr,
    shared_ptr<RemoteCallback> callbackPtr)
 {
    auto&& bdvAsync = AsyncClient::BlockDataViewer::getNewBDV(addr, port,
-      datadir, ephemeralPeers, callbackPtr);
+      datadir, ephemeralPeers, false, false, callbackPtr);
    auto bdvPtr = new BlockDataViewer(*bdvAsync);
    shared_ptr<BlockDataViewer> bdvSharedPtr;
    bdvSharedPtr.reset(bdvPtr);

--- a/cppForSwig/SwigClient.h
+++ b/cppForSwig/SwigClient.h
@@ -36,7 +36,7 @@ namespace SwigClient
    inline void DisableCppLogStdOut() { LOGDISABLESTDOUT(); }
    inline void EnableBIP150(const uint32_t& ipVer)
    {
-      startupBIP150CTX(ipVer, false);
+      startupBIP150CTX(ipVer);
    }
    inline void EnableBIP151() { startupBIP151CTX(); }
    inline void DisableBIP151() { shutdownBIP151CTX(); }

--- a/cppForSwig/WebSocketClient.cpp
+++ b/cppForSwig/WebSocketClient.cpp
@@ -27,6 +27,7 @@ static struct lws_protocols protocols[] = {
 ////////////////////////////////////////////////////////////////////////////////
 WebSocketClient::WebSocketClient(const string& addr, const string& port,
    const string& datadir, const bool& ephemeralPeers,
+   const bool& overrideBIP150AuthMode, const bool& newBIP150AuthMode,
    shared_ptr<RemoteCallback> cbPtr) :
    SocketPrototype(addr, port, false), callbackPtr_(cbPtr)
 {
@@ -44,8 +45,14 @@ WebSocketClient::WebSocketClient(const string& addr, const string& port,
       authPeers_ = make_shared<AuthorizedPeers>();
    }
 
+   // We may wish to override the global BIP 150 authentication mode setting.
    auto lbds = getAuthPeerLambda();
-   bip151Connection_ = make_shared<BIP151Connection>(lbds);
+   bool bip150AuthMode = ::publicRequester;
+   if (overrideBIP150AuthMode)
+   {
+      bip150AuthMode = newBIP150AuthMode;
+   }
+   bip151Connection_ = make_shared<BIP151Connection>(lbds, bip150AuthMode);
 }
 
 

--- a/cppForSwig/WebSocketClient.h
+++ b/cppForSwig/WebSocketClient.h
@@ -145,6 +145,7 @@ private:
 public:
    WebSocketClient(const std::string& addr, const std::string& port,
       const std::string& datadir, const bool& ephemeralPeers,
+      const bool& overrideBIP150AuthMode, const bool& newBIP150AuthMode,
       std::shared_ptr<RemoteCallback> cbPtr);
 
    ~WebSocketClient()

--- a/cppForSwig/gtest/BIP151RekeyTest.cpp
+++ b/cppForSwig/gtest/BIP151RekeyTest.cpp
@@ -36,10 +36,6 @@ protected:
 ////////////////////////////////////////////////////////////////////////////////
 TEST_F(BIP151RekeyTest, rekeyRequired)
 {
-   // Run before the first test has been run. (SetUp/TearDown will be called
-   // for each test. Context startup/shutdown multiple times leads to crashes.)
-   startupBIP151CTX();
-
    // BIP 151 connection uses private keys we feed it. (Normally, we'd let it
    // generate its own private keys.)
    auto getpubkeymap = [](void)->const std::map<std::string, btc_pubkey>&
@@ -206,14 +202,18 @@ GTEST_API_ int main(int argc, char **argv)
    STARTLOGGING("cppTestsLog.txt", LogLvlDebug2);
    //LOGDISABLESTDOUT();
 
-   // Required by libbtc.
-   btc_ecc_start();
+   btc_ecc_start(); // Required by libbtc.
+   // Run before the first test has been run. (SetUp/TearDown will be called
+   // for each test. Context startup/shutdown multiple times leads to crashes.)
+   startupBIP151CTX();
+   startupBIP150CTX(4);
 
    testing::InitGoogleTest(&argc, argv);
    int exitCode = RUN_ALL_TESTS();
 
    FLUSHLOG();
    CLEANUPLOG();
+   shutdownBIP151CTX();
 
    return exitCode;
 }

--- a/cppForSwig/gtest/CppBlockUtilsTests.cpp
+++ b/cppForSwig/gtest/CppBlockUtilsTests.cpp
@@ -237,7 +237,7 @@ TEST_F(BIP150_151Test, checkData_151_Only)
    // Run before the first test has been run. (SetUp/TearDown will be called
    // for each test. Multiple context startups/shutdowns leads to crashes.)
    startupBIP151CTX();
-   startupBIP150CTX(4, false);
+   startupBIP150CTX(4);
 
    // BIP 151 connection uses private keys we feed it. (Normally, we'd let it
    // generate its own private keys.)
@@ -608,7 +608,7 @@ TEST_F(BIP150_151Test, checkData_150_151)
    AuthPeersLambdas aklCli(cli_getPubKeyMap, cli_getPrivKey, cli_getauthset);
 
 
-   startupBIP150CTX(4, false);
+   startupBIP150CTX(4);
 
    btc_key prvKeyCliIn;
    btc_key prvKeyCliOut;
@@ -10196,7 +10196,7 @@ protected:
       LB2ID = BinaryData(TestChain::lb2B58ID);
 
       startupBIP151CTX();
-      startupBIP150CTX(4, false);
+      startupBIP150CTX(4);
 
       //setup auth peers for server and client
       AuthorizedPeers serverPeers(homedir_, SERVER_AUTH_PEER_FILENAME);

--- a/cppForSwig/gtest/SupernodeTests.cpp
+++ b/cppForSwig/gtest/SupernodeTests.cpp
@@ -3140,7 +3140,7 @@ TEST_F(WebSocketTests, WebSocketStack_ParallelAsync)
       auto pCallback = make_shared<DBTestUtils::UTCallback>();
       auto&& bdvObj = SwigClient::BlockDataViewer::getNewBDV(
          "127.0.0.1", config.listenPort_,  BlockDataManagerConfig::getDataDir(),
-         BlockDataManagerConfig::ephemeralPeers_,pCallback);
+         BlockDataManagerConfig::ephemeralPeers_, pCallback);
       bdvObj->addPublicKey(serverPubkey);
       bdvObj->connectToRemote();
       bdvObj->registerWithDB(NetworkConfig::getMagicBytes());
@@ -3174,7 +3174,7 @@ TEST_F(WebSocketTests, WebSocketStack_ParallelAsync)
       auto pCallback = make_shared<DBTestUtils::UTCallback>();
       auto bdvObj = AsyncClient::BlockDataViewer::getNewBDV(
          "127.0.0.1", config.listenPort_,  BlockDataManagerConfig::getDataDir(),
-         BlockDataManagerConfig::ephemeralPeers_,pCallback);
+         BlockDataManagerConfig::ephemeralPeers_, false, false, pCallback);
       bdvObj->addPublicKey(serverPubkey);
       bdvObj->connectToRemote();
       bdvObj->registerWithDB(NetworkConfig::getMagicBytes());
@@ -3538,7 +3538,7 @@ TEST_F(WebSocketTests, WebSocketStack_ZcUpdate)
    auto pCallback = make_shared<DBTestUtils::UTCallback>();
    auto bdvObj = AsyncClient::BlockDataViewer::getNewBDV(
       "127.0.0.1", config.listenPort_, BlockDataManagerConfig::getDataDir(),
-      BlockDataManagerConfig::ephemeralPeers_, pCallback);
+      BlockDataManagerConfig::ephemeralPeers_, false, false, pCallback);
    bdvObj->connectToRemote();
    bdvObj->registerWithDB(NetworkConfig::getMagicBytes());
 
@@ -3760,7 +3760,7 @@ TEST_F(WebSocketTests, WebSocketStack_ParallelAsync_ManyLargeWallets)
       auto pCallback = make_shared<DBTestUtils::UTCallback>();
       auto&& bdvObj = AsyncClient::BlockDataViewer::getNewBDV(
          "127.0.0.1", config.listenPort_, BlockDataManagerConfig::getDataDir(),
-         BlockDataManagerConfig::ephemeralPeers_, pCallback);
+         BlockDataManagerConfig::ephemeralPeers_, false, false, pCallback);
       bdvObj->addPublicKey(serverPubkey);
       bdvObj->connectToRemote();
       bdvObj->registerWithDB(NetworkConfig::getMagicBytes());

--- a/cppForSwig/main.cpp
+++ b/cppForSwig/main.cpp
@@ -21,7 +21,7 @@ int main(int argc, char* argv[])
 {
    btc_ecc_start();
    startupBIP151CTX();
-   startupBIP150CTX(4, false);
+   startupBIP150CTX(4);
 
    GOOGLE_PROTOBUF_VERIFY_VERSION;
 


### PR DESCRIPTION
The code relies on a global flag to determine if BIP 150 will operate in public mode (1-way auth). There are cases where code may not have access to the global flag. Adjust the code to allow for overriding the state in BIP 150/151 state machines.

Note that this affects both client and server connections.