### PR TITLE
restore fixed size socket buffer behavior with windows compatible send()

### DIFF
--- a/armoryengine/CppBridge.py
+++ b/armoryengine/CppBridge.py
@@ -112,15 +112,16 @@ class CppBridge(object):
 
    #############################################################################
    def readBridgeSocket(self):
-      while self.run is True:
 
-         response = bytearray()
+      response = bytearray()
+
+      while self.run is True:
 
          #wait for data on the socket
          try:
-            response += self.clientSocket.recv(4)
+            response += self.clientSocket.recv(4096)
             if len(response) < 4:
-               break
+               continue
          except socket.error as e:
             err = e.args[0]
             if err == errno.EAGAIN or err == errno.EWOULDBLOCK:
@@ -139,7 +140,7 @@ class CppBridge(object):
          #grab full packet
          while len(response) < packetLen + 4:
             try:
-               packet = self.clientSocket.recv(packetLen)
+               packet = self.clientSocket.recv(4096)
                response += packet
                if len(response) < packetLen + 4:
                   continue
@@ -185,6 +186,9 @@ class CppBridge(object):
 
          elif replyObj != None and replyObj[0] != None:
             replyObj[0](response[8:], replyObj[1])
+
+         #clear the response buffer only once we receive a full payload
+         response = bytearray()
         
    #############################################################################
    def pushNotification(self, data):

--- a/cppForSwig/CppBridge.cpp
+++ b/cppForSwig/CppBridge.cpp
@@ -2049,7 +2049,7 @@ void WritePayload_Bridge::serialize(std::vector<uint8_t>& data)
    if (message_ == nullptr)
       return;
 
-   data.resize(message_->ByteSize() + 8);
+   data.resize(message_->ByteSizeLong() + 8);
 
    //set packet size
    auto sizePtr = (uint32_t*)&data[0];
@@ -2119,7 +2119,7 @@ void BridgeCallback::run(BdmNotification notif)
             cppLedgerToProtoLedger(protoLe, *le);
          }
 
-         vector<uint8_t> payloadVec(payload.ByteSize());
+         vector<uint8_t> payloadVec(payload.ByteSizeLong());
          payload.SerializeToArray(&payloadVec[0], payloadVec.size());
 
          auto msg = make_unique<CppBridgeCallback>();
@@ -2169,7 +2169,7 @@ void BridgeCallback::run(BdmNotification notif)
          //notify node status
          BridgeNodeStatus nodeStatusMsg;
          cppNodeStatusToProtoNodeStatus(&nodeStatusMsg, *notif.nodeStatus_);
-         vector<uint8_t> serializedNodeStatus(nodeStatusMsg.ByteSize());
+         vector<uint8_t> serializedNodeStatus(nodeStatusMsg.ByteSizeLong());
          nodeStatusMsg.SerializeToArray(
             &serializedNodeStatus[0], serializedNodeStatus.size());
          

--- a/cppForSwig/CppBridge.h
+++ b/cppForSwig/CppBridge.h
@@ -28,7 +28,7 @@ struct WritePayload_Bridge : public Socket_WritePayload
 
    size_t getSerializedSize(void) const 
    {
-      return message_->ByteSize() + 8;
+      return message_->ByteSizeLong() + 8;
    }
 };
 

--- a/cppForSwig/Server.cpp
+++ b/cppForSwig/Server.cpp
@@ -547,7 +547,7 @@ void WebSocketServer::prepareWriteThread()
          bool needs_rekey = false;
          auto rightnow = chrono::system_clock::now();
 
-         if (statePtr->bip151Connection_->rekeyNeeded(msg->message_->ByteSize()))
+         if (statePtr->bip151Connection_->rekeyNeeded(msg->message_->ByteSizeLong()))
          {
             needs_rekey = true;
          }
@@ -584,9 +584,9 @@ void WebSocketServer::prepareWriteThread()
 
       //serialize arg
       vector<uint8_t> serializedData;
-      if (msg->message_->ByteSize() > 0)
+      if (msg->message_->ByteSizeLong() > 0)
       {
-         serializedData.resize(msg->message_->ByteSize());
+         serializedData.resize(msg->message_->ByteSizeLong());
          auto result = msg->message_->SerializeToArray(
             &serializedData[0], serializedData.size());
          if (!result)

--- a/cppForSwig/SocketWritePayload.h
+++ b/cppForSwig/SocketWritePayload.h
@@ -20,7 +20,7 @@ struct WritePayload_Protobuf : public Socket_WritePayload
    void serialize(std::vector<uint8_t>&);
    std::string serializeToText(void);
    size_t getSerializedSize(void) const {
-      return message_->ByteSize();
+      return message_->ByteSizeLong();
    }
 };
 

--- a/cppForSwig/WebSocketClient.cpp
+++ b/cppForSwig/WebSocketClient.cpp
@@ -281,7 +281,7 @@ void WebSocketClient::cleanUp()
    errMsg.set_code(-1);
    errMsg.set_errstr("LWS client disconnected");
 
-   BinaryData errPacket(errMsg.ByteSize());
+   BinaryData errPacket(errMsg.ByteSizeLong());
    if (!errMsg.SerializeToArray(
       errPacket.getPtr(), errPacket.getSize()))
    {

--- a/cppForSwig/gtest/TestUtils.cpp
+++ b/cppForSwig/gtest/TestUtils.cpp
@@ -751,7 +751,7 @@ namespace DBTestUtils
    shared_ptr<::google::protobuf::Message> processCommand(
       Clients* clients, shared_ptr<::google::protobuf::Message> msg)
    {
-      auto len = msg->ByteSize();
+      auto len = msg->ByteSizeLong();
       vector<uint8_t> buffer(len);
       msg->SerializeToArray(&buffer[0], len);
       auto&& bdVec = WebSocketMessageCodec::serialize(


### PR DESCRIPTION
This restores the behavior reverted in #631 for non-windows systems