### PR TITLE
fix for spentness callback data lifetime

### DIFF
--- a/cppForSwig/AsyncClient.h
+++ b/cppForSwig/AsyncClient.h
@@ -901,7 +901,7 @@ public:
 struct CallbackReturn_SpentnessData : public CallbackReturn_WebSocket
 {
 private:
-   const std::map<BinaryData, std::set<unsigned>>& outputs_;
+   const std::map<BinaryData, std::set<unsigned>> outputs_;
 
    std::function<void(
    ReturnMessage<std::map<BinaryData, std::map<unsigned, BinaryData>>>)>


### PR DESCRIPTION
Using const ref as a class member is not a good idea, as it will be destroyed once original data for it will get out of scope.