### PR TITLE
Fix JSON2 incompatibility and update build instructions on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,6 @@ _CppBlockUtils.*
 /cppForSwig/x64*
 /cppForSwig/LMDB_Win/x64*
 /cppForSwig/x64/*.*
+
+# Visual Studio cache/options directory
+.vs/

--- a/.gitignore
+++ b/.gitignore
@@ -132,6 +132,7 @@ _CppBlockUtils.*
 
 /cppForSwig/BDM_Client/build*
 /cppForSwig/BDM_Client/x64*
+/cppForSwig/BDM_Client/MSVCP90.dll
 /cppForSwig/BitcoinArmory_CppTests/x64*
 /cppForSwig/BlockDataManager/x64*
 /cppForSwig/ContainerTests/Release*

--- a/ArmorySetup.nsi
+++ b/ArmorySetup.nsi
@@ -34,7 +34,8 @@ Name "Bitcoin Armory"
 !include x64.nsh
 
 # Reserved Files
-ReserveFile "${NSISDIR}\Plugins\StartMenu.dll"
+#ReserveFile "${NSISDIR}\Plugins\StartMenu.dll"
+ReserveFile "${NSISDIR}\Plugins\x86-unicode\StartMenu.dll"
 
 # Variables
 Var StartMenuGroup
@@ -105,7 +106,7 @@ ShowUninstDetails show
 !macroend
 
 Section -Main SEC0000
-   
+
     ${If} ${RunningX64}
         # 64 bit code
         SetOutPath $INSTDIR
@@ -123,7 +124,7 @@ Section -Main SEC0000
     ${Else}
         # 32 bit code
         MessageBox MB_OK "You cannot install this version on a 32-bit system"
-    ${EndIf} 
+    ${EndIf}
 SectionEnd
 
 Section -post SEC0001
@@ -237,4 +238,3 @@ no_smgroup:
     Pop $R2
     Pop $R1
 FunctionEnd
-

--- a/cppForSwig/BDM_Client/BDM_Client.vcxproj
+++ b/cppForSwig/BDM_Client/BDM_Client.vcxproj
@@ -149,7 +149,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>..\leveldb_windows_port\win32_posix;../;../cryptopp;..\BlockDataManager\fcgi\include;C:\Python27amd64\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\leveldb_windows_port\win32_posix;../;../cryptopp;..\BlockDataManager\fcgi\include;C:\Python27\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_WINSOCKAPI_;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
@@ -157,7 +157,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>..\libs\x64;C:\Python27amd64\libs;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\libs\x64;C:\Python27\libs;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>LMDB_Win.lib;cryptopp.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PreBuildEvent>

--- a/cppForSwig/BDM_Client/build_installer_64.bat
+++ b/cppForSwig/BDM_Client/build_installer_64.bat
@@ -4,8 +4,8 @@ mkdir ..\..\ArmoryStandalone
 copy ..\Release\guardian.exe ..\..\ArmoryStandalone
 
 python ..\..\update_version.py
-copy ..\libs\x64\BDM_Client.dll ..\..\_CppBlockUtils.pyd 
-C:\Python27_64\Lib\site-packages\PyQt4\pyrcc4.exe -o ..\..\qrc_img_resources.py ..\..\imgList.xml
+copy ..\libs\x64\BDM_Client.dll ..\..\_CppBlockUtils.pyd
+C:\Python27\Lib\site-packages\PyQt4\pyrcc4.exe -o ..\..\qrc_img_resources.py ..\..\imgList.xml
 python ..\..\setup.py py2exe --includes sip,hashlib -d ..\..\ArmoryStandalone
 copy ..\x64\Release\BlockDataManager.exe ..\..\ArmoryStandalone\ArmoryDB.exe
 

--- a/cppForSwig/BitcoinArmory.sln
+++ b/cppForSwig/BitcoinArmory.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Express 2013 for Windows Desktop
-VisualStudioVersion = 12.0.40629.0
+# Visual Studio Version 17
+VisualStudioVersion = 17.13.35818.85 d17.13
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "guardian", "guardian\guardian.vcxproj", "{D35F732D-55D7-4037-9C6D-E141F740F802}"
 EndProject
@@ -23,8 +23,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "BDM_Client", "BDM_Client\BDM_Client.vcxproj", "{F7B56CDA-B8DF-4AE6-81DE-D0B3DCA226DA}"
 	ProjectSection(ProjectDependencies) = postProject
-		{D35F732D-55D7-4037-9C6D-E141F740F802} = {D35F732D-55D7-4037-9C6D-E141F740F802}
 		{2DAEB6BF-8CF7-43D5-AEA9-BF824BBC8AE4} = {2DAEB6BF-8CF7-43D5-AEA9-BF824BBC8AE4}
+		{B1055DA3-83CE-47BF-98E6-2850E3411D39} = {B1055DA3-83CE-47BF-98E6-2850E3411D39}
+		{D35F732D-55D7-4037-9C6D-E141F740F802} = {D35F732D-55D7-4037-9C6D-E141F740F802}
 	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ContainerTests", "ContainerTests\ContainerTests.vcxproj", "{BCBFED48-7330-493F-B2CA-65109046D74A}"

--- a/cppForSwig/JSON_codec.cpp
+++ b/cppForSwig/JSON_codec.cpp
@@ -396,7 +396,7 @@ bool JSON_object::isResponseValid(int id)
    auto error_obj = dynamic_pointer_cast<JSON_state>(errorVal);
 
    if (error_obj == nullptr)
-      return false;
+      return true;
 
    if (error_obj->state_ != JSON_null)
       return false;

--- a/windowsbuild/Windows_build_notes.md
+++ b/windowsbuild/Windows_build_notes.md
@@ -1,17 +1,19 @@
 # Setup MSVS 2013 Environment for building Armory in Windows
 
-### ***You must use 64-bit packages!***
+***You must use 64-bit packages!***
 
 ## List of packages needed
 
-The latest versions of all packages might be different by the time your are reading this, and it tends to be safe to use newer versions, but we know these versions work. You *must* use python 2.x and Python-Qt4, **do not** use python3.x or Python-Qt5.  
+The latest versions of all packages might be different by the time your are reading this, and it tends to be safe to use newer versions, but we know these versions work. You *must* use python 2.x and Python-Qt4, **do not** use python3.x or Python-Qt5.
 To just build the _CppBlockUtils.pyd so you can run ArmoryQt.py, you can omit py2exe and NSIS, and any steps related to them (such as making sure stuff is in your PATH).
 
-[Microsoft Visual Studio Express 2013 for Windows Desktop with Update 3](http://www.microsoft.com/en-us/download/confirmation.aspx?id=43733)
+[Microsoft Visual Studio Express 2013 for Windows Desktop with Update 3](http://www.microsoft.com/en-us/download/confirmation.aspx?id=43733)\
+VS 2013 is quite hard the get nowadays. *Visual Studio 2017 Express* or even *Visual Studio 2022 Community* with the right SDK and Platform tools works as well: [SDK version 10.0.171x](https://developer.microsoft.com/en-us/windows/downloads/sdk-archive/) + [platform tools version 141](https://stackoverflow.com/a/49653531)
 
 [SWIG 3.0.2 (Do not install! See below)](http://www.swig.org/download.html)
 
-[Python 2.7.8](https://www.python.org/downloads/release/python-278/)
+[Python 2.7.8](https://www.python.org/downloads/release/python-278/)\
+Python 2.7.18 works as well. It is the latest and final Python 2 version, which does not only include a pip version at all, but a pip version which works with modern http**s** infrastructure.
 
 [Python psutil - 2.1.3](https://pypi.python.org/pypi?:action=display&name=psutil#downloads)
 
@@ -21,26 +23,28 @@ To just build the _CppBlockUtils.pyd so you can run ArmoryQt.py, you can omit py
 
 [pywin32 - 2.19](http://sourceforge.net/projects/pywin32/files/pywin32/Build%20219/pywin32-219.win-amd64-py2.7.exe/download)
 
-[NSIS (3.0+)](http://nsis.sourceforge.net/Download)
+[NSIS (3.0+)](http://nsis.sourceforge.net/Download)\
+Also tested with version 3.10.
 
 ## Extra steps besides just installing everything
 
- - To accommodate systems with multiple versions of python, some tweaks were made to distinguish between them.
+- To accommodate systems with multiple versions of python, some tweaks were made to distinguish between them.
+   - `C:\Python27\python.exe` was copied and renamed to `C:\Python27\python64.exe`
+   - `C:\Python27_64\Lib\site-packages\PyQt4\pyrcc4.exe` is referenced by a build script even though default python installation does not have the **_64**.  Either rename the base directory or modify *BitcoinArmory/cppForSwig/BitcoinArmory_SwigDLL/build_installer_64.bat* to reference the correct path.
+- Make sure the following folders are in your PATH (environment variable):
+   - `C:\Python27\`
+  - `C:\Program Files (x86)\NSIS\`
+  - `C:\Python27_64\Lib\site-packages\PyQt4\`
+- py2exe chokes on zope because its directory does does not contain a __init__.py.  Make sure the following file exists (and is empty):
+   - `C:\Python27\Lib\site-packages\zope\__init__.py`
+- Swig is not installed like the other packages.  Unpack swig directory into *cppForSwig* and rename it to *swigwin*.  The following path should be valid:  `BitcoinArmory/cppForSwig/swigwin/swig.exe`
+- initialize the fast cgi submodule:
+  - `git submodule update --init`
+- create a copy of  `MSVCP90.dll` inside `BitcoinArmory\cppForSwig\BDM_Client\`
 
-    - `C:\Python27\python.exe` was copied and renamed to `C:\Python27\python64.exe`
+## Building the installer
 
-    - `C:\Python27_64\Lib\site-packages\PyQt4\pyrcc4.exe` is referenced by a build script even though default python installation does not have the **_64**.  Either rename the base directory or modify *BitcoinArmory/cppForSwig/BitcoinArmory_SwigDLL/build_installer_64.bat* to reference the correct path.
-
- - Make sure the following folders are in your PATH (environment variable):
-
-    - `C:\Python27\`
-    - `C:\Program Files (x86)\NSIS\`
-    - `C:\Python27_64\Lib\site-packages\PyQt4\`
-
-
- - py2exe chokes on zope because its directory does does not contain a __init__.py.  Make sure the following file exists (and is empty):
-
-    - `C:\Python27\Lib\site-packages\zope\__init__.py`
-
-
- - Swig is not installed like the other packages.  Unpack swig directory into *cppForSwig* and rename it to *swigwin*.  The following path should be valid:  `BitcoinArmory/cppForSwig/swigwin/swig.exe`
+- open the `BitcoinArmory\cppForSwig\BitcoinArmory.sln` solution file with Visual Studio
+- set the solution configuration to `Release` and `x64`
+- go to menu `Build` -> `Build Solution`
+- if no error occurs (warnings to be expected), the installer will be created as `BitcoinArmory\armory_<version>-testing_winAll.exe`


### PR DESCRIPTION
1. Apply some minor fixes to be able to build the master branch on Windows 10 in 2025.
2. Update Windows build instructions the reflect findings from previous step.
3. Finally apply one-line-fix from upstream dev to restore compatibility with core 0.28+.

Closes #720 