### PR TITLE
[Trivial] Include correct header for std::runtime_error

### DIFF
--- a/cppForSwig/SocketIncludes.h
+++ b/cppForSwig/SocketIncludes.h
@@ -9,7 +9,7 @@
 #ifndef _H_SOCKET_INCLUDES
 #define _H_SOCKET_INCLUDES
 
-#include <exception>
+#include <stdexcept>
 #include <string>
 
 #ifdef _WIN32


### PR DESCRIPTION
std::runtime_error is declared in \<stdexcept\> not in \<exception\>
g++ 10.2.0 fails with an error without this change