### PR TITLE
configure LWS AC_SUBST, missing C++ includes, capnp node status fields, pass integers to progress bar

### DIFF
--- a/ArmoryQt.py
+++ b/ArmoryQt.py
@@ -3554,10 +3554,10 @@ class ArmoryMainWindow(QtWidgets.QMainWindow):
          if showPct:
             if phase==BDMPhase_BlockHeaders or phase==BDMPhase_BlockData or phase==BDMPhase_DBHeaders:
                self.lblTimeLeftBuild.setText(tstring)
-               self.barProgressBuild.setValue(pvalue)
+               self.barProgressBuild.setValue(int(pvalue))
             elif phase==BDMPhase_Rescan or BDMPhase_ResolveHashes:
                self.lblTimeLeftScan.setText(tstring)
-               self.barProgressScan.setValue(pvalue)
+               self.barProgressScan.setValue(int(pvalue))
                self.lblTimeLeftScan.setVisible(True)
 
       elif sdmStr in ['NodeStatus_Initializing','NodeStatus_Syncing']:
@@ -3582,9 +3582,9 @@ class ArmoryMainWindow(QtWidgets.QMainWindow):
 
 
          if sdmStr == 'NodeStatus_Syncing':
-            sdmPercent = self.nodeStatus.chain_state.progress_pct * 100
+            sdmPercent = self.nodeStatus.chain.progress * 100
             self.lblTimeLeftSync.setText(\
-               "%d blocks remaining" % self.nodeStatus.chain_state.blocks_left)
+               "%d blocks remaining" % self.nodeStatus.chain.blocksLeft)
 
          elif sdmStr == 'NodeStatus_Initializing':
             sdmPercent = 0
@@ -4563,12 +4563,12 @@ class ArmoryMainWindow(QtWidgets.QMainWindow):
 
       elif action == NODESTATUS_UPDATE:
          prevStatus = None
-         if self.nodeStatus != None and self.nodeStatus.is_valid:
-            prevStatus = self.nodeStatus.node_state
+         if self.nodeStatus is not None and hasattr(self.nodeStatus, 'node'):
+            prevStatus = self.nodeStatus.node
          self.nodeStatus = args
 
-         if prevStatus != self.nodeStatus.node_state:
-            if self.nodeStatus.node_state == NodeStatus_Offline:
+         if prevStatus != self.nodeStatus.node:
+            if self.nodeStatus.node == 'offline':
                self.showTrayMsg(self.tr('Disconnected'),
                   self.tr('Connection to Bitcoin Core '
                      'client lost!  Armory cannot send nor '
@@ -4887,7 +4887,7 @@ class ArmoryMainWindow(QtWidgets.QMainWindow):
       self.ledgerView.setSelectionMode(QtWidgets.QTableView.SingleSelection)
 
 
-      self.ledgerView.verticalHeader().setDefaultSectionSize(sectionSz)
+      self.ledgerView.verticalHeader().setDefaultSectionSize(int(sectionSz))
       self.ledgerView.verticalHeader().hide()
       #self.ledgerView.horizontalHeader().setResizeMode(0, QHeaderView.Fixed)
       #self.ledgerView.horizontalHeader().setResizeMode(3, QHeaderView.Fixed)

--- a/configure.ac
+++ b/configure.ac
@@ -193,6 +193,8 @@ if test x$use_pkgconfig$with_own_lws = xyesno; then
     AC_MSG_RESULT($WEBSOCKETS_LIBDIR)
     AC_SUBST([WEBSOCKETS_LIBDIR])
     CXXFLAGS="${CXXFLAGS} ${WEBSOCKETS_CFLAGS}"
+    AC_SUBST([LWS_CFLAGS], ["${WEBSOCKETS_CFLAGS}"])
+    AC_SUBST([LWSLDFLAGS], ["${WEBSOCKETS_LIBS}"])
 else
     # Even if libraries don't directly use LWS, they may rely on libraries that do
     # rely on LWS. This causes the "child" libraries to rely on LWS too! Be sure to
@@ -200,6 +202,8 @@ else
     # "parent".
     AC_SUBST([WEBSOCKETS_LIBDIR], ["$with_own_lws/lib"])
     CXXFLAGS="${CXXFLAGS} -I$with_own_lws/include"
+    AC_SUBST([LWS_CFLAGS], ["-I$with_own_lws/include"])
+    AC_SUBST([LWSLDFLAGS], [""])
 fi
 
 if test x$with_own_libbtc = xno; then

--- a/cppForSwig/BridgeAPI/Wallets/Manager.cpp
+++ b/cppForSwig/BridgeAPI/Wallets/Manager.cpp
@@ -6,6 +6,7 @@
 //                                                                            //
 ////////////////////////////////////////////////////////////////////////////////
 
+#include <cstring>
 #include <filesystem>
 #include <string_view>
 

--- a/cppForSwig/Signer/TxEvalState.h
+++ b/cppForSwig/Signer/TxEvalState.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <stdint.h>
 #include <map>
 


### PR DESCRIPTION
Substitute LWS_CFLAGS and LWSLDFLAGS in configure.ac so the Makefiles receive the correct flags. Add missing `#include <cstddef>` and `#include <cstring>` for the GCC 12 build. In ArmoryQt, use the current Cap'n Proto node-status fields and pass integers to the progress UI (e.g. via `int()` where needed).