### PR TITLE
Fix passwords input

### DIFF
--- a/cppForSwig/TerminalPassphrasePrompt.cpp
+++ b/cppForSwig/TerminalPassphrasePrompt.cpp
@@ -54,16 +54,26 @@ SecureBinaryData TerminalPassphrasePrompt::promptNewPass()
         cout << "Enter new password: ";
 
         setEcho(false);
-        cin >> pass1;
+        std::getline(cin, pass1);
         setEcho(true);
         cout << endl;
+
+        if (cin.fail()) {
+           cerr << "Can't read password...";
+           std::exit(1);
+        }
 
         cout << "Repeat new password: ";
 
         setEcho(false);
-        cin >> pass2;
+        std::getline(cin, pass2);
         setEcho(true);
         cout << endl;
+
+        if (cin.fail()) {
+           cerr << "Can't read password...";
+           std::exit(1);
+        }
 
         if (pass1 != pass2)
         {
@@ -80,6 +90,11 @@ SecureBinaryData TerminalPassphrasePrompt::promptNewPass()
                 string yn;
                 cout << "Do you wish to continue (Y/n)? ";
                 cin >> yn;
+
+                if (cin.fail()) {
+                   cerr << "Can't read answer...";
+                   std::exit(1);
+                }
 
                 if (yn == "n")
                 {


### PR DESCRIPTION
Fix:
- Can't enter empty password
- Can't enter password with spaces
- Infinity loop if started without available cin (when started from systemd for example):
```
Do you wish to continue (Y/n)? Do you wish to continue (Y/n)? Do you wish to continue (Y/n)? Do you wish to continue (Y/n)? Do you wish to continue (Y/n)? Do you wis
h to continue (Y/n)? Do you wish to continue (Y/n)? Do you wish to continue (Y/n)? Do you wish to continue (Y/n)? Do you wish to continue (Y/n)? Do you wish to continue (Y/n)? Do you wish to cont
inue (Y/n)? Do you wish to continue (Y/n)? Do you wish to continue (Y/n)? Do you wish to continue (Y/n)? Do you wish to continue (Y/n)? Do you wish to continue (Y/n)? Do you wish to continue (Y/n
...
```