### PR TITLE
BIP32 Seed Phrase Backup/Restore/Create UI

### DIFF
--- a/armoryengine/CppBridge.py
+++ b/armoryengine/CppBridge.py
@@ -554,7 +554,7 @@ class BlockchainUtils(ProtoWrapper):
    #############################################################################
    def createWallet(self, addrPoolSize: int,
       shortLabel: str, longLabel: str, extraEntropy: bytes,
-      callbackId: str, successCb: callable):
+      callbackId: str, successCb: callable, walletType: str='legacy'):
       packet = Bridge.ToBridge.new_message()
 
       method = packet.init("utils").init("createWallet")
@@ -564,6 +564,19 @@ class BlockchainUtils(ProtoWrapper):
       method.description = longLabel
       if extraEntropy is not None:
          method.extraEntropy = extraEntropy
+
+      # Map string to capnp enum value
+      walletTypeEnum = Bridge.UtilsRequest.WalletType
+      if walletType == 'structuredBip32':
+         method.walletType = walletTypeEnum.structuredBip32
+      elif walletType == 'rawBip32':
+         method.walletType = walletTypeEnum.rawBip32
+      elif walletType == 'virgin':
+         method.walletType = walletTypeEnum.virgin
+      else:
+         method.walletType = walletTypeEnum.legacy
+
+      LOGINFO(f"Creating wallet with type: {walletType} -> {method.walletType}")
       self.send(packet, callback=successCb)
 
    #############################################################################
@@ -721,12 +734,14 @@ class BridgeWalletWrapper(ProtoWrapper):
       callbackFunc, passphrase, serverPushObj):
       packet = self._getPacket()
       req = packet.wallet.init("createBackupString")
-      if passphrase:
-         req.passphrase = passphrase
-      elif serverPushObj:
-         req.callbackId = serverPushObj.callbackId
+      if serverPushObj:
+         req.private = serverPushObj.callbackId
+      elif passphrase is None:
+         req.public = None
       else:
-         raise Exception("[createBackupStringForWallet] invalid args")
+         raise Exception(
+            "[createBackupStringForWallet] direct passphrase not supported, "
+            "use unlockHandler instead")
       self.send(packet, callback=callbackFunc)
 
    ####

--- a/armoryengine/PyBtcWallet.py
+++ b/armoryengine/PyBtcWallet.py
@@ -482,7 +482,8 @@ class PyBtcWallet(object):
    ## create/export
    @staticmethod
    def createNewWallet(replyCallback: callable, callbackId: str,
-      shortLabel: str='', longLabel: str='', extraEntropy: bytes=None):
+      shortLabel: str='', longLabel: str='', extraEntropy: bytes=None,
+      walletType: str='legacy'):
 
       """
       This method will create a new wallet, using as much customizability
@@ -507,6 +508,8 @@ class PyBtcWallet(object):
       We skip the atomic file operations since we don't even have
       a wallet file yet to safely update.
 
+      walletType: 'legacy', 'structuredBip32', 'rawBip32', or 'virgin'
+
       DO NOT CALL THIS FROM BDM METHOD.  IT MAY DEADLOCK.
       """
       LOGINFO('***Creating new deterministic wallet')
@@ -515,7 +518,7 @@ class PyBtcWallet(object):
       TheBridge.utils.createWallet(
          addrPoolSize,
          shortLabel, longLabel, extraEntropy,
-         callbackId, replyCallback
+         callbackId, replyCallback, walletType
       )
 
    ####
@@ -846,6 +849,21 @@ class PyBtcWallet(object):
       for instance, the wallet was just imported but has been used before.
       """
       return self.lastComputedChainIndex
+
+   ####
+   def hasAnyImported(self):
+      """
+      Returns True if wallet has any imported addresses (chainIndex < 0).
+      For BIP32/BIP39 wallets, this returns False as imported addresses
+      are not supported in the same way as legacy wallets.
+      """
+      for a160 in self.linearAddr160List:
+         if str(a160) == str('ROOT'):
+            continue
+         addr = self.addrMap.get(a160)
+         if addr is not None and addr.chainIndex < 0:
+            return True
+      return False
 
    ####
    def getWalletVersion(self):

--- a/qtdialogs/DlgBackupCenter.py
+++ b/qtdialogs/DlgBackupCenter.py
@@ -22,9 +22,7 @@ from ui.WalletFrames import WalletBackupFrame
 from ui.QrCodeMatrix import CreateQRMatrix
 from ui.QtExecuteSignal import TheSignalExecution
 
-from qtdialogs.qtdefines import makeHorizFrame, QRichLabel, \
-   makeVertFrame, QImageLabel, HLINE, GETFONT, STYLE_RAISED, tightSizeStr, \
-   setLayoutStretch, STRETCH, createToolTipWidget, MSGBOX
+import qtdialogs.qtdefines as qtdefines
 from qtdialogs.ArmoryDialog import ArmoryDialog
 from qtdialogs.DlgUnlockWallet import UnlockWalletHandler
 from qtdialogs.DlgRestore import getBackupTypeString, \
@@ -44,7 +42,7 @@ class DlgBackupCenter(ArmoryDialog):
       self.walletBackupFrame.setWallet(wlt)
       self.btnDone = QtWidgets.QPushButton(self.tr('Done'))
       self.btnDone.clicked.connect(self.reject)
-      frmBottomBtns = makeHorizFrame([STRETCH, self.btnDone])
+      frmBottomBtns = qtdefines.makeHorizFrame([qtdefines.STRETCH, self.btnDone])
 
       layoutDialog = QtWidgets.QVBoxLayout()
       layoutDialog.addWidget(self.walletBackupFrame)
@@ -60,10 +58,10 @@ class DlgSimpleBackup(ArmoryDialog):
       super(DlgSimpleBackup, self).__init__(parent, main)
       self.wlt = wlt
 
-      lblDescrTitle = QRichLabel(self.tr(
+      lblDescrTitle = qtdefines.QRichLabel(self.tr(
          '<b>Protect Your Bitcoins -- Make a Wallet Backup!</b>'))
 
-      lblDescr = QRichLabel(self.tr(
+      lblDescr = qtdefines.QRichLabel(self.tr(
          'A failed hard-drive or forgotten passphrase will lead to '
          '<u>permanent loss of bitcoins</u>!  Luckily, Armory wallets only '
          'need to be backed up <u>one time</u>, and protect you in both '
@@ -71,12 +69,12 @@ class DlgSimpleBackup(ArmoryDialog):
          'a hardware failure, make a backup!'))
 
       # ## Paper
-      lblPaper = QRichLabel(self.tr(
+      lblPaper = qtdefines.QRichLabel(self.tr(
          'Use a printer or pen-and-paper to write down your wallet "seed."'))
       btnPaper = QtWidgets.QPushButton(self.tr('Make Paper Backup'))
 
       # ## Digital
-      lblDigital = QRichLabel(self.tr(
+      lblDigital = qtdefines.QRichLabel(self.tr(
          'Create an unencrypted copy of your wallet file, including imported '
          'addresses.'))
       btnDigital = QtWidgets.QPushButton(self.tr('Make Digital Backup'))
@@ -97,33 +95,33 @@ class DlgSimpleBackup(ArmoryDialog):
          self.accept()
          DlgBackupCenter(self, self.main, self.wlt).exec_()
 
-      btnPaper.connect.clicked(backupPaper)
-      btnDigital.connect.clicked(backupDigital)
-      btnOther.connect.clicked(backupOther)
+      btnPaper.clicked.connect(backupPaper)
+      btnDigital.clicked.connect(backupDigital)
+      btnOther.clicked.connect(backupOther)
 
       layout = QtWidgets.QGridLayout()
       layout.addWidget(lblPaper, 0, 0)
       layout.addWidget(btnPaper, 0, 2)
-      layout.addWidget(HLINE(), 1, 0, 1, 3)
+      layout.addWidget(qtdefines.HLINE(), 1, 0, 1, 3)
       layout.addWidget(lblDigital, 2, 0)
       layout.addWidget(btnDigital, 2, 2)
-      layout.addWidget(HLINE(), 3, 0, 1, 3)
-      layout.addWidget(makeHorizFrame([STRETCH, btnOther, STRETCH]), 4, 0, 1, 3)
+      layout.addWidget(qtdefines.HLINE(), 3, 0, 1, 3)
+      layout.addWidget(qtdefines.makeHorizFrame([qtdefines.STRETCH, btnOther, qtdefines.STRETCH]), 4, 0, 1, 3)
       # layout.addWidget( VLINE(),      0,1, 5,1)
 
       layout.setContentsMargins(10, 5, 10, 5)
-      setLayoutStretchRows(layout, 1, 0, 1, 0, 0)
-      setLayoutStretchCols(layout, 1, 0, 0)
+      qtdefines.setLayoutStretchRows(layout, 1, 0, 1, 0, 0)
+      qtdefines.setLayoutStretchCols(layout, 1, 0, 0)
 
       frmGrid = QtWidgets.QFrame()
-      frmGrid.setFrameStyle(STYLE_PLAIN)
+      frmGrid.setFrameStyle(qtdefines.STYLE_PLAIN)
       frmGrid.setLayout(layout)
 
       btnClose = QtWidgets.QPushButton(self.tr('Done'))
-      btnClose.connect.clicked(self.accept)
-      frmClose = makeHorizFrame([STRETCH, btnClose])
+      btnClose.clicked.connect(self.accept)
+      frmClose = qtdefines.makeHorizFrame([qtdefines.STRETCH, btnClose])
 
-      frmAll = makeVertFrame([lblDescrTitle, lblDescr, frmGrid, frmClose])
+      frmAll = qtdefines.makeVertFrame([lblDescrTitle, lblDescr, frmGrid, frmClose])
       layoutAll = QtWidgets.QVBoxLayout()
       layoutAll.addWidget(frmAll)
       self.setLayout(layoutAll)
@@ -153,8 +151,8 @@ class SimplePrintableGraphicsScene(object):
       self.PAGE_BKGD_COLOR = Colors.White
       self.PAGE_TEXT_COLOR = Colors.Black
 
-      self.fontFix = GETFONT('Courier', 9)
-      self.fontVar = GETFONT('Times', 10)
+      self.fontFix = qtdefines.GETFONT('Courier', 9)
+      self.fontVar = qtdefines.GETFONT('Times', 10)
 
       self.gfxScene = QtWidgets.QGraphicsScene(self.parent)
       self.gfxScene.setSceneRect(0, 0, self.PAPER_A4_WIDTH, self.PAPER_A4_HEIGHT)
@@ -244,7 +242,7 @@ class SimplePrintableGraphicsScene(object):
 
    def drawText(self, txt, font=None, wrapWidth=None, useHtml=True):
       if font == None:
-         font = GETFONT('Var', 9)
+         font = qtdefines.GETFONT('Var', 9)
       txtItem = QtWidgets.QGraphicsTextItem('')
       if useHtml:
          txtItem.setHtml(toUnicode(txt))
@@ -429,7 +427,7 @@ class DlgPrintBackup(ArmoryDialog):
 
       tempTxtItem = QtWidgets.QGraphicsTextItem('')
       tempTxtItem.setPlainText(toUnicode('0123QAZjqlmYy'))
-      tempTxtItem.setFont(GETFONT('Fix', 7))
+      tempTxtItem.setFont(qtdefines.GETFONT('Fix', 7))
       self.importHgt = tempTxtItem.boundingRect().height() - 5
 
       # Create the scene and the view.
@@ -441,9 +439,9 @@ class DlgPrintBackup(ArmoryDialog):
       self.chkImportPrint = QtWidgets.QCheckBox(self.tr('Print imported keys'))
       self.chkImportPrint.clicked.connect(self.clickImportChk)
 
-      self.lblPageStr = QRichLabel(self.tr('Page:'))
+      self.lblPageStr = qtdefines.QRichLabel(self.tr('Page:'))
       self.comboPageNum = QtWidgets.QComboBox()
-      self.lblPageMaxStr = QRichLabel('')
+      self.lblPageMaxStr = qtdefines.QRichLabel('')
       self.comboPageNum.activated.connect(self.redrawBackup)
 
       # We enable printing of imported addresses but not frag'ing them.... way
@@ -462,7 +460,7 @@ class DlgPrintBackup(ArmoryDialog):
       if(self.doPrintFrag):
          self.chkSecurePrint.setChecked(self.fragData['Secure'])
 
-      self.ttipSecurePrint = createToolTipWidget(self.tr(
+      self.ttipSecurePrint = qtdefines.createToolTipWidget(self.tr(
          u'SecurePrint\u200b\u2122 encrypts your backup with a code displayed on '
          'the screen, so that no other devices on your network see the sensitive '
          'data when you send it to the printer.  If you turn on '
@@ -470,7 +468,7 @@ class DlgPrintBackup(ArmoryDialog):
          'it is done printing!</u>  There is no point in using this feature if '
          'you copy the data by hand.'))
 
-      self.lblSecurePrint = QRichLabel(self.tr(
+      self.lblSecurePrint = qtdefines.QRichLabel(self.tr(
          u'<b><font color="%s"><u>IMPORTANT:</u></b>  You must write the SecurePrint\u200b\u2122 '
          u'encryption code on each printed backup page!  Your SecurePrint\u200b\u2122 code is </font> '
          '<font color="%s">%s</font>.  <font color="%s">Your backup will not work '
@@ -479,14 +477,14 @@ class DlgPrintBackup(ArmoryDialog):
       self.chkSecurePrint.clicked.connect(self.redrawBackup)
 
       self.btnPrint = QtWidgets.QPushButton('&Print...')
-      self.btnPrint.setMinimumWidth(3 * tightSizeStr(self.btnPrint, 'Print...')[0])
+      self.btnPrint.setMinimumWidth(3 * qtdefines.tightSizeStr(self.btnPrint, 'Print...')[0])
       self.btnCancel = QtWidgets.QPushButton('&Cancel')
       self.btnPrint.clicked.connect(self.print_)
       self.btnCancel.clicked.connect(self.accept)
 
       if self.doPrintFrag:
          M, N = self.fragData['M'], self.fragData['N']
-         lblDescr = QRichLabel(self.tr(
+         lblDescr = qtdefines.QRichLabel(self.tr(
             '<b><u>Print Wallet Backup Fragments</u></b><br><br> '
             'When any %s of these fragments are combined, all <u>previous '
             '<b>and</b> future</u> addresses generated by this wallet will be '
@@ -497,7 +495,7 @@ class DlgPrintBackup(ArmoryDialog):
             'of <b>4 characters each</b> (excluding "ID" lines).' % M))
       else:
          withChain = '' if self.noNeedChaincode else 'and "Chaincode"'
-         lblDescr = QRichLabel(self.tr(
+         lblDescr = qtdefines.QRichLabel(self.tr(
             '<b><u>Print a Forever-Backup</u></b><br><br> '
             'Printing this sheet protects all <u>previous <b>and</b> future</u> addresses '
             'generated by this wallet!  You can copy the "Root Key" %s '
@@ -506,23 +504,23 @@ class DlgPrintBackup(ArmoryDialog):
             'of <b>4 characters each</b>.' % withChain))
 
       lblDescr.setContentsMargins(5, 5, 5, 5)
-      frmDescr = makeHorizFrame([lblDescr], STYLE_RAISED)
+      frmDescr = qtdefines.makeHorizFrame([lblDescr], qtdefines.STYLE_RAISED)
 
       self.redrawBackup()
-      frmChkImport = makeHorizFrame([
+      frmChkImport = qtdefines.makeHorizFrame([
          self.chkImportPrint,
-         STRETCH,
+         qtdefines.STRETCH,
          self.lblPageStr,
          self.comboPageNum,
          self.lblPageMaxStr
       ])
 
-      frmSecurePrint = makeHorizFrame([
+      frmSecurePrint = qtdefines.makeHorizFrame([
          self.chkSecurePrint,
          self.ttipSecurePrint,
-         STRETCH
+         qtdefines.STRETCH
       ])
-      frmButtons = makeHorizFrame([self.btnCancel, STRETCH, self.btnPrint])
+      frmButtons = qtdefines.makeHorizFrame([self.btnCancel, qtdefines.STRETCH, self.btnPrint])
 
       layout = QtWidgets.QVBoxLayout()
       layout.addWidget(frmDescr)
@@ -531,7 +529,7 @@ class DlgPrintBackup(ArmoryDialog):
       layout.addWidget(frmSecurePrint)
       layout.addWidget(self.lblSecurePrint)
       layout.addWidget(frmButtons)
-      setLayoutStretch(layout, 0, 1, 0, 0, 0)
+      qtdefines.setLayoutStretch(layout, 0, 1, 0, 0, 0)
 
       self.setLayout(layout)
       self.setWindowIcon(QtGui.QIcon('./img/printer_icon.png'))
@@ -692,7 +690,7 @@ class DlgPrintBackup(ArmoryDialog):
       self.scene.newLine()
 
       ## title ##
-      self.scene.drawText('Paper Backup for Armory Wallet', GETFONT('Var', 11))
+      self.scene.drawText('Paper Backup for Armory Wallet', qtdefines.GETFONT('Var', 11))
       self.scene.newLine()
 
       ## separator ##
@@ -764,7 +762,7 @@ class DlgPrintBackup(ArmoryDialog):
 
       wrap = 0.9 * self.scene.pageRect().width()
       self.scene.newLine()
-      self.scene.drawText(warnMsg, GETFONT('Var', 9), wrapWidth=wrap)
+      self.scene.drawText(warnMsg, qtdefines.GETFONT('Var', 9), wrapWidth=wrap)
 
       # separation
       self.scene.newLine(extra_dy=20)
@@ -802,7 +800,7 @@ class DlgPrintBackup(ArmoryDialog):
             'The following is fragment <font color="%s"><b>#%s</b></font> for this '
             'wallet.' % (htmlColor('TextBlue'), str(printData + 1)))
 
-      self.scene.drawText(descrMsg, GETFONT('var', 8), wrapWidth=wrap)
+      self.scene.drawText(descrMsg, qtdefines.GETFONT('var', 8), wrapWidth=wrap)
       self.scene.newLine(extra_dy=10)
 
       ## Draw the SecurePrint box if needed, frag pie, then return cursor ##
@@ -823,7 +821,7 @@ class DlgPrintBackup(ArmoryDialog):
             '<b><font color="#770000">CRITICAL:</font>  This backup will not '
             u'work without the SecurePrint\u200b\u2122 '
             'code displayed on the screen during printing. '
-            'Copy it here in ink:'), wrapWidth=spWid * 0.93, font=GETFONT('Var', 7))
+            'Copy it here in ink:'), wrapWidth=spWid * 0.93, font=qtdefines.GETFONT('Var', 7))
 
          self.scene.newLine(extra_dy=8)
          self.scene.moveCursor(4.07 * INCH, 0)
@@ -850,9 +848,9 @@ class DlgPrintBackup(ArmoryDialog):
             prprv = encodePrivKeyBase58(priv.toBinStr() + comprByte)
             toPrint = [prprv[i * 6:(i + 1) * 6] for i in range((len(prprv) + 5) / 6)]
             addrHint = '  (%s...)' % hash160_to_addrStr(a160)[:12]
-            self.scene.drawText(' '.join(toPrint), GETFONT('Fix', 7))
+            self.scene.drawText(' '.join(toPrint), qtdefines.GETFONT('Fix', 7))
             self.scene.moveCursor(0.02 * INCH, 0)
-            self.scene.drawText(addrHint, GETFONT('Var', 7))
+            self.scene.drawText(addrHint, qtdefines.GETFONT('Var', 7))
             self.scene.newLine(extra_dy=-3)
             prprv = None
          return
@@ -906,7 +904,7 @@ class DlgPrintBackup(ArmoryDialog):
       nudgeDown = 2  # because the differing font size makes it look unaligned
       self.scene.moveCursor(20, nudgeDown)
       self.scene.drawColumn(Lines,
-         font=GETFONT('Fixed', 8, bold=True),
+         font=qtdefines.GETFONT('Fixed', 8, bold=True),
          rowHeight=rowHgt,
          useHtml=False)
 
@@ -953,7 +951,7 @@ class DlgPrintBackup(ArmoryDialog):
                self.scene.newLine()
                self.scene.moveCursor(startX - MARGIN, 0)
                self.scene.drawText('<font color="%s">#%d</font>' %
-                  (htmlColor('TextBlue'), fragNum), GETFONT('Var', 10))
+                  (htmlColor('TextBlue'), fragNum), qtdefines.GETFONT('Var', 10))
                self.scene.moveCursor(returnX, returnY, absolute=True)
 
       vbar = self.view.verticalScrollBar()
@@ -966,16 +964,16 @@ class DlgFragBackup(ArmoryDialog):
       super(DlgFragBackup, self).__init__(parent, main)
       self.wlt = wlt
 
-      lblDescrTitle = QRichLabel(self.tr(
+      lblDescrTitle = qtdefines.QRichLabel(self.tr(
          '<b><u>Create M-of-N Fragmented Backup</u> of "%s" (%s)</b>' %
          (wlt.labelName, wlt.walletId)), doWrap=False)
       lblDescrTitle.setContentsMargins(5, 5, 5, 5)
 
-      self.lblAboveFrags = QRichLabel('')
+      self.lblAboveFrags = qtdefines.QRichLabel('')
       self.lblAboveFrags.setContentsMargins(10, 0, 10, 0)
 
-      frmDescr = makeVertFrame([lblDescrTitle, self.lblAboveFrags],
-         STYLE_RAISED)
+      frmDescr = qtdefines.makeVertFrame([lblDescrTitle, self.lblAboveFrags],
+         qtdefines.STYLE_RAISED)
 
       self.fragDisplayLastN = 0
       self.fragDisplayLastM = 0
@@ -1008,7 +1006,7 @@ class DlgFragBackup(ArmoryDialog):
 
       btnAccept = QtWidgets.QPushButton(self.tr('Close'))
       btnAccept.clicked.connect(self.accept)
-      frmBottomBtn = makeHorizFrame([STRETCH, btnAccept])
+      frmBottomBtn = qtdefines.makeHorizFrame([qtdefines.STRETCH, btnAccept])
 
       # We will hold all fragments here, in SBD objects.  Destroy all of them
       # before the dialog exits
@@ -1030,13 +1028,13 @@ class DlgFragBackup(ArmoryDialog):
       self.createFragDisplay()
       self.scrollArea.setWidgetResizable(True)
 
-      self.ttipSecurePrint = createToolTipWidget(self.tr(
+      self.ttipSecurePrint = qtdefines.createToolTipWidget(self.tr(
          u'SecurePrint\u200b\u2122 encrypts your backup with a code displayed on '
          'the screen, so that no other devices or processes has access to the '
          'unencrypted private keys (either network devices when printing, or '
          'other applications if you save a fragment to disk or USB device). '
          u'<u>You must keep the SecurePrint\u200b\u2122 code with the backup!</u>'))
-      self.lblSecurePrint = QRichLabel(self.tr(
+      self.lblSecurePrint = qtdefines.QRichLabel(self.tr(
          '<b><font color="%s"><u>IMPORTANT:</u>  You must keep the '
          u'SecurePrint\u200b\u2122 encryption code with your backup! '
          u'Your SecurePrint\u200b\u2122 code is </font> '
@@ -1047,7 +1045,7 @@ class DlgFragBackup(ArmoryDialog):
       self.chkSecurePrint.clicked.connect(self.clickChkSP)
       self.chkSecurePrint.setChecked(False)
       self.lblSecurePrint.setVisible(False)
-      frmChkSP = makeHorizFrame([self.chkSecurePrint, self.ttipSecurePrint, STRETCH])
+      frmChkSP = qtdefines.makeHorizFrame([self.chkSecurePrint, self.ttipSecurePrint, qtdefines.STRETCH])
 
       dlgLayout = QtWidgets.QVBoxLayout()
       dlgLayout.addWidget(frmDescr)
@@ -1055,7 +1053,7 @@ class DlgFragBackup(ArmoryDialog):
       dlgLayout.addWidget(frmChkSP)
       dlgLayout.addWidget(self.lblSecurePrint)
       dlgLayout.addWidget(frmBottomBtn)
-      setLayoutStretch(dlgLayout, 0, 1, 0, 0, 0)
+      qtdefines.setLayoutStretch(dlgLayout, 0, 1, 0, 0, 0)
 
       self.setLayout(dlgLayout)
       self.setMinimumWidth(650)
@@ -1096,22 +1094,22 @@ class DlgFragBackup(ArmoryDialog):
       self.fragDisplayLastN = N
       self.fragDisplayLastM = M
 
-      lblAboveM = QRichLabel(self.tr('<u><b>Required Fragments</b></u> '),
+      lblAboveM = qtdefines.QRichLabel(self.tr('<u><b>Required Fragments</b></u> '),
          hAlign=QtCore.Qt.AlignHCenter, doWrap=False)
-      lblAboveN = QRichLabel(self.tr('<u><b>Total Fragments</b></u> '),
+      lblAboveN = qtdefines.QRichLabel(self.tr('<u><b>Total Fragments</b></u> '),
          hAlign=QtCore.Qt.AlignHCenter)
-      frmComboM = makeHorizFrame([STRETCH, QtWidgets.QLabel('M:'), self.comboM, STRETCH])
-      frmComboN = makeHorizFrame([STRETCH, QtWidgets.QLabel('N:'), self.comboN, STRETCH])
+      frmComboM = qtdefines.makeHorizFrame([qtdefines.STRETCH, QtWidgets.QLabel('M:'), self.comboM, qtdefines.STRETCH])
+      frmComboN = qtdefines.makeHorizFrame([qtdefines.STRETCH, QtWidgets.QLabel('N:'), self.comboN, qtdefines.STRETCH])
 
       btnPrintAll = QtWidgets.QPushButton(self.tr('Print All Fragments'))
-      btnPrintAll.connect.clicked(self.clickPrintAll)
-      leftFrame = makeVertFrame([
-         STRETCH,
+      btnPrintAll.clicked.connect(self.clickPrintAll)
+      leftFrame = qtdefines.makeVertFrame([
+         qtdefines.STRETCH,
          lblAboveM, frmComboM,
          lblAboveN, frmComboN,
-         STRETCH, HLINE(),
+         qtdefines.STRETCH, qtdefines.HLINE(),
          btnPrintAll,
-         STRETCH], STYLE_STYLED)
+         qtdefines.STRETCH], qtdefines.STYLE_STYLED)
 
       layout = QtWidgets.QHBoxLayout()
       layout.addWidget(leftFrame)
@@ -1120,7 +1118,7 @@ class DlgFragBackup(ArmoryDialog):
          layout.addWidget(self.createFragFrm(f))
 
       frmScroll = QtWidgets.QFrame()
-      frmScroll.setFrameStyle(STYLE_SUNKEN)
+      frmScroll.setFrameStyle(qtdefines.STYLE_SUNKEN)
       frmScroll.setStyleSheet('QtWidgets.QFrame { background-color : %s  }' %
          htmlColor('SlightBkgdDark'))
       frmScroll.setLayout(layout)
@@ -1141,9 +1139,9 @@ class DlgFragBackup(ArmoryDialog):
       M = int(str(self.comboM.currentText()))
       N = int(str(self.comboN.currentText()))
 
-      lblFragID = QRichLabel(self.tr('<b>Fragment ID:<br>%s-%s</b>' % 
+      lblFragID = qtdefines.QRichLabel(self.tr('<b>Fragment ID:<br>%s-%s</b>' % 
          (str(self.fragPrefixStr), str(idx + 1))))
-      lblFragPix = QImageLabel(self.fragPixmapFn, size=(72, 72))
+      lblFragPix = qtdefines.QImageLabel(self.fragPixmapFn, size=(72, 72))
       if doMask:
          ys = self.secureMtrxCrypt[idx][1].toBinStr()[:42]
       else:
@@ -1158,16 +1156,16 @@ class DlgFragBackup(ArmoryDialog):
       fragPreview = 'ID: %s...<br>' % ID[:12]
       fragPreview += 'F1: %s...<br>' % easyYs1[:12]
       fragPreview += 'F2: %s...    ' % easyYs2[:12]
-      lblPreview = QRichLabel(fragPreview)
-      lblPreview.setFont(GETFONT('Fixed', 9))
+      lblPreview = qtdefines.QRichLabel(fragPreview)
+      lblPreview.setFont(qtdefines.GETFONT('Fixed', 9))
 
-      lblFragIdx = QRichLabel('#%d' % (idx + 1), size=4, color='TextBlue',
+      lblFragIdx = qtdefines.QRichLabel('#%d' % (idx + 1), size=4, color='TextBlue',
          hAlign=QtCore.Qt.AlignHCenter)
 
-      frmTopLeft = makeVertFrame([lblFragID, lblFragIdx, STRETCH])
-      frmTopRight = makeVertFrame([lblFragPix, STRETCH])
+      frmTopLeft = qtdefines.makeVertFrame([lblFragID, lblFragIdx, qtdefines.STRETCH])
+      frmTopRight = qtdefines.makeVertFrame([lblFragPix, qtdefines.STRETCH])
 
-      frmPaper = makeVertFrame([lblPreview])
+      frmPaper = qtdefines.makeVertFrame([lblPreview])
       frmPaper.setStyleSheet('QtWidgets.QFrame { background-color : #ffffff  }')
 
       fnPrint = lambda: self.clickPrintFrag(idx)
@@ -1177,7 +1175,7 @@ class DlgFragBackup(ArmoryDialog):
       btnSaveFrag = QtWidgets.QPushButton(self.tr('Save to File'))
       btnPrintFrag.clicked.connect(fnPrint)
       btnSaveFrag.clicked.connect(fnSave)
-      frmButtons = makeHorizFrame([btnPrintFrag, btnSaveFrag])
+      frmButtons = qtdefines.makeHorizFrame([btnPrintFrag, btnSaveFrag])
 
       layout = QtWidgets.QGridLayout()
       layout.addWidget(frmTopLeft, 0, 0, 1, 1)
@@ -1187,7 +1185,7 @@ class DlgFragBackup(ArmoryDialog):
       layout.setSizeConstraint(QtWidgets.QLayout.SetFixedSize)
 
       outFrame = QtWidgets.QFrame()
-      outFrame.setFrameStyle(STYLE_STYLED)
+      outFrame.setFrameStyle(qtdefines.STYLE_STYLED)
       outFrame.setLayout(layout)
       return outFrame
 
@@ -1392,7 +1390,7 @@ def OpenPaperBackupDialog(backupType, parent, main, wlt, passphrase: str=None):
          'same for all fragments.')
 
    if result:
-      doTest = MsgBoxCustom(MSGBOX.Warning, parent.tr('Verify Your Backup!'),
+      doTest = MsgBoxCustom(qtdefines.MSGBOX.Warning, parent.tr('Verify Your Backup!'),
          parent.tr(
             '<b><u>Verify your backup!</u></b> '
             '<br><br>'
@@ -1419,3 +1417,158 @@ def OpenPaperBackupDialog(backupType, parent, main, wlt, passphrase: str=None):
          elif backupType == 'Frag':
             DlgRestoreFragged(parent, main, True, wlt.walletId).exec_()
    return result
+
+################################################################################
+class DlgShowSeedPhrase(ArmoryDialog):
+   def __init__(self, parent, main, wlt):
+      super().__init__(parent, main)
+      self.wlt = wlt
+      self.backupData = None
+      self.seedDisplay = None
+
+      self.lblLoading = QtWidgets.QLabel(self.tr('Loading seed phrase...'))
+      self.lblLoading.setAlignment(QtCore.Qt.AlignCenter)
+      layout = QtWidgets.QVBoxLayout()
+      layout.addStretch()
+      layout.addWidget(self.lblLoading)
+      layout.addStretch()
+      self.setLayout(layout)
+      self.setWindowTitle(self.tr('Seed Phrase Backup'))
+      self.setMinimumWidth(500)
+      self.setMinimumHeight(300)
+
+      def resumeSetup(reply):
+         self.backupData = None
+         if reply.success:
+            self.backupData = reply.wallet.createBackupString
+         self.executeMethod(self.setup)
+
+      unlockHandler = UnlockWalletHandler(
+         self.wlt.walletId, "View Seed Phrase", self)
+      self.wlt.createBackupString(resumeSetup, unlockHandler=unlockHandler)
+
+   def setup(self):
+      # Qt C++ objects can be deleted while Python callbacks are pending.
+      # Calling methods on deleted objects raises RuntimeError.
+      try:
+         if not self.isVisible():
+            return
+      except RuntimeError:
+         return
+
+      if self.backupData is None:
+         LOGERROR("Failed to get backup data for seed phrase display")
+         QtWidgets.QMessageBox.critical(self, self.tr("Error"),
+            self.tr('Could not retrieve seed phrase. The wallet may be '
+            'locked or an error occurred.'), QtWidgets.QMessageBox.Ok)
+         self.reject()
+         return
+
+      self.lblLoading.setVisible(False)
+      oldLayout = self.layout()
+      if oldLayout is not None:
+         QtWidgets.QWidget().setLayout(oldLayout)
+
+      wltId = self.wlt.walletId
+      wltName = self.wlt.labelName
+
+      lblTitle = qtdefines.QRichLabel(self.tr(
+         '<b><u>Seed Phrase for "%s" (%s)</u></b>') % (wltName, wltId))
+      lblTitle.setAlignment(QtCore.Qt.AlignHCenter)
+
+      lblWarn = qtdefines.QRichLabel(self.tr(
+         '<font color="red"><b>WARNING:</b></font> Anyone who sees this seed '
+         'phrase can steal all your bitcoins! Keep it secret and secure.'))
+      lblWarn.setAlignment(QtCore.Qt.AlignHCenter)
+
+      backupType = getBackupTypeString(self.backupData.backupType)
+      isBIP39 = (self.backupData.backupType == 'bip39')
+
+      if isBIP39:
+         formatDesc = self.tr(
+            'Format: <b>BIP39 Mnemonic</b><br>'
+            '<font color="green">&#10003;</font> Universal - can be imported '
+            'into other wallet software')
+      else:
+         formatDesc = self.tr(
+            'Format: <b>Armory Easy16 (%s)</b><br>'
+            '<font color="orange">&#9888;</font> Armory-only - can only be '
+            'restored in Armory') % backupType
+      lblFormat = qtdefines.QRichLabel(formatDesc)
+
+      self.seedDisplay = qtdefines.SeedPhraseDisplayWidget()
+      seedText = self.getSeedText()
+      self.seedDisplay.setText(seedText)
+      self.seedDisplay.revealStateChanged.connect(self.onRevealStateChanged)
+
+      self.btnReveal = QtWidgets.QPushButton(self.tr('Reveal Seed Phrase'))
+      self.btnReveal.clicked.connect(self.seedDisplay.toggleReveal)
+
+      self.btnCopy = QtWidgets.QPushButton(self.tr('Copy to Clipboard'))
+      self.btnCopy.clicked.connect(self.copySeed)
+      self.btnCopy.setEnabled(False)
+
+      btnDone = QtWidgets.QPushButton(self.tr('Done'))
+      btnDone.clicked.connect(self.accept)
+
+      frmButtons = qtdefines.makeHorizFrame([
+         self.btnReveal, self.btnCopy, qtdefines.STRETCH, btnDone])
+
+      layout = QtWidgets.QVBoxLayout()
+      layout.addWidget(lblTitle)
+      layout.addWidget(qtdefines.HLINE())
+      layout.addWidget(lblWarn)
+      layout.addWidget(lblFormat)
+      layout.addWidget(self.seedDisplay)
+      layout.addWidget(frmButtons)
+
+      self.setLayout(layout)
+      self.setWindowTitle(self.tr('Seed Phrase Backup'))
+      self.setMinimumWidth(500)
+      self.setMinimumHeight(300)
+
+   def onRevealStateChanged(self, revealed):
+      if revealed:
+         self.btnReveal.setText(self.tr('Hide Seed Phrase'))
+         self.btnCopy.setEnabled(True)
+      else:
+         self.btnReveal.setText(self.tr('Reveal Seed Phrase'))
+         self.btnCopy.setEnabled(False)
+
+   def getSeedText(self):
+      if self.backupData.backupType == 'bip39':
+         return self.backupData.rootClear[0] if self.backupData.rootClear else ''
+      rootLines = self.backupData.rootClear
+      chainLines = self.backupData.chainClear
+      lines = []
+      if rootLines:
+         lines.append('Root Key:')
+         for line in rootLines:
+            lines.append('  ' + line)
+      if chainLines:
+         lines.append('Chaincode:')
+         for line in chainLines:
+            lines.append('  ' + line)
+      return '\n'.join(lines)
+
+   def copySeed(self):
+      seedText = self.seedDisplay.getText()
+      clipboard = QtWidgets.QApplication.clipboard()
+      clipboard.setText(seedText)
+      QtWidgets.QMessageBox.information(self, self.tr('Copied'),
+         self.tr('Seed phrase copied to clipboard. '
+         '<b>Clear your clipboard after use!</b>'),
+         QtWidgets.QMessageBox.Ok)
+
+   def cleanup(self):
+      self.backupData = None
+      if self.seedDisplay is not None:
+         self.seedDisplay.clear()
+
+   def accept(self):
+      self.cleanup()
+      super().accept()
+
+   def reject(self):
+      self.cleanup()
+      super().reject()

--- a/qtdialogs/DlgRestore.py
+++ b/qtdialogs/DlgRestore.py
@@ -24,9 +24,7 @@ from qtdialogs.ArmoryDialog import ArmoryDialog
 from qtdialogs.DlgChangePassphrase import DlgChangePassphrase
 from qtdialogs import DlgReplaceWallet as ReplaceWallet
 from qtdialogs.MsgBoxCustom import MsgBoxCustom
-from qtdialogs.qtdefines import HLINE, QRichLabel, STRETCH, STYLE_RAISED, \
-   makeHorizFrame, makeVertFrame, MSGBOX, GETFONT, tightSizeStr, \
-   AdvancedOptionsFrame
+import qtdialogs.qtdefines as qtdefines
 
 ################################################################################
 def getBackupTypeString(capnBType):
@@ -56,9 +54,9 @@ class MaskedInputLineEdit(QtWidgets.QLineEdit):
    def __init__(self, inputMask):
       super(MaskedInputLineEdit, self).__init__()
       self.setInputMask(inputMask)
-      fixFont = GETFONT('Fix', 9)
+      fixFont = qtdefines.GETFONT('Fix', 9)
       self.setFont(fixFont)
-      self.setMinimumWidth(tightSizeStr(fixFont, inputMask)[0] + 10)
+      self.setMinimumWidth(qtdefines.tightSizeStr(fixFont, inputMask)[0] + 10)
       self.cursorPositionChanged.connect(self.controlCursor)
 
    def controlCursor(self, oldpos, newpos):
@@ -74,14 +72,15 @@ class DlgRestoreSingle(ArmoryDialog, ServerPush):
       self.newWltID = None
       self.thisIsATest = thisIsATest
       self.testWltID = expectWltID
+      self.isSeedPhrase = False
       if thisIsATest:
-         lblDescr = QRichLabel(self.tr(
+         lblDescr = qtdefines.QRichLabel(self.tr(
             '<b><u><font color="blue" size="4">Test a Paper Backup</font></u></b> '
             '<br><br>'
             'Use this window to test a single-sheet paper backup.  If your '
             'backup includes imported keys, those will not be covered by this test.'))
       else:
-         lblDescr = QRichLabel(self.tr(
+         lblDescr = qtdefines.QRichLabel(self.tr(
             '<b><u>Restore a Wallet from Paper Backup</u></b> '
             '<br><br>'
             'Use this window to restore a single-sheet paper backup. '
@@ -90,7 +89,7 @@ class DlgRestoreSingle(ArmoryDialog, ServerPush):
             'double-click the restored wallet and select "Import Private '
             'Keys" from the right-hand menu.'))
 
-      lblType = QRichLabel(self.tr('<b>Backup Type:</b>'), doWrap=False)
+      lblType = qtdefines.QRichLabel(self.tr('<b>Backup Type:</b>'), doWrap=False)
       self.version135Button = QtWidgets.QRadioButton(
          self.tr('Version 1.35 (4 lines)'), self)
       self.version135aButton = QtWidgets.QRadioButton(
@@ -101,12 +100,15 @@ class DlgRestoreSingle(ArmoryDialog, ServerPush):
          self.tr('Version 1.35c (2 lines Unencrypted)'), self)
       self.version135cSPButton = QtWidgets.QRadioButton(
          self.tr(u'Version 1.35c (2 lines + SecurePrint\u200b\u2122)'), self)
+      self.seedPhraseButton = QtWidgets.QRadioButton(
+         self.tr('Seed Phrase (BIP39 / 12-24 words)'), self)
       self.backupTypeButtonGroup = QtWidgets.QButtonGroup(self)
       self.backupTypeButtonGroup.addButton(self.version135Button)
       self.backupTypeButtonGroup.addButton(self.version135aButton)
       self.backupTypeButtonGroup.addButton(self.version135aSPButton)
       self.backupTypeButtonGroup.addButton(self.version135cButton)
       self.backupTypeButtonGroup.addButton(self.version135cSPButton)
+      self.backupTypeButtonGroup.addButton(self.seedPhraseButton)
       self.version135cButton.setChecked(True)
       self.backupTypeButtonGroup.buttonClicked.connect(self.changeType)
 
@@ -116,14 +118,15 @@ class DlgRestoreSingle(ArmoryDialog, ServerPush):
       layoutRadio.addWidget(self.version135aSPButton)
       layoutRadio.addWidget(self.version135cButton)
       layoutRadio.addWidget(self.version135cSPButton)
+      layoutRadio.addWidget(self.seedPhraseButton)
       layoutRadio.setSpacing(0)
 
       radioButtonFrame = QtWidgets.QFrame()
       radioButtonFrame.setLayout(layoutRadio)
 
-      frmBackupType = makeVertFrame([lblType, radioButtonFrame])
+      frmBackupType = qtdefines.makeVertFrame([lblType, radioButtonFrame])
 
-      self.lblSP = QRichLabel(self.tr(u'SecurePrint\u200b\u2122 Code:'), doWrap=False)
+      self.lblSP = qtdefines.QRichLabel(self.tr(u'SecurePrint\u200b\u2122 Code:'), doWrap=False)
       self.editSecurePrint = QtWidgets.QLineEdit()
       self.prfxList = [
          QtWidgets.QLabel(self.tr('Root Key:')),
@@ -134,16 +137,27 @@ class DlgRestoreSingle(ArmoryDialog, ServerPush):
 
       inpMask = '<AAAA\ AAAA\ AAAA\ AAAA\ \ AAAA\ AAAA\ AAAA\ AAAA\ \ AAAA!'
       self.edtList = [MaskedInputLineEdit(inpMask) for i in range(4)]
-      self.frmSP = makeHorizFrame([STRETCH, self.lblSP, self.editSecurePrint])
+      self.frmSP = qtdefines.makeHorizFrame([qtdefines.STRETCH, self.lblSP, self.editSecurePrint])
 
-      frmAllInputs = QtWidgets.QFrame()
-      frmAllInputs.setFrameStyle(STYLE_RAISED)
+      self.frmEasy16Inputs = QtWidgets.QFrame()
+      self.frmEasy16Inputs.setFrameStyle(qtdefines.STYLE_RAISED)
       layoutAllInp = QtWidgets.QGridLayout()
       layoutAllInp.addWidget(self.frmSP, 0, 0, 1, 2)
       for i in range(4):
          layoutAllInp.addWidget(self.prfxList[i], i + 1, 0)
          layoutAllInp.addWidget(self.edtList[i], i + 1, 1)
-      frmAllInputs.setLayout(layoutAllInp)
+      self.frmEasy16Inputs.setLayout(layoutAllInp)
+
+      self.seedPhraseInput = qtdefines.SeedPhraseInputWidget()
+      self.accountSelection = qtdefines.AccountSelectionWidget()
+
+      self.frmSeedPhraseInputs = QtWidgets.QFrame()
+      self.frmSeedPhraseInputs.setFrameStyle(qtdefines.STYLE_RAISED)
+      layoutSeedPhrase = QtWidgets.QVBoxLayout()
+      layoutSeedPhrase.addWidget(self.seedPhraseInput)
+      layoutSeedPhrase.addWidget(self.accountSelection)
+      self.frmSeedPhraseInputs.setLayout(layoutSeedPhrase)
+      self.frmSeedPhraseInputs.setVisible(False)
 
       doItText = self.tr('Test Backup') if thisIsATest else self.tr('Restore Wallet')
       self.btnAccept = QtWidgets.QPushButton(doItText)
@@ -156,17 +170,18 @@ class DlgRestoreSingle(ArmoryDialog, ServerPush):
 
       self.chkEncrypt = QtWidgets.QCheckBox(self.tr('Encrypt Wallet'))
       self.chkEncrypt.setChecked(True)
-      bottomFrm = makeHorizFrame([self.chkEncrypt, buttonBox])
+      bottomFrm = qtdefines.makeHorizFrame([self.chkEncrypt, buttonBox])
 
       walletRestoreTabs = QtWidgets.QTabWidget()
-      backupTypeFrame = makeVertFrame([frmBackupType, frmAllInputs])
+      backupTypeFrame = qtdefines.makeVertFrame([
+         frmBackupType, self.frmEasy16Inputs, self.frmSeedPhraseInputs])
       walletRestoreTabs.addTab(backupTypeFrame, self.tr("Backup"))
-      self.advancedOptionsTab = AdvancedOptionsFrame(parent, main)
+      self.advancedOptionsTab = qtdefines.AdvancedOptionsFrame(parent, main)
       walletRestoreTabs.addTab(self.advancedOptionsTab, self.tr("Advanced Options"))
 
       layout = QtWidgets.QVBoxLayout()
       layout.addWidget(lblDescr)
-      layout.addWidget(HLINE())
+      layout.addWidget(qtdefines.HLINE())
       layout.addWidget(walletRestoreTabs)
       layout.addWidget(bottomFrm)
       self.setLayout(layout)
@@ -191,6 +206,17 @@ class DlgRestoreSingle(ArmoryDialog, ServerPush):
 
    #############################################################################
    def changeType(self, sel):
+      self.isSeedPhrase = (sel == self.seedPhraseButton)
+      if self.isSeedPhrase:
+         self.frmEasy16Inputs.setVisible(False)
+         self.frmSeedPhraseInputs.setVisible(True)
+         self.doMask = False
+         self.isLongForm = False
+         return
+
+      self.frmEasy16Inputs.setVisible(True)
+      self.frmSeedPhraseInputs.setVisible(False)
+
       if   sel == self.version135Button:
          visList = [0, 1, 1, 1, 1]
       elif sel == self.version135aButton:
@@ -390,6 +416,10 @@ class DlgRestoreSingle(ArmoryDialog, ServerPush):
 
    #############################################################################
    def verifyUserInput(self):
+      if self.isSeedPhrase:
+         self.verifySeedPhraseInput()
+         return
+
       #reset flagged inputs if any
       self.resetEditLines()
 
@@ -459,6 +489,27 @@ class DlgRestoreSingle(ArmoryDialog, ServerPush):
             QtWidgets.QMessageBox.Ok)
       '''
 
+   #############################################################################
+   def verifySeedPhraseInput(self):
+      if not self.seedPhraseInput.isValidWordCount():
+         wordCount = self.seedPhraseInput.getWordCount()
+         QtWidgets.QMessageBox.critical(self, self.tr('Invalid Seed Phrase'),
+            self.tr('Seed phrase must be exactly 12 or 24 words. '
+            'You entered %d words.') % wordCount, QtWidgets.QMessageBox.Ok)
+         return
+
+      if not self.accountSelection.isAnySelected():
+         QtWidgets.QMessageBox.critical(self, self.tr('No Account Selected'),
+            self.tr('Please select at least one account type to create.'),
+            QtWidgets.QMessageBox.Ok)
+         return
+
+      QtWidgets.QMessageBox.information(self, self.tr('Not Yet Supported'),
+         self.tr('BIP39 seed phrase restore is not yet supported. '
+         'This feature requires additional backend implementation. '
+         'Please use the Easy16 paper backup format for now.'),
+         QtWidgets.QMessageBox.Ok)
+
 ################################################################################
 class DlgRestoreFragged(ArmoryDialog):
    def __init__(self, parent, main, thisIsATest=False, expectWltID=None):
@@ -487,9 +538,9 @@ class DlgRestoreFragged(ArmoryDialog):
              'and Armory will test all subsets of the entered fragments to verify '
              'that each one still recovers the wallet successfully.</b>')
 
-      lblDescr = QRichLabel(descr)
+      lblDescr = qtdefines.QRichLabel(descr)
 
-      frmDescr = makeHorizFrame([lblDescr], STYLE_RAISED)
+      frmDescr = qtdefines.makeHorizFrame([lblDescr], qtdefines.STYLE_RAISED)
 
         # HLINE
 
@@ -497,7 +548,7 @@ class DlgRestoreFragged(ArmoryDialog):
       self.scrollFragInput.setWidgetResizable(True)
       self.scrollFragInput.setMinimumHeight(150)
 
-      lblFragList = QRichLabel(self.tr('Input Fragments Below:'), doWrap=False, bold=True)
+      lblFragList = qtdefines.QRichLabel(self.tr('Input Fragments Below:'), doWrap=False, bold=True)
       self.btnAddFrag = QtWidgets.QPushButton(self.tr('+Frag'))
       self.btnRmFrag = QtWidgets.QPushButton(self.tr('-Frag'))
       self.btnRmFrag.setVisible(False)
@@ -505,7 +556,7 @@ class DlgRestoreFragged(ArmoryDialog):
       self.btnRmFrag.clicked.connect(self.removeFragment)
       self.chkEncrypt = QtWidgets.QCheckBox(self.tr('Encrypt Restored Wallet'))
       self.chkEncrypt.setChecked(True)
-      frmAddRm = makeHorizFrame([self.chkEncrypt, STRETCH, self.btnRmFrag, self.btnAddFrag])
+      frmAddRm = qtdefines.makeHorizFrame([self.chkEncrypt, qtdefines.STRETCH, self.btnRmFrag, self.btnAddFrag])
 
       self.fragDataMap = {}
       self.tableSize = 2
@@ -518,38 +569,38 @@ class DlgRestoreFragged(ArmoryDialog):
       self.btnRestore = QtWidgets.QPushButton(doItText)
       btnExit.clicked.connect(self.reject)
       self.btnRestore.clicked.connect(self.processFrags)
-      frmBtns = makeHorizFrame([btnExit, STRETCH, self.btnRestore])
+      frmBtns = qtdefines.makeHorizFrame([btnExit, qtdefines.STRETCH, self.btnRestore])
 
-      self.lblRightFrm = QRichLabel('', hAlign=QtCore.Qt.AlignHCenter)
-      self.lblSecureStr = QRichLabel(self.trUtf8(u'SecurePrint\u200b\u2122 Code:'), \
+      self.lblRightFrm = qtdefines.QRichLabel('', hAlign=QtCore.Qt.AlignHCenter)
+      self.lblSecureStr = qtdefines.QRichLabel(self.trUtf8(u'SecurePrint\u200b\u2122 Code:'), \
                                      hAlign=QtCore.Qt.AlignHCenter,
                                      doWrap=False,
                                      color='TextWarn')
       self.displaySecureString = QtWidgets.QLineEdit()
-      self.imgPie = QRichLabel('', hAlign=QtCore.Qt.AlignHCenter)
+      self.imgPie = qtdefines.QRichLabel('', hAlign=QtCore.Qt.AlignHCenter)
       self.imgPie.setMinimumWidth(96)
       self.imgPie.setMinimumHeight(96)
-      self.lblReqd = QRichLabel('', hAlign=QtCore.Qt.AlignHCenter)
-      self.lblWltID = QRichLabel('', doWrap=False, hAlign=QtCore.Qt.AlignHCenter)
-      self.lblFragID = QRichLabel('', doWrap=False, hAlign=QtCore.Qt.AlignHCenter)
+      self.lblReqd = qtdefines.QRichLabel('', hAlign=QtCore.Qt.AlignHCenter)
+      self.lblWltID = qtdefines.QRichLabel('', doWrap=False, hAlign=QtCore.Qt.AlignHCenter)
+      self.lblFragID = qtdefines.QRichLabel('', doWrap=False, hAlign=QtCore.Qt.AlignHCenter)
       self.lblSecureStr.setVisible(False)
       self.displaySecureString.setVisible(False)
       self.displaySecureString.setMaximumWidth(relaxedSizeNChar(self.displaySecureString, 16)[0])
         # The Secure String is now edited in DlgEnterOneFrag, It is only displayed here
       self.displaySecureString.setEnabled(False)
-      frmSecPair = makeVertFrame([self.lblSecureStr, self.displaySecureString])
-      frmSecCtr = makeHorizFrame([STRETCH, frmSecPair, STRETCH])
+      frmSecPair = qtdefines.makeVertFrame([self.lblSecureStr, self.displaySecureString])
+      frmSecCtr = qtdefines.makeHorizFrame([qtdefines.STRETCH, frmSecPair, qtdefines.STRETCH])
 
-      frmWltInfo = makeVertFrame([STRETCH,
+      frmWltInfo = qtdefines.makeVertFrame([qtdefines.STRETCH,
                                    self.lblRightFrm,
                                    self.imgPie,
                                    self.lblReqd,
                                    self.lblWltID,
                                    self.lblFragID,
-                                   HLINE(),
+                                   qtdefines.HLINE(),
                                    frmSecCtr,
                                    'Strut(200)',
-                                   STRETCH], STYLE_SUNKEN)
+                                   qtdefines.STRETCH], qtdefines.STYLE_SUNKEN)
 
 
       fragmentsLayout = QtWidgets.QGridLayout()
@@ -563,7 +614,7 @@ class DlgRestoreFragged(ArmoryDialog):
       fragmentsFrame = QtWidgets.QFrame()
       fragmentsFrame.setLayout(fragmentsLayout)
       walletRestoreTabs.addTab(fragmentsFrame, self.tr("Fragments"))
-      self.advancedOptionsTab = AdvancedOptionsFrame(parent, main)
+      self.advancedOptionsTab = qtdefines.AdvancedOptionsFrame(parent, main)
       walletRestoreTabs.addTab(self.advancedOptionsTab, self.tr("Advanced Options"))
 
       self.chkEncrypt.setChecked(not thisIsATest)
@@ -595,12 +646,12 @@ class DlgRestoreFragged(ArmoryDialog):
       newLayout = QtWidgets.QGridLayout()
       newFrame = QtWidgets.QFrame()
       self.fragsDone = []
-      newLayout.addWidget(HLINE(), 0, 0, 1, 5)
+      newLayout.addWidget(qtdefines.HLINE(), 0, 0, 1, 5)
       for i in range(self.tableSize):
          btnEnter = QtWidgets.QPushButton(self.tr('Type Data'))
          btnLoad = QtWidgets.QPushButton(self.tr('Load File'))
          btnClear = QtWidgets.QPushButton(self.tr('Clear'))
-         lblFragID = QRichLabel('', doWrap=False)
+         lblFragID = qtdefines.QRichLabel('', doWrap=False)
          lblSecure = QtWidgets.QLabel('')
          if i in self.fragDataMap:
             M, fnum, wltID, doMask, fid = ReadFragIDLineBin(self.fragDataMap[i][0])
@@ -620,12 +671,12 @@ class DlgRestoreFragged(ArmoryDialog):
          newLayout.addWidget(btnClear, 2 * i + 1, 2)
          newLayout.addWidget(lblFragID, 2 * i + 1, 3)
          newLayout.addWidget(lblSecure, 2 * i + 1, 4)
-         newLayout.addWidget(HLINE(), 2 * i + 2, 0, 1, 5)
+         newLayout.addWidget(qtdefines.HLINE(), 2 * i + 2, 0, 1, 5)
 
       btnFrame = QtWidgets.QFrame()
       btnFrame.setLayout(newLayout)
 
-      frmFinal = makeVertFrame([btnFrame, STRETCH], STYLE_SUNKEN)
+      frmFinal = qtdefines.makeVertFrame([btnFrame, qtdefines.STRETCH], qtdefines.STYLE_SUNKEN)
       self.scrollFragInput.setWidget(frmFinal)
 
       self.btnAddFrag.setVisible(self.tableSize < 12)
@@ -1032,7 +1083,7 @@ class DlgEnterOneFrag(ArmoryDialog):
          replStr = '[' + ','.join(strList[:]) + ']'
          already = self.tr('You have entered fragments %s, so far.' % replStr)
 
-      lblDescr = QRichLabel(self.tr(
+      lblDescr = qtdefines.QRichLabel(self.tr(
          '<b><u>Enter Another Fragment...</u></b> <br><br> %s '
          'The fragments can be entered in any order, as long as you provide '
          'enough of them to restore the wallet.  If any fragments use a '
@@ -1082,7 +1133,7 @@ class DlgEnterOneFrag(ArmoryDialog):
          else:
             self.version135cButton.setChecked(True)
 
-      lblType = QRichLabel(self.tr('<b>Backup Type:</b>'), doWrap=False)
+      lblType = qtdefines.QRichLabel(self.tr('<b>Backup Type:</b>'), doWrap=False)
 
       layoutRadio = QtWidgets.QVBoxLayout()
       layoutRadio.addWidget(self.version0Button)
@@ -1095,7 +1146,7 @@ class DlgEnterOneFrag(ArmoryDialog):
       radioButtonFrame = QtWidgets.QFrame()
       radioButtonFrame.setLayout(layoutRadio)
 
-      frmBackupType = makeVertFrame([lblType, radioButtonFrame])
+      frmBackupType = qtdefines.makeVertFrame([lblType, radioButtonFrame])
 
       self.prfxList = ['x1:', 'x2:', 'x3:', 'x4:', \
                        'y1:', 'y2:', 'y3:', 'y4:', \
@@ -1105,21 +1156,21 @@ class DlgEnterOneFrag(ArmoryDialog):
       self.edtList = [MaskedInputLineEdit(inpMask) for i in range(12)]
 
       inpMaskID = '<HHHH\ HHHH\ HHHH\ HHHH!'
-      self.lblID = QRichLabel('ID:')
+      self.lblID = qtdefines.QRichLabel('ID:')
       self.edtID = MaskedInputLineEdit(inpMaskID)
 
       frmAllInputs = QtWidgets.QFrame()
-      frmAllInputs.setFrameStyle(STYLE_RAISED)
+      frmAllInputs.setFrameStyle(qtdefines.STYLE_RAISED)
       layoutAllInp = QtWidgets.QGridLayout()
 
       # Add Secure Print row - Use supplied securePrintCode and
       # disable text entry if it is not None
-      self.lblSP = QRichLabel(self.tr(u'SecurePrint\u200b\u2122 Code:'), doWrap=False)
+      self.lblSP = qtdefines.QRichLabel(self.tr(u'SecurePrint\u200b\u2122 Code:'), doWrap=False)
       self.editSecurePrint = QtWidgets.QLineEdit()
       self.editSecurePrint.setEnabled(not securePrintCode)
       if (securePrintCode):
          self.editSecurePrint.setText(securePrintCode)
-      self.frmSP = makeHorizFrame([STRETCH, self.lblSP, self.editSecurePrint])
+      self.frmSP = qtdefines.makeHorizFrame([qtdefines.STRETCH, self.lblSP, self.editSecurePrint])
       layoutAllInp.addWidget(self.frmSP, 0, 0, 1, 2)
 
       layoutAllInp.addWidget(self.lblID, 1, 0, 1, 1)
@@ -1139,7 +1190,7 @@ class DlgEnterOneFrag(ArmoryDialog):
 
       layout = QtWidgets.QVBoxLayout()
       layout.addWidget(lblDescr)
-      layout.addWidget(HLINE())
+      layout.addWidget(qtdefines.HLINE())
       layout.addWidget(frmBackupType)
       layout.addWidget(frmAllInputs)
       layout.addWidget(buttonBox)
@@ -1268,14 +1319,14 @@ class DlgRestoreWOData(ArmoryDialog):
 
       # Write the text at the top of the window.
       if thisIsATest:
-         lblDescr = QRichLabel(self.tr(
+         lblDescr = qtdefines.QRichLabel(self.tr(
             '<b><u><font color="blue" size="4">Test a Watch-Only Wallet Restore '
             '</font></u></b><br><br>'
             'Use this window to test the restoration of a watch-only wallet using '
             'the wallet\'s data. You can either type the data on a root data '
             'printout or import the data from a file.'))
       else:
-         lblDescr = QRichLabel(self.tr(
+         lblDescr = qtdefines.QRichLabel(self.tr(
             '<b><u><font color="blue" size="4">Restore a Watch-Only Wallet '
             '</font></u></b><br><br>'
             'Use this window to restore a watch-only wallet using the wallet\'s '
@@ -1283,25 +1334,25 @@ class DlgRestoreWOData(ArmoryDialog):
             'the data from a file.'))
 
       # Create the line that will contain the imported ID.
-      self.rootIDLabel = QRichLabel(self.tr('Watch-Only Root ID:'), doWrap=False)
+      self.rootIDLabel = qtdefines.QRichLabel(self.tr('Watch-Only Root ID:'), doWrap=False)
       inpMask = '<AAAA\ AAAA\ AAAA\ AAAA\ AA!'
       self.rootIDLine = MaskedInputLineEdit(inpMask)
-      self.rootIDLine.setFont(GETFONT('Fixed', 9))
-      self.rootIDFrame = makeHorizFrame([STRETCH, self.rootIDLabel, self.rootIDLine])
+      self.rootIDLine.setFont(qtdefines.GETFONT('Fixed', 9))
+      self.rootIDFrame = qtdefines.makeHorizFrame([qtdefines.STRETCH, self.rootIDLabel, self.rootIDLine])
 
       # Create the lines that will contain the imported key/code data.
       self.pkccLList = [QtWidgets.QLabel(self.tr('Data:')),
          QtWidgets.QLabel(''), QtWidgets.QLabel(''), QtWidgets.QLabel('')]
       for y in self.pkccLList:
-         y.setFont(GETFONT('Fixed', 9))
+         y.setFont(qtdefines.GETFONT('Fixed', 9))
       inpMask = '<AAAA\ AAAA\ AAAA\ AAAA\ \ AAAA\ AAAA\ AAAA\ AAAA\ \ AAAA!'
       self.pkccList = [MaskedInputLineEdit(inpMask) for i in range(4)]
       for x in self.pkccList:
-         x.setFont(GETFONT('Fixed', 9))
+         x.setFont(qtdefines.GETFONT('Fixed', 9))
 
       # Build the frame that will contain both the ID and the key/code data.
       frmAllInputs = QtWidgets.QFrame()
-      frmAllInputs.setFrameStyle(STYLE_RAISED)
+      frmAllInputs.setFrameStyle(qtdefines.STYLE_RAISED)
       layoutAllInp = QtWidgets.QGridLayout()
       layoutAllInp.addWidget(self.rootIDFrame, 0, 0, 1, 2)
       for i in range(4):
@@ -1325,10 +1376,10 @@ class DlgRestoreWOData(ArmoryDialog):
       # Set the final window layout.
       finalLayout = QtWidgets.QVBoxLayout()
       finalLayout.addWidget(lblDescr)
-      finalLayout.addWidget(makeHorizFrame(['Stretch',self.btnLoad]))
-      finalLayout.addWidget(HLINE())
+      finalLayout.addWidget(qtdefines.makeHorizFrame(['Stretch',self.btnLoad]))
+      finalLayout.addWidget(qtdefines.HLINE())
       finalLayout.addWidget(frmAllInputs)
-      finalLayout.addWidget(makeHorizFrame([self.btnCancel, 'Stretch', self.btnAccept]))
+      finalLayout.addWidget(qtdefines.makeHorizFrame([self.btnCancel, 'Stretch', self.btnAccept]))
       finalLayout.setStretch(0, 0)
       finalLayout.setStretch(1, 0)
       finalLayout.setStretch(2, 0)
@@ -1500,14 +1551,14 @@ class DlgEnterSecurePrintCode(ArmoryDialog):
    def __init__(self, parent, main):
       super(DlgEnterSecurePrintCode, self).__init__(parent, main)
 
-      lblSecurePrintCodeDescr = QRichLabel(self.tr(
+      lblSecurePrintCodeDescr = qtdefines.QRichLabel(self.tr(
          u'This fragment file requires a SecurePrint\u200b\u2122 code. '
          'You will only have to enter this code once since it is the same '
          'on all fragments.'))
       lblSecurePrintCodeDescr.setMinimumWidth(440)
-      self.lblSP = QRichLabel(self.tr(u'SecurePrint\u200b\u2122 Code: '), doWrap=False)
+      self.lblSP = qtdefines.QRichLabel(self.tr(u'SecurePrint\u200b\u2122 Code: '), doWrap=False)
       self.editSecurePrint = QtWidgets.QLineEdit()
-      spFrame = makeHorizFrame([self.lblSP, self.editSecurePrint, STRETCH])
+      spFrame = qtdefines.makeHorizFrame([self.lblSP, self.editSecurePrint, qtdefines.STRETCH])
 
       self.btnAccept = QtWidgets.QPushButton(self.tr("Done"))
       self.btnCancel = QtWidgets.QPushButton(self.tr("Cancel"))
@@ -1555,7 +1606,7 @@ def verifyRecoveryTestID(parent, computedWltID, expectedWltID=None):
             'Wallet ID of the data you entered: %s <br>' % computedWltID), \
             QtWidgets.QMessageBox.Ok)
       elif yesno == QtWidgets.QMessageBox.Yes:
-         MsgBoxCustom(MSGBOX.Good, parent.tr('Backup is Good!'), parent.tr(
+         MsgBoxCustom(qtdefines.MSGBOX.Good, parent.tr('Backup is Good!'), parent.tr(
             '<b>Your backup works!</b> '
             '<br><br>'
             'The wallet ID is computed from a combination of the root '
@@ -1578,7 +1629,7 @@ def verifyRecoveryTestID(parent, computedWltID, expectedWltID=None):
             'one you just made?' % (computedWltID, expectedWltID)), \
             QtWidgets.QMessageBox.Ok)
       else:
-         MsgBoxCustom(MSGBOX.Good, parent.tr('Backup is Good!'), parent.tr(
+         MsgBoxCustom(qtdefines.MSGBOX.Good, parent.tr('Backup is Good!'), parent.tr(
             'Your backup works! '
             '<br><br> '
             'The wallet ID computed from the data you entered matches '

--- a/qtdialogs/qtdefines.py
+++ b/qtdialogs/qtdefines.py
@@ -818,3 +818,192 @@ class AdvancedOptionsFrame(ArmoryFrame):
       except:
          pass
       return kdfBytes
+
+
+################################################################################
+class SeedPhraseDisplayWidget(QtWidgets.QFrame):
+   """
+   A widget for displaying seed phrases with blur/reveal functionality.
+   Used for both BIP39 mnemonic and Armory Easy16 format display.
+   """
+   revealStateChanged = QtCore.Signal(bool)
+
+   def __init__(self, parent=None):
+      super().__init__(parent)
+      self.setFrameStyle(STYLE_RAISED)
+      self.isRevealed = False
+      self.seedText = ''
+
+      self.lblContent = QtWidgets.QLabel()
+      self.lblContent.setFont(GETFONT('Fix', 11))
+      self.lblContent.setWordWrap(True)
+      self.lblContent.setTextInteractionFlags(QtCore.Qt.TextSelectableByMouse)
+      self.lblContent.setMinimumHeight(100)
+      self.lblContent.setAlignment(QtCore.Qt.AlignLeft | QtCore.Qt.AlignTop)
+
+      self.blurEffect = QtWidgets.QGraphicsBlurEffect()
+      self.blurEffect.setBlurRadius(8)
+      self.lblContent.setGraphicsEffect(self.blurEffect)
+
+      layout = QtWidgets.QVBoxLayout()
+      layout.addWidget(self.lblContent)
+      self.setLayout(layout)
+
+   def setText(self, text):
+      self.seedText = text
+      self.lblContent.setText(text)
+
+   def getText(self):
+      return self.seedText
+
+   def reveal(self):
+      if not self.isRevealed:
+         self.blurEffect.setBlurRadius(0)
+         self.isRevealed = True
+         self.revealStateChanged.emit(True)
+
+   def hide_(self):
+      if self.isRevealed:
+         self.blurEffect.setBlurRadius(8)
+         self.isRevealed = False
+         self.revealStateChanged.emit(False)
+
+   def toggleReveal(self):
+      if self.isRevealed:
+         self.hide_()
+      else:
+         self.reveal()
+
+   def clear(self):
+      self.seedText = ''
+      self.lblContent.setText('')
+      self.hide_()
+
+
+################################################################################
+class SeedPhraseInputWidget(QtWidgets.QFrame):
+   """
+   A widget for entering seed phrases (BIP39 mnemonic or Easy16).
+   Provides real-time word count feedback.
+   """
+   textChanged = QtCore.Signal()
+
+   def __init__(self, parent=None):
+      super().__init__(parent)
+      self.setFrameStyle(STYLE_RAISED)
+
+      self.lblInstr = QtWidgets.QLabel()
+      self.lblInstr.setText(
+         'Enter your 12 or 24 word seed phrase, separated by spaces:')
+
+      self.editSeed = QtWidgets.QTextEdit()
+      self.editSeed.setPlaceholderText(
+         'word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 '
+         'word11 word12 ...')
+      self.editSeed.setFixedHeight(80)
+      self.editSeed.setFont(GETFONT('Fix', 10))
+      self.editSeed.textChanged.connect(self.onTextChanged)
+
+      self.lblWordCount = QtWidgets.QLabel()
+      self.lblWordCount.setStyleSheet('color: gray;')
+      self.updateWordCount()
+
+      layout = QtWidgets.QVBoxLayout()
+      layout.addWidget(self.lblInstr)
+      layout.addWidget(self.editSeed)
+      layout.addWidget(self.lblWordCount)
+      self.setLayout(layout)
+
+   def onTextChanged(self):
+      self.updateWordCount()
+      self.textChanged.emit()
+
+   def updateWordCount(self):
+      words = self.getWords()
+      count = len(words)
+      if count == 0:
+         self.lblWordCount.setText('0 words')
+         self.lblWordCount.setStyleSheet('color: gray;')
+      elif count in [12, 24]:
+         self.lblWordCount.setText('%d words ✓' % count)
+         self.lblWordCount.setStyleSheet('color: green;')
+      else:
+         self.lblWordCount.setText('%d words (need 12 or 24)' % count)
+         self.lblWordCount.setStyleSheet('color: orange;')
+
+   def getText(self):
+      return str(self.editSeed.toPlainText()).strip()
+
+   def getWords(self):
+      text = self.getText()
+      if not text:
+         return []
+      return text.split()
+
+   def getWordCount(self):
+      return len(self.getWords())
+
+   def isValidWordCount(self):
+      return self.getWordCount() in [12, 24]
+
+   def clear(self):
+      self.editSeed.clear()
+
+   def setInstructionText(self, text):
+      self.lblInstr.setText(text)
+
+
+################################################################################
+class AccountSelectionWidget(QtWidgets.QFrame):
+   """
+   A widget for selecting BIP account types (BIP44/BIP49/BIP84).
+   Used during BIP39 seed restore to choose which account types to create.
+   """
+
+   def __init__(self, parent=None):
+      super().__init__(parent)
+
+      self.lblTitle = QtWidgets.QLabel('<b>Account Types to Create:</b>')
+
+      self.chkBIP44 = QtWidgets.QCheckBox(
+         'BIP44 - Legacy (addresses start with 1)')
+      self.chkBIP49 = QtWidgets.QCheckBox(
+         'BIP49 - Nested SegWit (addresses start with 3)')
+      self.chkBIP84 = QtWidgets.QCheckBox(
+         'BIP84 - Native SegWit (addresses start with bc1q)')
+      self.chkBIP84.setChecked(True)
+
+      layout = QtWidgets.QVBoxLayout()
+      layout.addWidget(self.lblTitle)
+
+      layoutChk = QtWidgets.QHBoxLayout()
+      layoutChk.addWidget(self.chkBIP44)
+      layoutChk.addWidget(self.chkBIP49)
+      layoutChk.addWidget(self.chkBIP84)
+      layoutChk.addStretch()
+      layout.addLayout(layoutChk)
+      self.setLayout(layout)
+
+   def isBIP44Selected(self):
+      return self.chkBIP44.isChecked()
+
+   def isBIP49Selected(self):
+      return self.chkBIP49.isChecked()
+
+   def isBIP84Selected(self):
+      return self.chkBIP84.isChecked()
+
+   def isAnySelected(self):
+      return self.chkBIP44.isChecked() or \
+         self.chkBIP49.isChecked() or \
+         self.chkBIP84.isChecked()
+
+   def getSelectedTypes(self):
+      types = []
+      if self.chkBIP44.isChecked():
+         types.append('BIP44')
+      if self.chkBIP49.isChecked():
+         types.append('BIP49')
+      if self.chkBIP84.isChecked():
+         types.append('BIP84')
+      return types

--- a/ui/WalletFrames.py
+++ b/ui/WalletFrames.py
@@ -432,6 +432,16 @@ class NewWalletFrame(ArmoryFrame):
       lblManualEntropy.setAlignment(QtCore.Qt.AlignVCenter)
       lblManualEntropy.setBuddy(self.useManualEntropy)
 
+      lblWalletType = QtWidgets.QLabel(self.tr("<b>Wallet Type:</b>"))
+      self.radioBIP32 = QtWidgets.QRadioButton(
+         self.tr("BIP32/BIP39 (Modern HD wallet - recommended)"))
+      self.radioLegacy = QtWidgets.QRadioButton(
+         self.tr("Legacy Armory (Classic format)"))
+      self.radioBIP32.setChecked(True)
+      self.walletTypeGroup = QtWidgets.QButtonGroup()
+      self.walletTypeGroup.addButton(self.radioBIP32)
+      self.walletTypeGroup.addButton(self.radioLegacy)
+
       # breaking this up into tabs
       frameLayout = QtWidgets.QVBoxLayout()
       newWalletTabs = QtWidgets.QTabWidget()
@@ -440,10 +450,12 @@ class NewWalletFrame(ArmoryFrame):
       nameFrame = makeHorizFrame([lblName, STRETCH, self.editName])
       descriptionFrame = makeHorizFrame(
          [lblDescription, STRETCH, self.editDescription])
+      walletTypeFrame = makeVertFrame([
+         lblWalletType, self.radioBIP32, self.radioLegacy])
       entropyFrame = makeHorizFrame(
          [self.useManualEntropy, lblManualEntropy, STRETCH])
       basicQTab = makeVertFrame(
-         [nameFrame, descriptionFrame, entropyFrame, STRETCH])
+         [nameFrame, descriptionFrame, walletTypeFrame, entropyFrame, STRETCH])
       newWalletTabs.addTab(basicQTab, self.tr("Configure"))
 
       # Fork watching-only wallet
@@ -471,6 +483,11 @@ class NewWalletFrame(ArmoryFrame):
 
    def getDescription(self):
       return str(self.editDescription.toPlainText())
+
+   def getWalletType(self):
+      if self.radioBIP32.isChecked():
+         return 'structuredBip32'
+      return 'legacy'
 
 ################################################################################
 class CardDeckFrame(ArmoryFrame):
@@ -733,10 +750,12 @@ class WalletBackupFrame(ArmoryFrame):
    # Some static enums, and a QtWidgets.QRadioButton with mouse-enter/mouse-leave events
    FEATURES = enum('ProtGen', 'ProtImport', 'LostPass', 'Durable', \
       'Visual', 'Physical', 'Count')
-   OPTIONS = enum('Paper1', 'PaperN', 'DigPlain', 'DigCrypt', 'Export', 'Count')
+   OPTIONS = enum('Paper1', 'PaperN', 'DigPlain', 'DigCrypt', 'Export',
+      'SeedPhrase', 'Count')
    def __init__(self, parent, main, initLabel=''):
       super(WalletBackupFrame, self).__init__(parent, main)
       # Don't have a wallet yet so assume false.
+      self.wlt = None
       self.hasImportedAddr = False
       self.isBackupCreated = False
       self.passphrase = None
@@ -761,10 +780,13 @@ class WalletBackupFrame(ArmoryFrame):
          self.tr('Encrypted'), self.OPTIONS.DigCrypt)
       self.optIndivKeyListTop = QRadioButtonBackupCtr(self,
          self.tr('Export Key Lists'), self.OPTIONS.Export)
+      self.optSeedPhraseTop = QRadioButtonBackupCtr(self,
+         self.tr('Seed Phrase'), self.OPTIONS.SeedPhrase)
 
       self.optPaperBackupTop.setFont(GETFONT('Var', bold=True))
       self.optDigitalBackupTop.setFont(GETFONT('Var', bold=True))
       self.optIndivKeyListTop.setFont(GETFONT('Var', bold=True))
+      self.optSeedPhraseTop.setFont(GETFONT('Var', bold=True))
 
       # I need to be able to unset the sub-options when they become disabled
       self.optPaperBackupNONE = QtWidgets.QRadioButton('')
@@ -774,6 +796,7 @@ class WalletBackupFrame(ArmoryFrame):
       btngrpTop.addButton(self.optPaperBackupTop)
       btngrpTop.addButton(self.optDigitalBackupTop)
       btngrpTop.addButton(self.optIndivKeyListTop)
+      btngrpTop.addButton(self.optSeedPhraseTop)
       btngrpTop.setExclusive(True)
 
       btngrpPaper = QtWidgets.QButtonGroup(self)
@@ -795,6 +818,7 @@ class WalletBackupFrame(ArmoryFrame):
       self.optDigitalBackupPlain.clicked.connect(self.optionClicked)
       self.optDigitalBackupCrypt.clicked.connect(self.optionClicked)
       self.optIndivKeyListTop.clicked.connect(self.optionClicked)
+      self.optSeedPhraseTop.clicked.connect(self.optionClicked)
 
       spacer = lambda: QtWidgets.QSpacerItem(20, 1,
          QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Expanding)
@@ -806,6 +830,7 @@ class WalletBackupFrame(ArmoryFrame):
       layoutOpts.addItem(spacer(), 4, 0)
       layoutOpts.addItem(spacer(), 5, 0)
       layoutOpts.addWidget(self.optIndivKeyListTop, 6, 0, 1, 2)
+      layoutOpts.addWidget(self.optSeedPhraseTop, 7, 0, 1, 2)
 
       layoutOpts.addWidget(self.optPaperBackupOne, 1, 1)
       layoutOpts.addWidget(self.optPaperBackupFrag, 2, 1)
@@ -919,6 +944,8 @@ class WalletBackupFrame(ArmoryFrame):
 
    #############################################################################
    def setWallet(self, wlt):
+      if wlt is None:
+         return
       self.wlt = wlt
       wltId = wlt.getDisplayStr()
       wltName = wlt.labelName
@@ -1032,6 +1059,24 @@ class WalletBackupFrame(ArmoryFrame):
             self.featuresImgs[self.FEATURES.Visual    ].setPixmap(_X_())
             self.featuresImgs[self.FEATURES.Physical  ].setPixmap(_X_())
             self.lblDescrSelected.setText(txtIndivKeys)
+         elif index == self.OPTIONS.SeedPhrase:
+            self.lblSelFeat.setText(self.tr('Seed Phrase Backup'), bold=True)
+            self.featuresImgs[self.FEATURES.ProtGen   ].setPixmap(chk())
+            self.featuresImgs[self.FEATURES.ProtImport].setPixmap(_X_())
+            self.featuresImgs[self.FEATURES.LostPass  ].setPixmap(chk())
+            self.featuresImgs[self.FEATURES.Durable   ].setPixmap(chk())
+            self.featuresImgs[self.FEATURES.Visual    ].setPixmap(chk())
+            self.featuresImgs[self.FEATURES.Physical  ].setPixmap(_X_())
+            txtSeedPhrase = self.tr(
+               'Export your wallet seed as a mnemonic phrase. '
+               '<br><br>'
+               '<b>BIP39 format</b> can be imported into other wallet software. '
+               '<b>Easy16 format</b> (Armory native) preserves account structure '
+               'but can only be restored in Armory. '
+               '<br><br>'
+               '<font color="red"><b>WARNING:</b></font> Anyone with access to '
+               'your seed phrase has full control of your bitcoins!')
+            self.lblDescrSelected.setText(txtSeedPhrase)
          else:
             LOGERROR('What index was sent to setDispFrame? %d', index)
 
@@ -1051,6 +1096,8 @@ class WalletBackupFrame(ArmoryFrame):
          return self.OPTIONS.DigPlain
       elif self.optIndivKeyListTop.isChecked():
          return self.OPTIONS.Export
+      elif self.optSeedPhraseTop.isChecked():
+         return self.OPTIONS.SeedPhrase
       else:
          return 0
 
@@ -1086,6 +1133,18 @@ class WalletBackupFrame(ArmoryFrame):
          self.optDigitalBackupNONE.setChecked(True)
          self.optPaperBackupNONE.setChecked(True)
          self.btnDoIt.setText(self.tr('Export Key Lists'))
+      elif self.optSeedPhraseTop.isChecked():
+         self.optPaperBackupOne.setEnabled(False)
+         self.optPaperBackupFrag.setEnabled(False)
+         self.optPaperBackupOne.setChecked(False)
+         self.optPaperBackupFrag.setChecked(False)
+         self.optDigitalBackupPlain.setEnabled(False)
+         self.optDigitalBackupCrypt.setEnabled(False)
+         self.optDigitalBackupPlain.setChecked(False)
+         self.optDigitalBackupCrypt.setChecked(False)
+         self.optDigitalBackupNONE.setChecked(True)
+         self.optPaperBackupNONE.setChecked(True)
+         self.btnDoIt.setText(self.tr('View Seed Phrase'))
       self.setDispFrame(-1)
 
    def setPassphrase(self, passphrase):
@@ -1133,6 +1192,16 @@ class WalletBackupFrame(ArmoryFrame):
                      return
          DlgShowKeyList(self.wlt, self.parent(), self.main).exec_()
          isBackupCreated = True
+      elif self.optSeedPhraseTop.isChecked():
+         if self.wlt is None:
+            QtWidgets.QMessageBox.warning(self, self.tr('No Wallet'),
+               self.tr('No wallet is available for backup.'),
+               QtWidgets.QMessageBox.Ok)
+            return
+         from qtdialogs.DlgBackupCenter import DlgShowSeedPhrase
+         dlg = DlgShowSeedPhrase(self.parent(), self.main, self.wlt)
+         if dlg.exec_():
+            isBackupCreated = True
       if isBackupCreated:
          self.isBackupCreated = True
 

--- a/ui/Wizards.py
+++ b/ui/Wizards.py
@@ -281,12 +281,16 @@ class WalletWizard(ArmoryWizard):
 
       def finalizeInner(reply):
          if reply.success == False:
-            LOGDEBUG(f"create wallet failed with error: {reply.error}")
+            LOGERROR(f"create wallet failed with error: {reply.error}")
+            QtWidgets.QMessageBox.critical(self, self.tr('Wallet Creation Failed'),
+               self.tr('Failed to create wallet: %s') % str(reply.error),
+               QtWidgets.QMessageBox.Ok)
             self.reject()
          else:
             wltId = reply.utils.createWallet
             self.newWallet = PyBtcWallet().loadFromBridge(wltId)
             self.main.addWalletToApplication(self.newWallet, walletIsNew=True)
+            self.button(QtWidgets.QWizard.NextButton).setEnabled(True)
 
       def finalizeCb(reply):
          TheSignalExecution.executeMethod(finalizeInner, reply)
@@ -296,7 +300,8 @@ class WalletWizard(ArmoryWizard):
          replyCallback=finalizeCb, callbackId=handler.callbackId,
          shortLabel=self.walletCreationPage.pageFrame.getName(),
          longLabel=self.walletCreationPage.pageFrame.getDescription(),
-         extraEntropy=entropy)
+         extraEntropy=entropy,
+         walletType=self.walletCreationPage.pageFrame.getWalletType())
 
    def cleanupPage(self, *args, **kwargs):
       if self.hasCWOWPage and self.currentPage() == self.createWOWPage:


### PR DESCRIPTION
Adds UI support for BIP32/BIP39 seed phrase backup and restore functionality.

Backup:
- Add "Seed Phrase" option to Backup Center
- New DlgShowSeedPhrase dialog with blur/reveal functionality
- Auto-detects BIP39 vs Easy16 format based on wallet type
- Displays format compatibility info (universal vs Armory-only)

Restore:
- Add seed phrase input option to DlgRestoreSingle
- SeedPhraseInputWidget with real-time word count validation (12/24 words)
- AccountSelectionWidget for BIP44/49/84 account type selection

Wallet Creation:
- Add wallet type selection (BIP32/BIP39 vs Legacy) to NewWalletFrame
- BIP32/BIP39 set as default
- Pass walletType through PyBtcWallet to CppBridge

New Widgets (qtdefines.py):
- SeedPhraseDisplayWidget - blur/reveal seed display
- SeedPhraseInputWidget - seed entry with validation
- AccountSelectionWidget - BIP account type checkboxes

Fixes:
- Add PyBtcWallet.hasAnyImported() method
- Fix Qt signal connection syntax in DlgSimpleBackup
- Handle async callback race condition in DlgShowSeedPhrase