### PR TITLE
Update cppBridge.py to use capnp instead of protobuf

### DIFF
--- a/ArmoryQt.py
+++ b/ArmoryQt.py
@@ -1165,7 +1165,8 @@ class ArmoryMainWindow(QtWidgets.QMainWindow):
 
       source3 = bytes()
       try:
-         pixDesk = QtGui.QPixmap.grabWindow(QtWidgets.QApplication.desktop().winId())
+         screen = QtWidgets.QApplication.primaryScreen()
+         pixDesk = screen.grabWindow(QtWidgets.QApplication.desktop().winId())
          pixRaw = QtCore.QByteArray()
          pixBuf = QtCore.QBuffer(pixRaw)
          pixBuf.open(QtCore.QIODevice.WriteOnly)

--- a/armoryengine/CppBridge.py
+++ b/armoryengine/CppBridge.py
@@ -12,7 +12,7 @@ import os
 import errno
 import socket
 from armoryengine import BridgeProto_pb2
-from armoryengine.ArmoryUtils import LOGDEBUG, LOGERROR, LOGWARN, hash256
+from armoryengine.ArmoryUtils import LOGDEBUG, LOGERROR, hash256
 from armoryengine.BinaryPacker import BinaryPacker, \
    UINT32, UINT8, BINARY_CHUNK, VAR_INT
 from struct import unpack
@@ -172,8 +172,6 @@ class BridgeSocket(object):
    ####
    def sendToBridgeProto(self, msg, needsReply: bool,
       callbackFunc, callbackArgs, msgType):
-
-      print("="*10 + "\n", msg, "\n" + "="*10)
 
       msg.referenceId = self.idCounter
       self.idCounter = self.idCounter + 1

--- a/armoryengine/PyBtcWallet.py
+++ b/armoryengine/PyBtcWallet.py
@@ -528,9 +528,11 @@ class PyBtcWallet(object):
 
       LOGINFO('***Creating new deterministic wallet')
 
+      addrPoolSize = 10 if USE_TESTNET or USE_REGTEST else CLI_OPTIONS.keypool
+
       #create cpp wallet
       walletId = TheBridge.utils.createWallet(
-         self.addrPoolSize,
+         addrPoolSize,
          passphrase, "",
          #kdfTargSec, kdfMaxMem,
          shortLabel, longLabel,

--- a/ui/WalletFrames.py
+++ b/ui/WalletFrames.py
@@ -15,7 +15,7 @@ import math
 
 from armoryengine.BDM import TheBDM, BDM_BLOCKCHAIN_READY
 from qtpy import QtCore, QtGui, QtWidgets
-from qtdialogs.qtdefines import ArmoryFrame, VERTICAL, HORIZONTAL, \
+from qtdialogs.qtdefines import AdvancedOptionsFrame, ArmoryFrame, VERTICAL, HORIZONTAL, \
    tightSizeNChar, makeHorizFrame, makeVertFrame, QRichLabel, \
    QPixMapButton, GETFONT, STYLE_SUNKEN, HLINE, determineWalletType, \
    QMoneyLabel, makeLayoutFrame, createToolTipWidget


### PR DESCRIPTION
This PR includes:
* Updated methods that have been changed to use capnproto instead of protobuf
* Typehints and the `annotations` import to support typed lists