### PR TITLE
Try to fix LMDB readers leak (`MDB_READERS_FULL` error)

### DIFF
--- a/cppForSwig/lmdb_wrapper.cpp
+++ b/cppForSwig/lmdb_wrapper.cpp
@@ -3030,7 +3030,7 @@ void DBPair::open(const string& path, const string& dbName)
    if (isOpen())
       return;
    
-   unsigned flags = MDB_NOSYNC;
+   unsigned flags = MDB_NOSYNC | MDB_NOTLS;
 
    env_.open(path, flags);
    auto map_size = env_.getMapSize();


### PR DESCRIPTION
Long running process leaks LMDB readers in thread local storage and ArmoryDB crashes after some time (`mdb_txn_begin` fails with `MDB_READERS_FULL: Environment maxreaders limit reached` error).
Looks like `MDB_NOTLS` flag fixes the problem (no crashes for more than 9 days so far and debug log shows that there usually 0..2 allocated readers, before that the amount of allocated readers increased steadily). I have not noticed any performance difference when that flag is enabled (tested with `time` on linux for same load).