### PR TITLE
Try to fix crash in lws_callback_on_writable

### DIFF
--- a/cppForSwig/Server.cpp
+++ b/cppForSwig/Server.cpp
@@ -107,6 +107,12 @@ int WebSocketServer::callback(
       instance->clients_->unregisterBDV(bdr.toHexStr());
       instance->eraseId(session_data->id_, wsi);
 
+      if (instance->pendingWritesIter_ != instance->pendingWrites_.end() && *instance->pendingWritesIter_ == wsi) {
+         instance->pendingWrites_.erase(instance->pendingWritesIter_++);
+      } else {
+         instance->pendingWrites_.erase(wsi);
+      }
+
       break;
    }
 


### PR DESCRIPTION
When client disconnects `pendingWritesIter_` and `pendingWrites_` should be cleared up too.