### PR TITLE
Add bridge API to export all wallet private keys

### DIFF
--- a/armoryengine/CppBridge.py
+++ b/armoryengine/CppBridge.py
@@ -1071,6 +1071,12 @@ class BridgeWalletWrapper(ProtoWrapper):
       reply = fut.getVal()
       return reply.wallet.hasImports
 
+   ####
+   def exportPrivateKeys(self, callback: callable, unlockHandler):
+      packet = self._getPacket()
+      packet.wallet.exportPrivateKeys = unlockHandler.callbackId
+      self.send(packet, callback=callback)
+
 ################################################################################
 class BridgeCoinSelectionWrapper(ProtoWrapper):
    #############################################################################

--- a/armoryengine/PyBtcWallet.py
+++ b/armoryengine/PyBtcWallet.py
@@ -663,6 +663,10 @@ class PyBtcWallet(object):
       return self.bridgeWalletObj.createBackupStringForWallet(callback,
          passphrase, unlockHandler)
 
+   ####
+   def exportPrivateKeys(self, callback, unlockHandler):
+      return self.bridgeWalletObj.exportPrivateKeys(callback, unlockHandler)
+
    #############################################################################
    ## helpers
    def getLinearAddrList(self, withImported=True, withAddrPool=False):

--- a/cppForSwig/BridgeAPI/CppBridge.cpp
+++ b/cppForSwig/BridgeAPI/CppBridge.cpp
@@ -755,6 +755,131 @@ void CppBridge::forkWatchingOnly(const Wallets::WalletId& wltId,
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+void CppBridge::exportPrivateKeys(const Wallets::WalletId& wltId,
+   const CallbackId& callbackId, MessageId msgId)
+{
+   auto func = [this, wltId, callbackId, msgId]()
+   {
+      // (assetId serialized with PROTO_ASSETID_PREFIX, private key copy)
+      std::vector<std::pair<BinaryData, SecureBinaryData>> keyPairs;
+      std::string error;
+
+      std::shared_ptr<BridgePassphrasePrompt> passPromptObj;
+
+      struct ExportKeysCleanup
+      {
+         std::shared_ptr<BridgePassphrasePrompt> prompt;
+
+         ~ExportKeysCleanup()
+         {
+            if (prompt) {
+               prompt->cleanup();
+            }
+         }
+      };
+
+      try {
+         auto wltContainer = wltManager_->getWalletContainer(wltId);
+         auto wltPtr = wltContainer->getWalletPtr();
+         auto wltSingle = std::dynamic_pointer_cast<
+            Wallets::AssetWallet_Single>(wltPtr);
+         if (!wltSingle) {
+            throw std::runtime_error("wallet is not an AssetWallet_Single");
+         }
+
+         //setup passphrase prompt
+         passPromptObj = std::make_shared<BridgePassphrasePrompt>(
+            callbackId, [this](ServerPushWrapper wrapper){
+               this->callbackWriter(wrapper);
+            });
+         auto lbd = passPromptObj->getLambda();
+         ExportKeysCleanup cleanupGuard{passPromptObj};
+
+         //lock the decrypted container for the entire batch operation;
+         //the unlock lambda lifetime is tied to this lock
+         auto lock = wltSingle->lockDecryptedContainer(lbd);
+
+         //export every private key in the wallet, walking all address
+         //accounts and their asset accounts. Keys are exported
+         //indiscriminately of address use state so that offline instances
+         //get the full set.
+         for (const auto& addrAccId : wltSingle->getAccountIDs()) {
+            auto accPtr = wltSingle->getAccountForID(addrAccId);
+            if (!accPtr) {
+               continue;
+            }
+
+            for (const auto& assetAccId : accPtr->getAccountIdSet()) {
+               auto assetAcc = accPtr->getAccountForID(assetAccId);
+               if (!assetAcc) {
+                  continue;
+               }
+
+               auto lastIdx = assetAcc->getLastComputedIndex();
+               for (int32_t i = 0; i <= lastIdx; i++) {
+                  auto assetPtr = assetAcc->getAssetForKey(i);
+                  if (!assetPtr || !assetPtr->hasPrivateKey()) {
+                     continue;
+                  }
+
+                  auto assetSingle = std::dynamic_pointer_cast<
+                     Assets::AssetEntry_Single>(assetPtr);
+                  if (!assetSingle) {
+                     continue;
+                  }
+
+                  const auto& assetID = assetPtr->getID();
+                  const auto& serAssetId = assetID.getSerializedKey(
+                     PROTO_ASSETID_PREFIX);
+                  const auto& privKey =
+                     wltSingle->getDecryptedPrivateKeyForAsset(assetSingle);
+
+                  keyPairs.emplace_back(serAssetId, SecureBinaryData(privKey));
+               }
+            }
+         }
+         //lock released, DecryptedDataContainer wiped
+
+      } catch (const std::exception& e) {
+         error = e.what();
+      }
+
+      //build reply
+      capnp::MallocMessageBuilder message;
+      auto fromBridge = message.initRoot<FromBridge>();
+      auto reply = fromBridge.initReply();
+      reply.setReferenceId(msgId);
+
+      if (!error.empty()) {
+         reply.setSuccess(false);
+         reply.setError(error);
+      } else {
+         reply.setSuccess(true);
+         auto walletReply = reply.initWallet();
+         auto capnKeys = walletReply.initExportPrivateKeys(keyPairs.size());
+         for (size_t i = 0; i < keyPairs.size(); i++) {
+            auto capnKey = capnKeys[i];
+            const auto& id  = keyPairs[i].first;
+            const auto& key = keyPairs[i].second;
+            capnKey.setAssetId(capnp::Data::Builder(
+               (uint8_t*)id.getPtr(), id.getSize()));
+            capnKey.setPrivKey(capnp::Data::Builder(
+               (uint8_t*)key.getPtr(), key.getSize()));
+         }
+      }
+
+      auto serialized = serializeCapnp(message);
+      this->writeToClient(serialized);
+      //keyPairs destroyed here; SecureBinaryData destructor zeroes memory
+   };
+
+   std::thread thr(func);
+   if (thr.joinable()) {
+      thr.detach();
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
 BinaryData CppBridge::loadWallets(MessageId msgId)
 {
    wltManager_->loadWallets();

--- a/cppForSwig/BridgeAPI/CppBridge.h
+++ b/cppForSwig/BridgeAPI/CppBridge.h
@@ -197,6 +197,8 @@ namespace Armory
          void importWallet(const std::filesystem::path&, MessageId);
          void forkWatchingOnly(const Wallets::WalletId&,
             const CallbackId&, MessageId);
+         void exportPrivateKeys(const Wallets::WalletId&,
+            const CallbackId&, MessageId);
 
          //ledgers
          const std::string& getLedgerDelegateId(void);

--- a/cppForSwig/BridgeAPI/ProtoCommandParser.cpp
+++ b/cppForSwig/BridgeAPI/ProtoCommandParser.cpp
@@ -678,6 +678,13 @@ namespace
             break;
          }
 
+         case WalletRequest::EXPORT_PRIVATE_KEYS:
+         {
+            std::string callbackId{request.getExportPrivateKeys()};
+            bridge->exportPrivateKeys(walletId, callbackId, referenceId);
+            break;
+         }
+
          default:
             capnp::MallocMessageBuilder message;
             auto fromBridge = message.initRoot<FromBridge>();

--- a/cppForSwig/capnp/Bridge.capnp
+++ b/cppForSwig/capnp/Bridge.capnp
@@ -490,6 +490,7 @@ struct WalletRequest {
       getUnlockTime                 @19: Void;
       forkWatchingOnly              @20: Types.CallbackId;
       hasImports                    @21: Void;
+      exportPrivateKeys             @22: Types.CallbackId;
    }
 }
 
@@ -503,6 +504,11 @@ struct WalletReply {
    struct AddressAndBalanceData {
       balances       @0 : List(AddressBalanceData);
       updatedAssets  @1 : List(WalletData.AddressData);
+   }
+
+   struct ExportedPrivateKey {
+      assetId  @0 : Data;
+      privKey  @1 : Data;
    }
 
    # reply
@@ -530,6 +536,7 @@ struct WalletReply {
       getUnlockTime                 @14: UInt32; #unlock time in ms
       forkWatchingOnly              @15: Text; #path to new WO wallet
       hasImports                    @16: Bool;
+      exportPrivateKeys             @17: List(ExportedPrivateKey);
    }
 }
 

--- a/cppForSwig/gtest/BridgeTests.cpp
+++ b/cppForSwig/gtest/BridgeTests.cpp
@@ -1154,6 +1154,109 @@ namespace {
       return true;
    }
 
+
+   //-----------------------------------------------------------------------
+   // exportPrivateKeys helper — mirrors changeWalletPassphrase pattern
+   //-----------------------------------------------------------------------
+   struct ExportResult {
+      bool success = false;
+      std::string error;
+      std::vector<std::pair<BinaryData, BinaryData>> keys;
+   };
+
+   ExportResult exportPrivateKeys(
+      std::shared_ptr<Bridge::CppBridge> bridge,
+      const std::string& walletId,
+      const std::string& passphrase,
+      bool provideCorrectPass = true)
+   {
+      ExportResult out;
+      auto callbackId = Cryptography::PRNG::fortuna.generateRandom(10).toHexStr();
+      uint64_t refId = rand();
+
+      //send export request
+      {
+         capnp::MallocMessageBuilder message;
+         auto toBridge = message.initRoot<Codec::Bridge::ToBridge>();
+         toBridge.setReferenceId(refId);
+         auto request = toBridge.initWallet();
+         request.setWalletId(walletId);
+
+         request.setExportPrivateKeys(callbackId);
+
+         auto rawReq = serializeCapnp(message);
+         pushRequest(bridge, rawReq);
+      }
+
+      //Process the notification flow until the terminal reply arrives.
+      //The flow is deterministic: either the wallet unlocks and a
+      //successful reply shows up, or the unlock is rejected, a cleanup
+      //notification is sent and the reply reports success == false.
+      while (true) {
+         auto result = waitOnReply();
+         kj::ArrayPtr<const capnp::word> words(
+            reinterpret_cast<const capnp::word*>(result->data.getPtr()),
+            result->data.getSize() / sizeof(capnp::word));
+         capnp::FlatArrayMessageReader reader(words);
+
+         auto fromBridge = reader.getRoot<Codec::Bridge::FromBridge>();
+
+         //terminal message: the only place a reply is parsed
+         if (fromBridge.which() == Codec::Bridge::FromBridge::REPLY) {
+            auto reply = fromBridge.getReply();
+            out.success = reply.getSuccess();
+            if (!out.success) {
+               out.error = reply.getError();
+            } else {
+               auto walletReply = reply.getWallet();
+               auto capnKeys = walletReply.getExportPrivateKeys();
+               for (auto k : capnKeys) {
+                  auto capnId  = k.getAssetId();
+                  auto capnKey = k.getPrivKey();
+                  out.keys.emplace_back(
+                     BinaryData(capnId.begin(),  capnId.size()),
+                     BinaryData(capnKey.begin(), capnKey.size()));
+               }
+            }
+            break;
+         }
+
+         if (fromBridge.which() != Codec::Bridge::FromBridge::NOTIFICATION) {
+            out.error = "unexpected message type";
+            break;
+         }
+
+         auto notif = fromBridge.getNotification();
+         if (notif.getCallbackId() != callbackId) {
+            out.error = "callback id mismatch";
+            break;
+         }
+
+         auto notifType = notif.which();
+         if (notifType == Codec::Bridge::Notification::UNLOCK_REQUEST) {
+            capnp::MallocMessageBuilder notifMsg;
+            auto notifBridge = notifMsg.initRoot<Codec::Bridge::ToBridge>();
+            auto notifReply = notifBridge.initNotification();
+            notifReply.setCounter(notif.getCounter());
+            if (provideCorrectPass) {
+               notifReply.setSuccess(true);
+               notifReply.setUnlockRequest(passphrase);
+            } else {
+               notifReply.setSuccess(false);
+            }
+            auto rawNotif = serializeCapnp(notifMsg);
+            pushRequest(bridge, rawNotif);
+         } else if (notifType == Codec::Bridge::Notification::CLEANUP) {
+            //unlock rejected; keep reading for the terminal reply
+            continue;
+         } else {
+            out.error = "unexpected notification type";
+            break;
+         }
+      }
+
+      return out;
+   }
    WalletData extendAddressPool(
       std::shared_ptr<Bridge::CppBridge> bridge,
       const std::string& walletId, const std::string& accountId,
@@ -5528,6 +5631,131 @@ TEST_F(BridgeWalletTests, ChangeWalletPassphrase)
       ASSERT_EQ(newLines[1], wltBackupLines[1]);
    } catch (const std::exception& e) {
       ASSERT_TRUE(false);
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+TEST_F(BridgeWalletTests, ExportPrivateKeysEncrypted)
+{
+   /* 1. create an encrypted wallet and count its full set of private keys.
+      The count is derived by walking the wallet the same way the bridge
+      does, so the export can be checked against every computed key rather
+      than an arbitrary lower bound. */
+   std::string walletId;
+   std::string privPass{"privPass1"};
+   unsigned lookup = 4;
+   size_t expectedKeyCount = 0;
+
+   {
+      Wallets::IO::CreateWalletParams params{
+         homedir,
+         {500ms, 0, SecureBinaryData::fromString(privPass)},
+         {1ms, 0, {}},
+         nullptr, lookup
+      };
+
+      std::unique_ptr<Seeds::ClearTextSeed> seed(
+         new Seeds::ClearTextSeed_Armory());
+      auto assetWlt = Wallets::AssetWallet_Single::createFromSeed(
+         std::move(seed), params);
+      walletId = assetWlt->getID();
+
+      for (const auto& addrAccId : assetWlt->getAccountIDs()) {
+         auto accPtr = assetWlt->getAccountForID(addrAccId);
+         ASSERT_NE(accPtr, nullptr);
+         for (const auto& assetAccId : accPtr->getAccountIdSet()) {
+            auto assetAcc = accPtr->getAccountForID(assetAccId);
+            ASSERT_NE(assetAcc, nullptr);
+            auto lastIdx = assetAcc->getLastComputedIndex();
+            for (int32_t i = 0; i <= lastIdx; i++) {
+               auto assetPtr = assetAcc->getAssetForKey(i);
+               if (assetPtr && assetPtr->hasPrivateKey()) {
+                  ++expectedKeyCount;
+               }
+            }
+         }
+      }
+   }
+   ASSERT_FALSE(walletId.empty());
+   //the wallet must hold more than a single key, otherwise the "export all"
+   //behaviour is not actually being exercised
+   ASSERT_GT(expectedKeyCount, 1ULL);
+
+   /* 2. load into bridge */
+   auto wltList = listWallets(bridge_);
+   ASSERT_EQ(wltList.size(), 1ULL);
+
+   auto wallets = loadWallets(bridge_);
+   ASSERT_EQ(wallets.size(), 1ULL);
+   ASSERT_EQ(wallets.begin()->first, walletId);
+
+   /* 3. export with correct passphrase: every private key must come back */
+   std::map<BinaryData, BinaryData> originalKeys;
+   {
+      auto result = exportPrivateKeys(bridge_, walletId, privPass, true);
+      ASSERT_TRUE(result.success) << "export failed: " << result.error;
+      ASSERT_EQ(result.keys.size(), expectedKeyCount);
+
+      for (const auto& kp : result.keys) {
+         EXPECT_GE(kp.first.getSize(), 1ULL);    // assetId non-empty
+         EXPECT_GE(kp.second.getSize(), 32ULL);  // privKey >= 32 bytes
+         originalKeys.emplace(kp.first, kp.second);
+      }
+      //no duplicate asset ids
+      ASSERT_EQ(originalKeys.size(), result.keys.size());
+   }
+
+   /* 4. export with wrong passphrase: unlock is rejected */
+   {
+      auto result = exportPrivateKeys(bridge_, walletId, "wrongPass", false);
+      EXPECT_FALSE(result.success);
+   }
+
+   /* 5. restore the wallet from its backup, then export again and check the
+      keys against the original export list. NOTE: restoring may recompute a
+      different portion of the address chain than the original lookahead pool,
+      which can legitimately surface fewer keys here. */
+   std::vector<std::string> lines;
+   try {
+      lines = getWalletBackup(bridge_, walletId, privPass,
+         Codec::Bridge::WalletBackup::Type::ARMORY200_A);
+   } catch (const std::exception& e) {
+      ASSERT_TRUE(false) << e.what();
+   }
+   ASSERT_EQ(lines.size(), 2);
+
+   restoreWallet(bridge_, lines, walletId,
+      Codec::Bridge::WalletBackup::Type::ARMORY200_A,
+      privPass, 1ms, 0, true,
+      //the legacy armory account always starts with asset 0
+      lookup - 1);
+
+   {
+      auto result = exportPrivateKeys(bridge_, walletId, privPass, true);
+      ASSERT_TRUE(result.success) << "export failed: " << result.error;
+
+      std::map<BinaryData, BinaryData> restoredKeys;
+      for (const auto& kp : result.keys) {
+         restoredKeys.emplace(kp.first, kp.second);
+      }
+
+      //every key the restored wallet did recompute must match the original
+      //export exactly (same asset id -> same private key)
+      for (const auto& kp : restoredKeys) {
+         auto it = originalKeys.find(kp.first);
+         ASSERT_NE(it, originalKeys.end())
+            << "restored an unexpected asset id: " << kp.first.toHexStr();
+         EXPECT_EQ(kp.second.toHexStr(), it->second.toHexStr())
+            << "private key mismatch for asset " << kp.first.toHexStr();
+      }
+
+      //the restored export must cover the full original set. Restoring may
+      //recompute fewer keys than the original lookahead pool, which surfaces
+      //the known "uncomputed private key" edge case rather than a defect in
+      //the export path itself.
+      EXPECT_EQ(restoredKeys.size(), originalKeys.size())
+         << "restored " << restoredKeys.size() << " keys, expected "
+         << originalKeys.size();
    }
 }
 

--- a/qtdialogs/DlgBackupCenter.py
+++ b/qtdialogs/DlgBackupCenter.py
@@ -23,8 +23,10 @@ from ui.QrCodeMatrix import CreateQRMatrix
 from ui.QtExecuteSignal import TheSignalExecution
 
 from qtdialogs.qtdefines import makeHorizFrame, QRichLabel, \
-   makeVertFrame, QImageLabel, HLINE, GETFONT, STYLE_RAISED, tightSizeStr, \
-   setLayoutStretch, STRETCH, createToolTipWidget, MSGBOX
+   makeVertFrame, QImageLabel, HLINE, GETFONT, STYLE_PLAIN, STYLE_RAISED, \
+   STYLE_STYLED, STYLE_SUNKEN, tightSizeStr, setLayoutStretch, \
+   setLayoutStretchRows, setLayoutStretchCols, STRETCH, createToolTipWidget, \
+   MSGBOX
 from qtdialogs.ArmoryDialog import ArmoryDialog
 from qtdialogs.DlgUnlockWallet import UnlockWalletHandler
 from qtdialogs.DlgRestore import getBackupTypeString, \
@@ -97,9 +99,9 @@ class DlgSimpleBackup(ArmoryDialog):
          self.accept()
          DlgBackupCenter(self, self.main, self.wlt).exec_()
 
-      btnPaper.connect.clicked(backupPaper)
-      btnDigital.connect.clicked(backupDigital)
-      btnOther.connect.clicked(backupOther)
+      btnPaper.clicked.connect(backupPaper)
+      btnDigital.clicked.connect(backupDigital)
+      btnOther.clicked.connect(backupOther)
 
       layout = QtWidgets.QGridLayout()
       layout.addWidget(lblPaper, 0, 0)
@@ -120,7 +122,7 @@ class DlgSimpleBackup(ArmoryDialog):
       frmGrid.setLayout(layout)
 
       btnClose = QtWidgets.QPushButton(self.tr('Done'))
-      btnClose.connect.clicked(self.accept)
+      btnClose.clicked.connect(self.accept)
       frmClose = makeHorizFrame([STRETCH, btnClose])
 
       frmAll = makeVertFrame([lblDescrTitle, lblDescr, frmGrid, frmClose])
@@ -1104,7 +1106,7 @@ class DlgFragBackup(ArmoryDialog):
       frmComboN = makeHorizFrame([STRETCH, QtWidgets.QLabel('N:'), self.comboN, STRETCH])
 
       btnPrintAll = QtWidgets.QPushButton(self.tr('Print All Fragments'))
-      btnPrintAll.connect.clicked(self.clickPrintAll)
+      btnPrintAll.clicked.connect(self.clickPrintAll)
       leftFrame = makeVertFrame([
          STRETCH,
          lblAboveM, frmComboM,


### PR DESCRIPTION
This description has been revised to reflect changes to the PR since the initial submission (rebased onto `0.97_rc2`, scoped to bridge + test only, and reworked per review feedback). The GUI changes are in #770.

Add a bridge API to export every private key in a wallet in one batch call, with a test that exercises encrypted export. This is the bridge-only first step toward fixing the export key list for bridge wallets; the GUI follow-up is a separate PR.

The export walks all address and asset accounts and returns every computed private key under a single `lockDecryptedContainer(lbd)` lock, using the post-rc2 unlock-lifetime API. The unlock callback id is passed as a plain `Types.CallbackId` with no dedicated request struct. `BridgeWalletTests.ExportPrivateKeysEncrypted` asserts the full key set is returned, rejects a wrong passphrase, and restores the wallet to compare the re-export against the original export (the restore step surfaces the known uncomputed-key edge case goatpig offered to fix alongside merge). This PR also fixes unrelated PySide6 signal connections in `DlgBackupCenter` so backup buttons work under PySide6.

Contributes to #755.

Tested by rebuilding `CppBridge` and `gtest/BridgeTests`, running `BridgeWalletTests.ExportPrivateKeysEncrypted` (export-all passes; the restore full-count assertion fails as expected pending the upstream edge-case fix), and manually exercising the full key-export GUI flow on the stacked GUI branch with an encrypted wallet in offline mode.