### PR TITLE
Fix off-by-one error on fees selection

### DIFF
--- a/cppForSwig/nodeRPC.cpp
+++ b/cppForSwig/nodeRPC.cpp
@@ -323,7 +323,10 @@ FeeEstimateResult NodeRPC::getFeeByte(
    if (iterStrat == estimateCachePtr->end())
       throw RpcError();
 
-   auto targetIter = iterStrat->second.lower_bound(confTarget);
+   if (iterStrat->second.empty())
+      throw RpcError();
+
+   auto targetIter = iterStrat->second.upper_bound(confTarget);
    if (targetIter != iterStrat->second.begin())
       --targetIter;
 


### PR DESCRIPTION
`NodeRPC::getFeeByte` has off-by-one error when exact block count is queried. So, for example, when fees for 4 block queried result for 2 blocks is returned. Switching from `lower_bound` to `upper_bound` fixes the problem.