### PR TITLE
Fix a few startup and robustness issues on 0.97_rc2

### DIFF
--- a/armoryengine/CppBridge.py
+++ b/armoryengine/CppBridge.py
@@ -48,6 +48,24 @@ class BridgeSignerError(Exception):
    pass
 
 ################################################################################
+def findCppBridgeBinary() -> str:
+   #search candidate locations in priority order, return the first that exists
+   candidates = [
+      os.path.normpath(os.path.join(
+         os.path.dirname(os.path.abspath(__file__)), '..', 'CppBridge')),
+      os.path.join(os.getcwd(), 'CppBridge'),
+      os.path.join(os.getcwd(), 'build', 'CppBridge'),
+   ]
+
+   for candidate in candidates:
+      if os.path.isfile(candidate):
+         return candidate
+
+   triedPaths = '\n'.join('  ' + path for path in candidates)
+   raise BridgeError(
+      "could not find CppBridge binary; tried:\n" + triedPaths)
+
+################################################################################
 ##
 #### Tools
 ##
@@ -157,7 +175,7 @@ class BridgeSocket(object):
 
    ####
    def spawnBridge(self, args: list):
-      subprocess.run(["./build/CppBridge", *args])
+      subprocess.run([findCppBridgeBinary(), *args])
 
    #############################################################################
    ## socket write

--- a/armoryengine/CppBridge.py
+++ b/armoryengine/CppBridge.py
@@ -29,7 +29,26 @@ from armoryengine.BIP15x import \
 BRIDGE_CLIENT_HEADER = 1
 
 import sys
-sys.path.append("cppForSwig/capnp")
+
+################################################################################
+def findCapnpSchemaDir() -> str:
+   #search candidate locations for the capnp schema dir, in priority order
+   candidates = [
+      os.path.normpath(os.path.join(
+         os.path.dirname(os.path.abspath(__file__)),
+         '..', 'cppForSwig', 'capnp')),
+      os.path.join(os.getcwd(), 'cppForSwig', 'capnp'),
+   ]
+
+   for candidate in candidates:
+      if os.path.isdir(candidate):
+         return candidate
+
+   triedPaths = '\n'.join('  ' + path for path in candidates)
+   raise ImportError(
+      "could not find capnp schema directory; tried:\n" + triedPaths)
+
+sys.path.append(findCapnpSchemaDir())
 
 import capnp
 import Bridge_capnp as Bridge

--- a/cppForSwig/Utils/ArmoryConfig.cpp
+++ b/cppForSwig/Utils/ArmoryConfig.cpp
@@ -249,7 +249,11 @@ std::map<std::string, std::string> SettingsUtils::getKeyValsFromLines(
 {
    std::map<std::string, std::string> output;
    for (auto& line : lines) {
-      output.emplace(getKeyValFromLine(line, delim));
+      auto keyval = getKeyValFromLine(line, delim);
+      if (keyval.first.empty()) {
+         continue;
+      }
+      output.emplace(keyval);
    }
    return output;
 }

--- a/cppForSwig/gtest/UtilsTests.cpp
+++ b/cppForSwig/gtest/UtilsTests.cpp
@@ -37,6 +37,25 @@ using namespace std;
 using namespace Armory;
 
 ////////////////////////////////////////////////////////////////////////////////
+TEST(SettingsUtilsTest, GetKeyValsFromLines_SkipsEmptyLines)
+{
+   vector<string> lines{
+      "",
+      "key1=val1",
+      "",
+      "key2=val2",
+      ""
+   };
+
+   auto keyVals = Config::SettingsUtils::getKeyValsFromLines(lines, '=');
+
+   EXPECT_EQ(keyVals.size(), 2ULL);
+   EXPECT_EQ(keyVals.at("key1"), "val1");
+   EXPECT_EQ(keyVals.at("key2"), "val2");
+   EXPECT_EQ(keyVals.find(""), keyVals.end());
+}
+
+////////////////////////////////////////////////////////////////////////////////
 // RFC 5869 (HKDF) unit tests for SHA-256.
 class HKDF256Test : public ::testing::Test
 {

--- a/qtdialogs/qtdefines.py
+++ b/qtdialogs/qtdefines.py
@@ -518,7 +518,7 @@ class QLabelButton(QtWidgets.QLabel):
       txt = toBytes(self.text())
       if txt in self.mousePressOn:
          self.mousePressOn.remove(txt)
-         self.linkActivated.emit(ev)
+         self.linkActivated.emit(None)
 
    def enterEvent(self, ev):
       ssStr = "QtWidgets.QLabel { background-color : %s }" % \


### PR DESCRIPTION
Four small, independent fixes, one per commit.

The first and last share a cause: the client looked for the `CppBridge` binary and the capnp schemas at cwd-relative paths, so it only really started from the project root. Both now search a few candidate locations (module-relative first, then the old cwd-relative path) and raise a clear error listing what they tried if nothing is found.

The `QLabelButton` commit clears a PySide6 `Cannot copy-convert QMouseEvent to C++` error that fired on every click: the widget emits `linkActivated` (a `Signal(str)`) just as a "clicked" trigger, so it was handing a `QMouseEvent` to a string signal for no reason. It now emits `None`. The cleaner fix is a dedicated parameterless `clicked` signal, but that touches every call site and risks disturbing the real `<a href>` hyperlink labels nearby, so I kept this minimal for now.

The third commit guards `getKeyValsFromLines` against blank lines, which could crash startup.