### PR TITLE
Fix crash in WebSocketClient

### DIFF
--- a/cppForSwig/WebSocketClient.cpp
+++ b/cppForSwig/WebSocketClient.cpp
@@ -207,25 +207,25 @@ bool WebSocketClient::connectToRemote()
 
    auto serviceLBD = [this](void)->void
    {
+      auto readLBD = [this](void)->void
+      {
+         this->readService();
+      };
+
+      readThr_ = thread(readLBD);
+
+      auto writeLBD = [this](void)->void
+      {
+         this->writeService();
+      };
+
+      writeThr_ = thread(writeLBD);
+
       auto contextPtr = init();
       this->service(contextPtr);
    };
 
    serviceThr_ = thread(serviceLBD);
-
-   auto readLBD = [this](void)->void
-   {
-      this->readService();
-   };
-
-   readThr_ = thread(readLBD);
-
-   auto writeLBD = [this](void)->void
-   {
-      this->writeService();
-   };
-
-   writeThr_ = thread(writeLBD);
 
    return connectedFut.get();
 }


### PR DESCRIPTION
WebSocketClient sometimes crashes for in `WebSocketClient::~WebSocketClient` when ArmoryDB disconnects (and `writeThr_` is not joined).
I think there is some kine of race here as we start and try to stop `writeThr_` in different threads (and perhaps `writeThr_.joinable` returns `false` because of this).
With this change it works fine (start and stop `writeThr_` and `readThr_` in same thread):