### PR TITLE
Avoid infinite loop at data corruption

### DIFF
--- a/cppForSwig/WalletFileInterface.cpp
+++ b/cppForSwig/WalletFileInterface.cpp
@@ -199,6 +199,10 @@ void DBInterface::loadAllEntries(const SecureBinaryData& rootKey)
 
          //dbkeys should be consecutive integers, mark gaps
          int dbKeyInt = READ_UINT32_BE(key_bdr);
+         if (dbKeyInt < 0) {     // dbKey can unlikely be >2^31, so this looks like
+            throw WalletInterfaceException("invalid dbkey");   // data corruption
+         }
+
          if (dbKeyInt - prevDbKey != 1)
          {
             for (unsigned i = prevDbKey + 1; i < dbKeyInt; i++)


### PR DESCRIPTION
This fix addresses the "real world" (tm) situation when some corrupted file may lead to [almost] infinite loop and unbound memory consumption when inserting many entries to the `gaps` set in the loop below (which also employs signed/unsigned comparison).