### PR TITLE
Fix export key list dialog for bridge/LMDB wallets

### DIFF
--- a/armoryengine/CppBridge.py
+++ b/armoryengine/CppBridge.py
@@ -1062,6 +1062,13 @@ class BridgeWalletWrapper(ProtoWrapper):
          changeRequest.control = None
       self.send(packet, callback=callback)
 
+   ####
+   def exportPrivateKeys(self, callback: callable, unlockHandler):
+      packet = self._getPacket()
+      req = packet.wallet.init("exportPrivateKeys")
+      req.callbackId = unlockHandler.callbackId
+      self.send(packet, callback=callback)
+
 ################################################################################
 class BridgeCoinSelectionWrapper(ProtoWrapper):
    #############################################################################

--- a/armoryengine/PyBtcWallet.py
+++ b/armoryengine/PyBtcWallet.py
@@ -128,6 +128,7 @@ class PyBtcWallet(object):
 
       #To enable/disable wallet row in wallet table model
       self.isEnabled = True
+      self.isLocked = False
 
       #list of callables and their args to perform after a wallet
       #has been scanned. Entries are order as follows:
@@ -141,6 +142,13 @@ class PyBtcWallet(object):
          self.bridgeWalletObj = BridgeWalletWrapper(wltId, accId)
       elif proto != None:
          self.loadFromProto(proto)
+
+      # Bridge wallets: C++ manages decryption via passphrase lambda.
+      # Legacy wallets: start locked when encryption is enabled.
+      if self.bridgeWalletObj is not None:
+         self.isLocked = False
+      else:
+         self.isLocked = self.useEncryption
 
    #############################################################################
    ## setup routines
@@ -662,6 +670,10 @@ class PyBtcWallet(object):
       passphrase: str=None, unlockHandler: callable=None):
       return self.bridgeWalletObj.createBackupStringForWallet(callback,
          passphrase, unlockHandler)
+
+   ####
+   def exportPrivateKeys(self, callback, unlockHandler):
+      return self.bridgeWalletObj.exportPrivateKeys(callback, unlockHandler)
 
    #############################################################################
    ## helpers

--- a/cppForSwig/BridgeAPI/CppBridge.cpp
+++ b/cppForSwig/BridgeAPI/CppBridge.cpp
@@ -755,6 +755,134 @@ void CppBridge::forkWatchingOnly(const Wallets::WalletId& wltId,
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+void CppBridge::exportPrivateKeys(const Wallets::WalletId& wltId,
+   const Wallets::AddressAccountId& accId,
+   const CallbackId& callbackId, MessageId msgId)
+{
+   auto func = [this, wltId, accId, callbackId, msgId]()
+   {
+      // (assetId serialized with PROTO_ASSETID_PREFIX, private key copy)
+      std::vector<std::pair<BinaryData, SecureBinaryData>> keyPairs;
+      std::string error;
+
+      std::shared_ptr<Wallets::AssetWallet_Single> wltSingle;
+      std::shared_ptr<BridgePassphrasePrompt> passPromptObj;
+
+      struct ExportKeysCleanup
+      {
+         std::shared_ptr<Wallets::AssetWallet_Single> wlt;
+         std::shared_ptr<BridgePassphrasePrompt> prompt;
+
+         ~ExportKeysCleanup()
+         {
+            if (wlt) {
+               wlt->resetPassphrasePromptLambda();
+            }
+            if (prompt) {
+               prompt->cleanup();
+            }
+         }
+      };
+
+      try {
+         //grab wallet container
+         std::shared_ptr<WalletContainer> wltContainer;
+         if (accId.isValid()) {
+            wltContainer = wltManager_->getWalletContainer(wltId, accId);
+         } else {
+            wltContainer = wltManager_->getWalletContainer(wltId);
+         }
+
+         auto wltPtr = wltContainer->getWalletPtr();
+         wltSingle = std::dynamic_pointer_cast<
+            Wallets::AssetWallet_Single>(wltPtr);
+         if (!wltSingle) {
+            throw std::runtime_error("wallet is not an AssetWallet_Single");
+         }
+
+         //setup passphrase prompt
+         passPromptObj = std::make_shared<BridgePassphrasePrompt>(
+            callbackId, [this](ServerPushWrapper wrapper){
+               this->callbackWriter(wrapper);
+            });
+         auto lbd = passPromptObj->getLambda();
+
+         wltSingle->setPassphrasePromptLambda(lbd);
+         ExportKeysCleanup cleanupGuard{wltSingle, passPromptObj};
+
+         //lock the decrypted container for the entire batch operation
+         auto lock = wltSingle->lockDecryptedContainer();
+
+         auto accPtr = wltContainer->getAddressAccount();
+         for (const auto& assetAccId : accPtr->getAccountIdSet()) {
+            auto assetAcc = accPtr->getAccountForID(assetAccId);
+            if (!assetAcc) {
+               continue;
+            }
+
+            auto lastIdx = assetAcc->getLastComputedIndex();
+            for (int32_t i = 0; i <= lastIdx; i++) {
+               auto assetPtr = assetAcc->getAssetForKey(i);
+               if (!assetPtr || !assetPtr->hasPrivateKey()) {
+                  continue;
+               }
+
+               auto assetSingle = std::dynamic_pointer_cast<
+                  Assets::AssetEntry_Single>(assetPtr);
+               if (!assetSingle) {
+                  continue;
+               }
+
+               const auto& assetID = assetPtr->getID();
+               const auto& serAssetId = assetID.getSerializedKey(
+                  PROTO_ASSETID_PREFIX);
+               const auto& privKey = wltSingle->getDecryptedPrivateKeyForAsset(
+                  assetSingle);
+
+               keyPairs.emplace_back(serAssetId, SecureBinaryData(privKey));
+            }
+         }
+         //lock released, DecryptedDataContainer wiped
+
+      } catch (const std::exception& e) {
+         error = e.what();
+      }
+
+      //build reply
+      capnp::MallocMessageBuilder message;
+      auto fromBridge = message.initRoot<FromBridge>();
+      auto reply = fromBridge.initReply();
+      reply.setReferenceId(msgId);
+
+      if (!error.empty()) {
+         reply.setSuccess(false);
+         reply.setError(error);
+      } else {
+         reply.setSuccess(true);
+         auto walletReply = reply.initWallet();
+         auto capnKeys = walletReply.initExportPrivateKeys(keyPairs.size());
+         for (size_t i = 0; i < keyPairs.size(); i++) {
+            auto capnKey = capnKeys[i];
+            const auto& id  = keyPairs[i].first;
+            const auto& key = keyPairs[i].second;
+            capnKey.setAssetId(capnp::Data::Builder(
+               (uint8_t*)id.getPtr(), id.getSize()));
+            capnKey.setPrivKey(capnp::Data::Builder(
+               (uint8_t*)key.getPtr(), key.getSize()));
+         }
+      }
+
+      writeToClient(serializeCapnp(message));
+      //keyPairs destroyed here; SecureBinaryData destructor zeroes memory
+   };
+
+   std::thread thr(func);
+   if (thr.joinable()) {
+      thr.detach();
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
 BinaryData CppBridge::loadWallets(MessageId msgId)
 {
    wltManager_->loadWallets();

--- a/cppForSwig/BridgeAPI/CppBridge.h
+++ b/cppForSwig/BridgeAPI/CppBridge.h
@@ -197,6 +197,8 @@ namespace Armory
          void importWallet(const std::filesystem::path&, MessageId);
          void forkWatchingOnly(const Wallets::WalletId&,
             const CallbackId&, MessageId);
+         void exportPrivateKeys(const Wallets::WalletId&,
+            const Wallets::AddressAccountId&, const CallbackId&, MessageId);
 
          //ledgers
          const std::string& getLedgerDelegateId(void);

--- a/cppForSwig/BridgeAPI/ProtoCommandParser.cpp
+++ b/cppForSwig/BridgeAPI/ProtoCommandParser.cpp
@@ -657,6 +657,14 @@ namespace
             break;
          }
 
+         case WalletRequest::EXPORT_PRIVATE_KEYS:
+         {
+            auto args = request.getExportPrivateKeys();
+            std::string callbackId{args.getCallbackId()};
+            bridge->exportPrivateKeys(walletId, accountId, callbackId, referenceId);
+            break;
+         }
+
          default:
             capnp::MallocMessageBuilder message;
             auto fromBridge = message.initRoot<FromBridge>();

--- a/cppForSwig/capnp/Bridge.capnp
+++ b/cppForSwig/capnp/Bridge.capnp
@@ -460,6 +460,10 @@ struct WalletRequest {
       description    @1 : Text;
    }
 
+   struct ExportPrivateKeysRequest {
+      callbackId     @0 : Types.CallbackId;
+   }
+
    walletId                         @0 : Types.WalletId;
    accountId                        @1 : Types.AccountId;
    union {
@@ -489,6 +493,7 @@ struct WalletRequest {
 
       getUnlockTime                 @19: Void;
       forkWatchingOnly              @20: Types.CallbackId;
+      exportPrivateKeys             @21: ExportPrivateKeysRequest;
    }
 }
 
@@ -502,6 +507,11 @@ struct WalletReply {
    struct AddressAndBalanceData {
       balances       @0 : List(AddressBalanceData);
       updatedAssets  @1 : List(WalletData.AddressData);
+   }
+
+   struct ExportedPrivateKey {
+      assetId  @0 : Data;
+      privKey  @1 : Data;
    }
 
    # reply
@@ -528,6 +538,7 @@ struct WalletReply {
       createAddressBook             @13: Types.AddressBook;
       getUnlockTime                 @14: UInt32; #unlock time in ms
       forkWatchingOnly              @15: Text; #path to new WO wallet
+      exportPrivateKeys             @16: List(ExportedPrivateKey);
    }
 }
 

--- a/qtdialogs/DlgShowKeyList.py
+++ b/qtdialogs/DlgShowKeyList.py
@@ -10,9 +10,26 @@
 #                                                                            #
 ##############################################################################
 
+from qtpy import QtCore, QtWidgets
+
 from qtdialogs.ArmoryDialog import ArmoryDialog
+from qtdialogs.MsgBoxWithDNAA import MsgBoxWithDNAA
+from qtdialogs.qtdefines import (
+   GETFONT, MSGBOX, STRETCH, STYLE_SUNKEN, USERMODE,
+   VERTICAL, HORIZONTAL, QRichLabel, makeLayoutFrame, tightSizeNChar,
+)
 from armoryengine.AddressUtils import encodePrivKeyBase58
+from armoryengine.ArmoryUtils import (
+   RightNow, binary_to_hex, binary_to_easyType16,
+   computeChecksum, hex_switchEndian, unixTimeToFormatStr,
+   LOGERROR, hash256, HMAC256,
+)
+from armoryengine.Settings import TheSettings
 from armoryengine.WalletUtils import determineWalletType, WalletTypes
+
+BACKUP_TYPE_135A = '1.35a'
+BACKUP_TYPE_135C = '1.35c'
+
 
 ################################################################################
 class DlgShowKeyList(ArmoryDialog):
@@ -20,31 +37,51 @@ class DlgShowKeyList(ArmoryDialog):
       super(DlgShowKeyList, self).__init__(parent, main)
 
       self.wlt = wlt
+      self.isBridgeWallet = bool(getattr(self.wlt, 'bridgeWalletObj', None))
 
-      self.havePriv = ((not self.wlt.useEncryption) or not (self.wlt.isLocked))
+      # For bridge wallets private keys arrive asynchronously via the cache.
+      # For legacy wallets they are already in addr.binPrivKey32_Plain.
+      self._privKeyCache = {}  # assetId (bytes) -> privkey (bytes)
 
       wltType = determineWalletType(self.wlt)
-      if wltType in (WalletTypes.Offline, WalletTypes.WatchOnly):
+      isWatchOnly = wltType in (WalletTypes.Offline, WalletTypes.WatchOnly)
+
+      if self.isBridgeWallet:
+         # Bridge wallets: private keys are fetched async; start locked.
          self.havePriv = False
+         self.rootKeyCopy = None
+         self.needChaincode = False
+         self.addrCopies = list(self.wlt.getLinearAddrList(withAddrPool=True))
+      else:
+         # Legacy wallets: keys are already decrypted in RAM.
+         self.havePriv = (not self.wlt.useEncryption) or (not self.wlt.isLocked)
+         if isWatchOnly:
+            self.havePriv = False
 
+         # NOTE/WARNING:  We have to make copies (in RAM) of the unencrypted
+         #                keys, or else we will have to type in our address
+         #                every 10s if we want to modify the key list.
+         self.addrCopies = []
+         for addr in self.wlt.getLinearAddrList(withAddrPool=True):
+            self.addrCopies.append(addr.copy())
 
-      # NOTE/WARNING:  We have to make copies (in RAM) of the unencrypted
-      #                keys, or else we will have to type in our address
-      #                every 10s if we want to modify the key list.  This
-      #                isn't likely a big problem, but it's not ideal,
-      #                either.  Not much I can do about, though...
-      #                (at least:  once this dialog is closed, all the
-      #                garbage should be collected...)
-      self.addrCopies = []
-      for addr in self.wlt.getLinearAddrList(withAddrPool=True):
-         self.addrCopies.append(addr.copy())
-      self.rootKeyCopy = self.wlt.addrMap['ROOT'].copy()
+         self.rootKeyCopy = self.wlt.addrMap.get('ROOT')
+         if self.rootKeyCopy is not None:
+            self.rootKeyCopy = self.rootKeyCopy.copy()
 
-      backupVersion = BACKUP_TYPE_135A
-      testChain = DeriveChaincodeFromRootKey(self.rootKeyCopy.binPrivKey32_Plain)
-      self.needChaincode = (not testChain == self.rootKeyCopy.chaincode)
-      if not self.needChaincode:
-         backupVersion = BACKUP_TYPE_135C
+         self.needChaincode = False
+         if self.rootKeyCopy is not None:
+            try:
+               rootPriv = self.rootKeyCopy.binPrivKey32_Plain.toBinStr()
+               testChain = HMAC256(
+                  hash256(rootPriv), b'Derive Chaincode from Root Key')
+               self.needChaincode = (
+                  testChain != self.rootKeyCopy.chaincode.toBinStr())
+            except Exception:
+               self.needChaincode = True
+
+         if isWatchOnly:
+            self.havePriv = False
 
       self.strDescrReg = (self.tr(
          'The textbox below shows all keys that are part of this wallet, '
@@ -79,16 +116,14 @@ class DlgShowKeyList(ArmoryDialog):
       self.txtBox.setMinimumHeight(int(h * 3.2))
       self.txtBox.setSizePolicy(QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Preferred)
 
-      # Create a list of checkboxes and then some ID word to identify what
-      # to put there
       self.chkList = {}
-      self.chkList['AddrStr'] = QtWidgets.QCheckBox(self.tr('Address String'))
-      self.chkList['PubKeyHash'] = QtWidgets.QCheckBox(self.tr('Hash160'))
+      self.chkList['AddrStr']   = QtWidgets.QCheckBox(self.tr('Address String'))
+      self.chkList['PubKeyHash']= QtWidgets.QCheckBox(self.tr('Hash160'))
       self.chkList['PrivCrypt'] = QtWidgets.QCheckBox(self.tr('Private Key (Encrypted)'))
       self.chkList['PrivHexBE'] = QtWidgets.QCheckBox(self.tr('Private Key (Plain Hex)'))
-      self.chkList['PrivB58'] = QtWidgets.QCheckBox(self.tr('Private Key (Plain Base58)'))
-      self.chkList['PubKey'] = QtWidgets.QCheckBox(self.tr('Public Key (BE)'))
-      self.chkList['ChainIndex'] = QtWidgets.QCheckBox(self.tr('Chain Index'))
+      self.chkList['PrivB58']   = QtWidgets.QCheckBox(self.tr('Private Key (Plain Base58)'))
+      self.chkList['PubKey']    = QtWidgets.QCheckBox(self.tr('Public Key (BE)'))
+      self.chkList['ChainIndex']= QtWidgets.QCheckBox(self.tr('Chain Index'))
 
       self.chkList['AddrStr'   ].setChecked(True)
       self.chkList['PubKeyHash'].setChecked(False)
@@ -98,32 +133,30 @@ class DlgShowKeyList(ArmoryDialog):
       self.chkList['PubKey'    ].setChecked(not self.havePriv)
       self.chkList['ChainIndex'].setChecked(False)
 
-      namelist = ['AddrStr', 'PubKeyHash', 'PrivB58', 'PrivCrypt', \
+      namelist = ['AddrStr', 'PubKeyHash', 'PrivB58', 'PrivCrypt',
                   'PrivHexBE', 'PubKey', 'ChainIndex']
 
       for name in self.chkList.keys():
          self.chkList[name].toggled.connect(self.rewriteList)
 
-
       self.chkImportedOnly = QtWidgets.QCheckBox(self.tr('Imported Addresses Only'))
       self.chkWithAddrPool = QtWidgets.QCheckBox(self.tr('Include Unused (Address Pool)'))
-      self.chkDispRootKey = QtWidgets.QCheckBox(self.tr('Include Paper Backup Root'))
-      self.chkOmitSpaces = QtWidgets.QCheckBox(self.tr('Omit spaces in key data'))
+      self.chkDispRootKey  = QtWidgets.QCheckBox(self.tr('Include Paper Backup Root'))
+      self.chkOmitSpaces   = QtWidgets.QCheckBox(self.tr('Omit spaces in key data'))
       self.chkDispRootKey.setChecked(True)
       self.chkImportedOnly.toggled.connect(self.rewriteList)
       self.chkWithAddrPool.toggled.connect(self.rewriteList)
       self.chkDispRootKey.toggled.connect(self.rewriteList)
       self.chkOmitSpaces.toggled.connect(self.rewriteList)
-      # self.chkCSV = QtWidgets.QCheckBox('Display in CSV format')
 
-      if not self.havePriv:
+      # Root key section not supported for bridge wallets or watch-only
+      hasRoot = (not self.isBridgeWallet) and (self.rootKeyCopy is not None)
+      if not self.havePriv or not hasRoot:
          self.chkDispRootKey.setChecked(False)
          self.chkDispRootKey.setEnabled(False)
 
-
       std = (self.main.usermode == USERMODE.Standard)
       adv = (self.main.usermode == USERMODE.Advanced)
-      dev = (self.main.usermode == USERMODE.Expert)
       if std:
          self.chkList['PubKeyHash'].setVisible(False)
          self.chkList['PrivCrypt' ].setVisible(False)
@@ -132,10 +165,7 @@ class DlgShowKeyList(ArmoryDialog):
          self.chkList['PubKeyHash'].setVisible(False)
          self.chkList['ChainIndex'].setVisible(False)
 
-      # We actually just want to remove these entirely
-      # (either we need to display all data needed for decryption,
-      # besides passphrase,  or we shouldn't show any of it)
-      self.chkList['PrivCrypt' ].setVisible(False)
+      self.chkList['PrivCrypt'].setVisible(False)
 
       chkBoxList = [self.chkList[n] for n in namelist]
       chkBoxList.append('Line')
@@ -145,10 +175,9 @@ class DlgShowKeyList(ArmoryDialog):
 
       frmChks = makeLayoutFrame(VERTICAL, chkBoxList, STYLE_SUNKEN)
 
-
-      btnGoBack = QtWidgets.QPushButton(self.tr('<<< Go Back'))
-      btnSaveFile = QtWidgets.QPushButton(self.tr('Save to File...'))
-      btnCopyClip = QtWidgets.QPushButton(self.tr('Copy to Clipboard'))
+      btnGoBack  = QtWidgets.QPushButton(self.tr('<<< Go Back'))
+      btnSaveFile= QtWidgets.QPushButton(self.tr('Save to File...'))
+      btnCopyClip= QtWidgets.QPushButton(self.tr('Copy to Clipboard'))
       self.lblCopied = QRichLabel('')
 
       btnGoBack.clicked.connect(self.accept)
@@ -166,6 +195,8 @@ class DlgShowKeyList(ArmoryDialog):
 
       frmDescr = makeLayoutFrame(HORIZONTAL, [self.lblDescr], STYLE_SUNKEN)
 
+      # Private-key columns: for bridge wallets they start disabled and are
+      # enabled after the async export call completes.
       if not self.havePriv or (self.wlt.useEncryption and self.wlt.isLocked):
          self.chkList['PrivHexBE'].setEnabled(False)
          self.chkList['PrivHexBE'].setChecked(False)
@@ -173,9 +204,9 @@ class DlgShowKeyList(ArmoryDialog):
          self.chkList['PrivB58'  ].setChecked(False)
 
       dlgLayout = QtWidgets.QGridLayout()
-      dlgLayout.addWidget(frmDescr, 0, 0, 1, 1)
-      dlgLayout.addWidget(frmChks, 0, 1, 1, 1)
-      dlgLayout.addWidget(self.txtBox, 1, 0, 1, 2)
+      dlgLayout.addWidget(frmDescr,  0, 0, 1, 1)
+      dlgLayout.addWidget(frmChks,   0, 1, 1, 1)
+      dlgLayout.addWidget(self.txtBox,1, 0, 1, 2)
       dlgLayout.addWidget(frmGoBack, 2, 0, 1, 2)
       dlgLayout.setRowStretch(0, 0)
       dlgLayout.setRowStretch(1, 1)
@@ -185,10 +216,51 @@ class DlgShowKeyList(ArmoryDialog):
       self.rewriteList()
       self.setWindowTitle(self.tr('All Wallet Keys'))
 
+      # For bridge wallets with private keys, kick off the async export now.
+      if self.isBridgeWallet and not isWatchOnly:
+         self._startBridgeExport()
+
+   def _startBridgeExport(self):
+      from qtdialogs.DlgUnlockWallet import UnlockWalletHandler
+      self._unlockHandler = UnlockWalletHandler(
+         self.wlt.walletId, self.tr('Export Key List'), self)
+
+      def _onKeysReceived(reply):
+         if reply.success:
+            cache = {}
+            for item in reply.wallet.exportPrivateKeys:
+               cache[bytes(item.assetId)] = bytes(item.privKey)
+            self._privKeyCache = cache
+            self.executeMethod(self._onKeysReady)
+         else:
+            err = getattr(reply, 'error', None) or self.tr('Export failed.')
+            LOGERROR('exportPrivateKeys failed: %s', err)
+            self.executeMethod(self._onExportFailed, str(err))
+
+      self.wlt.exportPrivateKeys(_onKeysReceived, self._unlockHandler)
+
+   def _onExportFailed(self, errMsg):
+      QtWidgets.QMessageBox.warning(
+         self, self.tr('Export Key List'),
+         self.tr('Could not export private keys from this wallet.') +
+         '<br><br>' + errMsg,
+         QtWidgets.QMessageBox.Ok)
+
+   def _walletDisplayId(self):
+      return getattr(self.wlt, 'uniqueIDB58', None) or self.wlt.walletId
+
+   def _onKeysReady(self):
+      if not self._privKeyCache:
+         return
+      # Enable and pre-check private key columns now that we have the keys.
+      self.chkList['PrivB58'  ].setEnabled(True)
+      self.chkList['PrivB58'  ].setChecked(True)
+      self.chkList['PrivHexBE'].setEnabled(True)
+      self.chkList['PrivHexBE'].setChecked(True)
+      self.chkList['PubKey'   ].setChecked(False)
+      self.rewriteList()
+
    def rewriteList(self, *args):
-      """
-      Write out all the wallet data
-      """
       whitespace = '' if self.chkOmitSpaces.isChecked() else ' '
 
       def fmtBin(s, nB=4, sw=False):
@@ -199,22 +271,23 @@ class DlgShowKeyList(ArmoryDialog):
 
       L = []
       L.append('Created:       ' + unixTimeToFormatStr(RightNow(), self.main.getPreferredDateFormat()))
-      L.append('Wallet ID:     ' + self.wlt.uniqueIDB58)
+      L.append('Wallet ID:     ' + self._walletDisplayId())
       L.append('Wallet Name:   ' + self.wlt.labelName)
       L.append('')
 
-      if self.chkDispRootKey.isChecked():
+      # --- Root key section (legacy wallets only) ---
+      if self.chkDispRootKey.isChecked() and self.rootKeyCopy is not None:
          binPriv0 = self.rootKeyCopy.binPrivKey32_Plain.toBinStr()[:16]
          binPriv1 = self.rootKeyCopy.binPrivKey32_Plain.toBinStr()[16:]
          binChain0 = self.rootKeyCopy.chaincode.toBinStr()[:16]
          binChain1 = self.rootKeyCopy.chaincode.toBinStr()[16:]
-         binPriv0Chk = computeChecksum(binPriv0, nBytes=2)
-         binPriv1Chk = computeChecksum(binPriv1, nBytes=2)
+         binPriv0Chk  = computeChecksum(binPriv0,  nBytes=2)
+         binPriv1Chk  = computeChecksum(binPriv1,  nBytes=2)
          binChain0Chk = computeChecksum(binChain0, nBytes=2)
          binChain1Chk = computeChecksum(binChain1, nBytes=2)
 
-         binPriv0 = binary_to_easyType16(binPriv0 + binPriv0Chk)
-         binPriv1 = binary_to_easyType16(binPriv1 + binPriv1Chk)
+         binPriv0  = binary_to_easyType16(binPriv0  + binPriv0Chk)
+         binPriv1  = binary_to_easyType16(binPriv1  + binPriv1Chk)
          binChain0 = binary_to_easyType16(binChain0 + binChain0Chk)
          binChain1 = binary_to_easyType16(binChain1 + binChain1Chk)
 
@@ -222,32 +295,23 @@ class DlgShowKeyList(ArmoryDialog):
          L.append('The following is the same information contained on your paper backup.')
          L.append('All NON-imported addresses in your wallet are backed up by this data.')
          L.append('')
-         L.append('Root Key:     ' + ' '.join([binPriv0[i:i + 4]  for i in range(0, 36, 4)]))
-         L.append('              ' + ' '.join([binPriv1[i:i + 4]  for i in range(0, 36, 4)]))
+         L.append('Root Key:     ' + ' '.join([binPriv0[i:i+4] for i in range(0, 36, 4)]))
+         L.append('              ' + ' '.join([binPriv1[i:i+4] for i in range(0, 36, 4)]))
          if self.needChaincode:
-            L.append('Chain Code:   ' + ' '.join([binChain0[i:i + 4] for i in range(0, 36, 4)]))
-            L.append('              ' + ' '.join([binChain1[i:i + 4] for i in range(0, 36, 4)]))
+            L.append('Chain Code:   ' + ' '.join([binChain0[i:i+4] for i in range(0, 36, 4)]))
+            L.append('              ' + ' '.join([binChain1[i:i+4] for i in range(0, 36, 4)]))
          L.append('-' * 80)
          L.append('')
 
-         # Cleanup all that sensitive data laying around in RAM
-         binPriv0, binPriv1 = None, None
-         binChain0, binChain1 = None, None
-         binPriv0Chk, binPriv1Chk = None, None
-         binChain0Chk, binChain1Chk = None, None
+         binPriv0 = binPriv1 = binChain0 = binChain1 = None
+         binPriv0Chk = binPriv1Chk = binChain0Chk = binChain1Chk = None
 
       self.havePriv = False
       topChain = self.wlt.getHighestUsedIndex()
       extraLbl = ''
 
       for addr in self.addrCopies:
-         try:
-            cppAddrObj = self.wlt.cppWallet.getAddrObjByIndex(addr.chainIndex)
-         except:
-            addrIndex = self.wlt.cppWallet.getAssetIndexForAddr(addr.getAddr160())
-            cppAddrObj = self.wlt.cppWallet.getAddrObjByIndex(addrIndex)
-
-         # Address pool
+         # Address pool filter
          if self.chkWithAddrPool.isChecked():
             if addr.chainIndex > topChain:
                extraLbl = '   (Unused/Address Pool)'
@@ -255,33 +319,20 @@ class DlgShowKeyList(ArmoryDialog):
             if addr.chainIndex > topChain:
                continue
 
-         # Imported Addresses
+         # Imported filter
          if self.chkImportedOnly.isChecked():
-            if not addr.chainIndex == -2:
+            if addr.chainIndex != -2:
                continue
          else:
             if addr.chainIndex == -2:
                extraLbl = '   (Imported)'
 
-         if self.chkList['AddrStr'   ].isChecked():
-            L.append(cppAddrObj.getScrAddr() + extraLbl)
-         if self.chkList['PubKeyHash'].isChecked():
-            L.append('   Hash160   : ' + fmtBin(addr.getAddr160()))
-         if self.chkList['PrivB58'   ].isChecked():
-            pB58 = encodePrivKeyBase58(addr.binPrivKey32_Plain.toBinStr())
-            pB58Stretch = whitespace.join([pB58[i:i + 6] for i in range(0, len(pB58), 6)])
-            L.append('   PrivBase58: ' + pB58Stretch)
-            self.havePriv = True
-         if self.chkList['PrivCrypt' ].isChecked():
-            L.append('   PrivCrypt : ' + fmtBin(addr.binPrivKey32_Encr.toBinStr()))
-         if self.chkList['PrivHexBE' ].isChecked():
-            L.append('   PrivHexBE : ' + fmtBin(addr.binPrivKey32_Plain.toBinStr()))
-            self.havePriv = True
-         if self.chkList['PubKey'    ].isChecked():
-            L.append('   PublicX   : ' + fmtBin(addr.binPublicKey65.toBinStr()[1:33 ]))
-            L.append('   PublicY   : ' + fmtBin(addr.binPublicKey65.toBinStr()[  33:]))
-         if self.chkList['ChainIndex'].isChecked():
-            L.append('   ChainIndex: ' + str(addr.chainIndex))
+         if self.isBridgeWallet:
+            self._appendBridgeAddr(L, addr, extraLbl, whitespace, fmtBin)
+         else:
+            self._appendLegacyAddr(L, addr, extraLbl, whitespace, fmtBin)
+
+         extraLbl = ''
 
       self.txtBox.setText('\n'.join(L))
       if self.havePriv:
@@ -289,29 +340,82 @@ class DlgShowKeyList(ArmoryDialog):
       else:
          self.lblDescr.setText(self.strDescrReg)
 
+   def _appendBridgeAddr(self, L, addr, extraLbl, whitespace, fmtBin):
+      addrStr = getattr(addr, 'addressString', None) or ''
+      if self.chkList['AddrStr'].isChecked():
+         L.append((addrStr or '(no address)') + extraLbl)
+      if self.chkList['PubKeyHash'].isChecked():
+         pubKeyHash = bytes(getattr(addr, 'prefixedHash', b''))
+         if len(pubKeyHash) > 1:
+            L.append('   Hash160   : ' + fmtBin(pubKeyHash[1:]))
+      if self.chkList['PrivB58'].isChecked() and addr.hasPrivKey:
+         privKeyBytes = self._privKeyCache.get(bytes(addr.assetId), b'')
+         if privKeyBytes:
+            pB58 = encodePrivKeyBase58(privKeyBytes)
+            pB58Stretch = whitespace.join([pB58[i:i+6] for i in range(0, len(pB58), 6)])
+            L.append('   PrivBase58: ' + pB58Stretch)
+            self.havePriv = True
+      if self.chkList['PrivHexBE'].isChecked() and addr.hasPrivKey:
+         privKeyBytes = self._privKeyCache.get(bytes(addr.assetId), b'')
+         if privKeyBytes:
+            L.append('   PrivHexBE : ' + fmtBin(privKeyBytes))
+            self.havePriv = True
+      if self.chkList['PubKey'].isChecked():
+         pubKey = bytes(getattr(addr, 'binPublicKey', b''))
+         if pubKey:
+            L.append('   PublicKey : ' + fmtBin(pubKey))
+      if self.chkList['ChainIndex'].isChecked():
+         L.append('   ChainIndex: ' + str(addr.chainIndex))
+
+   def _appendLegacyAddr(self, L, addr, extraLbl, whitespace, fmtBin):
+      try:
+         cppAddrObj = self.wlt.cppWallet.getAddrObjByIndex(addr.chainIndex)
+      except Exception:
+         addrIndex = self.wlt.cppWallet.getAssetIndexForAddr(addr.getAddr160())
+         cppAddrObj = self.wlt.cppWallet.getAddrObjByIndex(addrIndex)
+
+      if self.chkList['AddrStr'].isChecked():
+         L.append(cppAddrObj.getScrAddr() + extraLbl)
+      if self.chkList['PubKeyHash'].isChecked():
+         L.append('   Hash160   : ' + fmtBin(addr.getAddr160()))
+      if self.chkList['PrivB58'].isChecked():
+         pB58 = encodePrivKeyBase58(addr.binPrivKey32_Plain.toBinStr())
+         pB58Stretch = whitespace.join([pB58[i:i+6] for i in range(0, len(pB58), 6)])
+         L.append('   PrivBase58: ' + pB58Stretch)
+         self.havePriv = True
+      if self.chkList['PrivCrypt'].isChecked():
+         L.append('   PrivCrypt : ' + fmtBin(addr.binPrivKey32_Encr.toBinStr()))
+      if self.chkList['PrivHexBE'].isChecked():
+         L.append('   PrivHexBE : ' + fmtBin(addr.binPrivKey32_Plain.toBinStr()))
+         self.havePriv = True
+      if self.chkList['PubKey'].isChecked():
+         L.append('   PublicX   : ' + fmtBin(addr.binPublicKey65.toBinStr()[1:33]))
+         L.append('   PublicY   : ' + fmtBin(addr.binPublicKey65.toBinStr()[33:]))
+      if self.chkList['ChainIndex'].isChecked():
+         L.append('   ChainIndex: ' + str(addr.chainIndex))
+
    def saveToFile(self):
       if self.havePriv:
          if not TheSettings.getSettingOrSetDefault('DNAA_WarnPrintKeys', False):
-            result = MsgBoxWithDNAA(self, self.main, MSGBOX.Warning, title=self.tr('Plaintext Private Keys'), \
-                  msg=self.tr('<font color="red"><b>REMEMBER:</b></font> The data you '
-                  'are about to save contains private keys.  Please make sure '
-                  'that only trusted persons will have access to this file. '
-                  '<br><br>Are you sure you want to continue?'), \
-                  dnaaMsg=None, wCancel=True)
+            result = MsgBoxWithDNAA(self, self.main, MSGBOX.Warning,
+               title=self.tr('Plaintext Private Keys'),
+               msg=self.tr('<font color="red"><b>REMEMBER:</b></font> The data you '
+               'are about to save contains private keys.  Please make sure '
+               'that only trusted persons will have access to this file. '
+               '<br><br>Are you sure you want to continue?'),
+               dnaaMsg=None, wCancel=True)
             if not result[0]:
                return
             TheSettings.set('DNAA_WarnPrintKeys', result[1])
 
-      wltID = self.wlt.uniqueIDB58
-      fn = self.main.getFileSave(title=self.tr('Save Key List'), \
-                                 ffilter=[self.tr('Text Files (*.txt)')], \
+      wltID = self._walletDisplayId()
+      fn = self.main.getFileSave(title=self.tr('Save Key List'),
+                                 ffilter=[self.tr('Text Files (*.txt)')],
                                  defaultFilename=('keylist_%s_.txt' % wltID))
       if len(fn) > 0:
          fileobj = open(fn, 'w')
          fileobj.write(str(self.txtBox.toPlainText()))
          fileobj.close()
-
-
 
    def copyToClipboard(self):
       clipb = QtWidgets.QApplication.clipboard()
@@ -319,13 +423,22 @@ class DlgShowKeyList(ArmoryDialog):
       clipb.setText(str(self.txtBox.toPlainText()))
       self.lblCopied.setText(self.tr('<i>Copied!</i>'))
 
-
    def cleanup(self):
-      self.rootKeyCopy.binPrivKey32_Plain.destroy()
-      for addr in self.addrCopies:
-         addr.binPrivKey32_Plain.destroy()
+      if self.isBridgeWallet:
+         self._privKeyCache.clear()
+      else:
+         if self.rootKeyCopy is not None:
+            try:
+               self.rootKeyCopy.binPrivKey32_Plain.destroy()
+            except Exception:
+               pass
+         for addr in (self.addrCopies or []):
+            try:
+               addr.binPrivKey32_Plain.destroy()
+            except Exception:
+               pass
       self.rootKeyCopy = None
-      self.addrCopies = None
+      self.addrCopies  = None
 
    def accept(self):
       self.cleanup()

--- a/qtdialogs/DlgWalletDetails.py
+++ b/qtdialogs/DlgWalletDetails.py
@@ -537,7 +537,8 @@ class DlgWalletDetails(ArmoryDialog):
          pass  # not sure that I don't handle everything in the dialog itself
 
    def execKeyList(self):
-      if self.wlt.useEncryption and self.wlt.isLocked:
+      isBridge = bool(getattr(self.wlt, 'bridgeWalletObj', None))
+      if not isBridge and self.wlt.useEncryption and self.wlt.isLocked:
          dlg = DlgUnlockWallet(self.wlt, self, self.main, self.tr('Unlock Private Keys'))
          if not dlg.exec_():
             if self.main.usermode == USERMODE.Expert:

--- a/ui/WalletFrames.py
+++ b/ui/WalletFrames.py
@@ -1115,7 +1115,8 @@ class WalletBackupFrame(ArmoryFrame):
          isBackupCreated = self.main.makeWalletCopy(
             self, self.wlt, 'Encrypt', 'encrypt')
       elif self.optIndivKeyListTop.isChecked():
-         if self.wlt.useEncryption and self.wlt.isLocked:
+         isBridge = bool(getattr(self.wlt, 'bridgeWalletObj', None))
+         if not isBridge and self.wlt.useEncryption and self.wlt.isLocked:
             dlg = DlgUnlockWallet(self.wlt, self, self.main,
                'Unlock Private Keys')
             if not dlg.exec_():


### PR DESCRIPTION
Fix the export key list flow for bridge/LMDB wallets so the dialogs open and private keys show in the key list. Add a bridge API to fetch private keys by asset, fix missing imports in AddressUtils, and update the key list dialog to support bridge wallets and wallets without a ROOT key.

This makes it possible to open the export key list dialog and extract your private keys while running BitcoinArmory on a current linux distro.

Fixes #755