### PR TITLE
Add more fees selection periods

### DIFF
--- a/cppForSwig/nodeRPC.cpp
+++ b/cppForSwig/nodeRPC.cpp
@@ -348,9 +348,9 @@ map<unsigned, FeeEstimateResult> NodeRPC::getFeeSchedule(const string& strategy)
 ////////////////////////////////////////////////////////////////////////////////
 void NodeRPC::aggregateFeeEstimates()
 {
-   //get fee/byte for 2-3-4-5-6-10-20 confs on both strategies
-   static vector<unsigned> confTargets = { 2, 3, 4, 5, 6, 10, 20 };
-   static vector<string> strategies = { 
+   //get fee/byte on both strategies
+   vector<unsigned> confTargets = { 2, 3, 4, 5, 6, 10, 12, 20, 24, 48, 144 };
+   static vector<string> strategies = {
       FEE_STRAT_CONSERVATIVE, FEE_STRAT_ECONOMICAL };
 
    HttpSocket sock("127.0.0.1", bdmConfig_.rpcPort_);


### PR DESCRIPTION
BlockSettle Terminal now uses this periods for fees selection: 2, 4, 6, 12, 24, 48, 144.
If we will add this periods, fees selection will work more correctly when Terminal connects to upstream ArmoryDB builds.