### PR TITLE
Wire Export Key Lists GUI to bridge batch export

### DIFF
--- a/armoryengine/AddressUtils.py
+++ b/armoryengine/AddressUtils.py
@@ -16,7 +16,7 @@ import binascii
 from armoryengine.BinaryPacker import BinaryPacker, UINT8, BINARY_CHUNK
 from armoryengine.ArmoryUtils import DATATYPE, ADDRBYTE, P2SHBYTE, \
    binary_to_hex, prettyHex, hash256, hash160, SCRADDR_BYTE_LIST, \
-   ADDRBYTE, P2SHBYTE, LOGERROR
+   ADDRBYTE, P2SHBYTE, PRIVKEYBYTE, computeChecksum, LOGERROR
 
 
 ################################################################################

--- a/armoryengine/CppBridge.py
+++ b/armoryengine/CppBridge.py
@@ -1109,16 +1109,22 @@ class BridgeWalletWrapper(ProtoWrapper):
       return reply.wallet.hasImports
 
    ####
-   def exportPrivateKeys(self, callback: callable, unlockHandler):
+   def exportKeys(self, callback: callable, publicOnly=False, unlockHandler=None):
       packet = self._getPacket()
-      packet.wallet.exportPrivateKeys = unlockHandler.callbackId
+      exportReq = packet.wallet.init('exportKeys')
+      if publicOnly:
+         exportReq.publicDataOnly = None
+      else:
+         exportReq.withPrivateKeys = unlockHandler.callbackId
       self.send(packet, callback=callback)
 
    ####
+   def exportPrivateKeys(self, callback: callable, unlockHandler):
+      self.exportKeys(callback, publicOnly=False, unlockHandler=unlockHandler)
+
+   ####
    def exportPublicKeys(self, callback: callable):
-      packet = self._getPacket()
-      packet.wallet.exportPublicKeys = None
-      self.send(packet, callback=callback)
+      self.exportKeys(callback, publicOnly=True)
 
 ################################################################################
 class BridgeCoinSelectionWrapper(ProtoWrapper):

--- a/armoryengine/CppBridge.py
+++ b/armoryengine/CppBridge.py
@@ -1114,6 +1114,12 @@ class BridgeWalletWrapper(ProtoWrapper):
       packet.wallet.exportPrivateKeys = unlockHandler.callbackId
       self.send(packet, callback=callback)
 
+   ####
+   def exportPublicKeys(self, callback: callable):
+      packet = self._getPacket()
+      packet.wallet.exportPublicKeys = None
+      self.send(packet, callback=callback)
+
 ################################################################################
 class BridgeCoinSelectionWrapper(ProtoWrapper):
    #############################################################################

--- a/armoryengine/PyBtcWallet.py
+++ b/armoryengine/PyBtcWallet.py
@@ -664,12 +664,18 @@ class PyBtcWallet(object):
          passphrase, unlockHandler)
 
    ####
+   def exportKeys(self, callback, publicOnly=False, unlockHandler=None):
+      return self.bridgeWalletObj.exportKeys(
+         callback, publicOnly=publicOnly, unlockHandler=unlockHandler)
+
+   ####
    def exportPrivateKeys(self, callback, unlockHandler):
-      return self.bridgeWalletObj.exportPrivateKeys(callback, unlockHandler)
+      return self.exportKeys(callback, publicOnly=False,
+         unlockHandler=unlockHandler)
 
    ####
    def exportPublicKeys(self, callback):
-      return self.bridgeWalletObj.exportPublicKeys(callback)
+      return self.exportKeys(callback, publicOnly=True)
 
    #############################################################################
    ## helpers

--- a/armoryengine/PyBtcWallet.py
+++ b/armoryengine/PyBtcWallet.py
@@ -667,6 +667,10 @@ class PyBtcWallet(object):
    def exportPrivateKeys(self, callback, unlockHandler):
       return self.bridgeWalletObj.exportPrivateKeys(callback, unlockHandler)
 
+   ####
+   def exportPublicKeys(self, callback):
+      return self.bridgeWalletObj.exportPublicKeys(callback)
+
    #############################################################################
    ## helpers
    def getLinearAddrList(self, withImported=True, withAddrPool=False):

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ Unreleased (0.97_rc2)
    - Add Address Type column to the wallet key list dialog.
 
 == Changed ==
+   - Replace exportPrivateKeys and exportPublicKeys bridge requests with a single exportKeys request supporting public-only and with-private-keys modes.
    - Refactor CppBridge key export into a shared walker used by private and public export paths.
    - Encode nested address types in exported key metadata the same way as addressToCapnp.
    - Show public key list data on dialog open; request private keys only when a private-key column is enabled.
@@ -15,6 +16,11 @@ Unreleased (0.97_rc2)
    - Escape bridge error text in the key list dialog HTML label.
    - Reset private export in-progress state when the key list dialog closes.
    - Assert addrType metadata in ExportPublicKeysLegacy and restored-wallet export tests.
+   - Rename assertExportedKeyMatchesExpected to expectExportedKeyMatchesExpected in bridge export tests.
+   - Assert exact key counts and full export-set equality in bridge export tests.
+   - Extract buildExpectedExportKeys helper for reuse across bridge export tests.
+   - List eligible and default address types in the key list export header.
+   - Stop unchecking the Public Key column when private keys are loaded in the key list dialog.
 
 v0.96.5, released December 23rd 2018
 == Added ==

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,21 @@
+Unreleased (0.97_rc2)
+== Added ==
+   - Add exportPublicKeys bridge request to export address and public-key metadata without unlocking the wallet.
+   - Add Address Type column to the wallet key list dialog.
+
+== Changed ==
+   - Refactor CppBridge key export into a shared walker used by private and public export paths.
+   - Encode nested address types in exported key metadata the same way as addressToCapnp.
+   - Show public key list data on dialog open; request private keys only when a private-key column is enabled.
+   - Extend BridgeWalletTests export helpers to assert asset ids, public keys, addresses, indices, and address types.
+   - Add ExportPublicKeysNoUnlock and ExportPublicKeysLegacy bridge wallet tests.
+   - Skip empty privKey in capnp export replies for the public export path.
+   - Guard private key export against duplicate unlock prompts when both priv-key columns are toggled quickly.
+   - Show private key export failures in the key list dialog without clearing public data.
+   - Escape bridge error text in the key list dialog HTML label.
+   - Reset private export in-progress state when the key list dialog closes.
+   - Assert addrType metadata in ExportPublicKeysLegacy and restored-wallet export tests.
+
 v0.96.5, released December 23rd 2018
 == Added ==
    - You can now set the database path from the Settings menu.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,26 +1,16 @@
 Unreleased (0.97_rc2)
 == Added ==
-   - Add exportPublicKeys bridge request to export address and public-key metadata without unlocking the wallet.
+   - Add exportKeys bridge request supporting public-only and passphrase-gated private key export.
    - Add Address Type column to the wallet key list dialog.
 
 == Changed ==
-   - Replace exportPrivateKeys and exportPublicKeys bridge requests with a single exportKeys request supporting public-only and with-private-keys modes.
-   - Refactor CppBridge key export into a shared walker used by private and public export paths.
-   - Encode nested address types in exported key metadata the same way as addressToCapnp.
-   - Show public key list data on dialog open; request private keys only when a private-key column is enabled.
-   - Extend BridgeWalletTests export helpers to assert asset ids, public keys, addresses, indices, and address types.
-   - Add ExportPublicKeysNoUnlock and ExportPublicKeysLegacy bridge wallet tests.
-   - Skip empty privKey in capnp export replies for the public export path.
-   - Guard private key export against duplicate unlock prompts when both priv-key columns are toggled quickly.
-   - Show private key export failures in the key list dialog without clearing public data.
-   - Escape bridge error text in the key list dialog HTML label.
-   - Reset private export in-progress state when the key list dialog closes.
-   - Assert addrType metadata in ExportPublicKeysLegacy and restored-wallet export tests.
-   - Rename assertExportedKeyMatchesExpected to expectExportedKeyMatchesExpected in bridge export tests.
-   - Assert exact key counts and full export-set equality in bridge export tests.
-   - Extract buildExpectedExportKeys helper for reuse across bridge export tests.
+   - Show key list public data on dialog open without unlocking the wallet.
+   - Request private keys only when a private-key column is enabled.
    - List eligible and default address types in the key list export header.
+   - Fix exported public key compression for legacy address types.
+   - Show private key export failures in the key list dialog without clearing public data.
    - Stop unchecking the Public Key column when private keys are loaded in the key list dialog.
+   - Guard private key export against duplicate unlock prompts when both priv-key columns are toggled quickly.
 
 v0.96.5, released December 23rd 2018
 == Added ==

--- a/cppForSwig/BridgeAPI/CppBridge.cpp
+++ b/cppForSwig/BridgeAPI/CppBridge.cpp
@@ -755,23 +755,188 @@ void CppBridge::forkWatchingOnly(const Wallets::WalletId& wltId,
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+namespace {
+   struct ExportedKeyData
+   {
+      BinaryData assetId;
+      SecureBinaryData privKey;
+      BinaryData pubKey;
+      std::string addressString;
+      uint32_t addrType = 0;
+      int32_t index = 0;
+   };
+
+   void fillExportedKeyMetadata(ExportedKeyData& entry,
+      const std::shared_ptr<Accounts::AddressAccount>& accPtr,
+      const Wallets::AssetId& assetID)
+   {
+      try {
+         auto addrEntry = accPtr->getAddressEntryForID(assetID);
+         if (addrEntry == nullptr) {
+            return;
+         }
+
+         uint32_t addrType = (uint32_t)addrEntry->getType();
+         auto addrNested = std::dynamic_pointer_cast<
+            AddressEntry_Nested>(addrEntry);
+         if (addrNested != nullptr) {
+            addrType |= (uint32_t)addrNested->getPredecessor()->getType();
+         }
+         entry.addrType = addrType;
+
+         try {
+            if (addrNested != nullptr) {
+               entry.pubKey = addrNested->getPredecessor()->getPreimage();
+            } else {
+               entry.pubKey = addrEntry->getPreimage();
+            }
+         } catch (const AddressException&) {
+            //no public key for this address type, leave empty
+         }
+
+         try {
+            entry.addressString = addrEntry->getAddress();
+         } catch (const AddressException&) {
+            //address type yields no human readable string
+         }
+      } catch (const std::exception&) {
+         //asset has no instantiable address, leave blank
+      }
+   }
+
+   std::vector<ExportedKeyData> collectExportedKeys(
+      const std::shared_ptr<Wallets::AssetWallet_Single>& wltSingle,
+      bool includePrivateKeys,
+      const std::function<Passphrase::Result(
+         const std::set<Wallets::EncryptionKeyId>&)>& decryptLbd)
+   {
+      std::vector<ExportedKeyData> exportedKeys;
+
+      auto walkWallet = [&]()
+      {
+         for (const auto& addrAccId : wltSingle->getAccountIDs()) {
+            auto accPtr = wltSingle->getAccountForID(addrAccId);
+            if (!accPtr) {
+               continue;
+            }
+
+            for (const auto& assetAccId : accPtr->getAccountIdSet()) {
+               auto assetAcc = accPtr->getAccountForID(assetAccId);
+               if (!assetAcc) {
+                  continue;
+               }
+
+               switch (assetAcc->type()) {
+                  case Accounts::AssetAccountType::Plain:
+                  case Accounts::AssetAccountType::Imports:
+                     break;
+
+                  case Accounts::AssetAccountType::ECDH:
+                  case Accounts::AssetAccountType::ImportsWO:
+                     continue;
+
+                  default:
+                     LOGWARN << "trying to export keys" <<
+                        " from unsupported account type";
+                     continue;
+               }
+
+               auto lastIdx = assetAcc->getLastComputedIndex();
+               for (int32_t i = lastIdx; i >= 0; i--) {
+                  auto assetPtr = assetAcc->getAssetForKey(i);
+                  auto assetSingle = std::dynamic_pointer_cast<
+                     Assets::AssetEntry_Single>(assetPtr);
+                  if (!assetSingle) {
+                     continue;
+                  }
+
+                  const auto& assetID = assetPtr->getID();
+
+                  ExportedKeyData entry;
+                  entry.assetId = assetID.getSerializedKey(PROTO_ASSETID_PREFIX);
+                  entry.index = assetSingle->getIndex();
+
+                  if (includePrivateKeys) {
+                     const auto& privKey =
+                        wltSingle->getDecryptedPrivateKeyForAsset(assetSingle);
+                     entry.privKey = SecureBinaryData(privKey);
+                  }
+
+                  fillExportedKeyMetadata(entry, accPtr, assetID);
+                  exportedKeys.emplace_back(std::move(entry));
+               }
+            }
+         }
+      };
+
+      if (includePrivateKeys) {
+         auto lock = wltSingle->lockDecryptedContainer(decryptLbd);
+         walkWallet();
+      } else {
+         walkWallet();
+      }
+
+      return exportedKeys;
+   }
+
+   void populateExportedKey(WalletReply::ExportedPrivateKey::Builder& capnKey,
+      const ExportedKeyData& entry)
+   {
+      capnKey.setAssetId(capnp::Data::Builder(
+         (uint8_t*)entry.assetId.getPtr(), entry.assetId.getSize()));
+      if (!entry.privKey.empty()) {
+         capnKey.setPrivKey(capnp::Data::Builder(
+            (uint8_t*)entry.privKey.getPtr(), entry.privKey.getSize()));
+      }
+      if (!entry.pubKey.empty()) {
+         capnKey.setPublicKey(capnp::Data::Builder(
+            (uint8_t*)entry.pubKey.getPtr(), entry.pubKey.getSize()));
+      }
+      capnKey.setAddressString(entry.addressString);
+      capnKey.setAddrType(entry.addrType);
+      capnKey.setIndex(entry.index);
+   }
+
+   BinaryData buildExportedKeysReply(MessageId msgId,
+      const std::vector<ExportedKeyData>& exportedKeys,
+      const std::string& error, bool publicExport)
+   {
+      capnp::MallocMessageBuilder message;
+      auto fromBridge = message.initRoot<FromBridge>();
+      auto reply = fromBridge.initReply();
+      reply.setReferenceId(msgId);
+
+      if (!error.empty()) {
+         reply.setSuccess(false);
+         reply.setError(error);
+      } else {
+         reply.setSuccess(true);
+         auto walletReply = reply.initWallet();
+         if (publicExport) {
+            auto capnKeys = walletReply.initExportPublicKeys(exportedKeys.size());
+            for (size_t i = 0; i < exportedKeys.size(); i++) {
+               auto capnKey = capnKeys[i];
+               populateExportedKey(capnKey, exportedKeys[i]);
+            }
+         } else {
+            auto capnKeys = walletReply.initExportPrivateKeys(exportedKeys.size());
+            for (size_t i = 0; i < exportedKeys.size(); i++) {
+               auto capnKey = capnKeys[i];
+               populateExportedKey(capnKey, exportedKeys[i]);
+            }
+         }
+      }
+
+      return serializeCapnp(message);
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
 void CppBridge::exportPrivateKeys(const Wallets::WalletId& wltId,
    const CallbackId& callbackId, MessageId msgId)
 {
    auto func = [this, wltId, callbackId, msgId]()
    {
-      //one entry per exported key: the serialized asset id (with
-      //PROTO_ASSETID_PREFIX), the decrypted private key and the public
-      //metadata needed to render the key without the in-use address map
-      struct ExportedKeyData
-      {
-         BinaryData assetId;
-         SecureBinaryData privKey;
-         BinaryData pubKey;
-         std::string addressString;
-         uint32_t addrType = 0;
-         int32_t index = 0;
-      };
       std::vector<ExportedKeyData> exportedKeys;
       std::string error;
 
@@ -802,7 +967,6 @@ void CppBridge::exportPrivateKeys(const Wallets::WalletId& wltId,
             throw std::runtime_error("this is a WO wallet");
          }
 
-         //setup passphrase prompt
          passPromptObj = std::make_shared<BridgePassphrasePrompt>(
             callbackId, [this](ServerPushWrapper wrapper){
                this->callbackWriter(wrapper);
@@ -810,140 +974,53 @@ void CppBridge::exportPrivateKeys(const Wallets::WalletId& wltId,
          auto lbd = passPromptObj->getLambda();
          ExportKeysCleanup cleanupGuard{passPromptObj};
 
-         //lock the decrypted container for the entire batch operation;
-         //the unlock lambda lifetime is tied to this lock
-         auto lock = wltSingle->lockDecryptedContainer(lbd);
-
-         //export every private key in the wallet, walking all address
-         //accounts and their asset accounts. Keys are exported
-         //indiscriminately of address use state so that offline instances
-         //get the full set.
-         for (const auto& addrAccId : wltSingle->getAccountIDs()) {
-            auto accPtr = wltSingle->getAccountForID(addrAccId);
-            if (!accPtr) {
-               continue;
-            }
-
-            for (const auto& assetAccId : accPtr->getAccountIdSet()) {
-               auto assetAcc = accPtr->getAccountForID(assetAccId);
-               if (!assetAcc) {
-                  continue;
-               }
-
-               //check this account carries private keys
-               switch (assetAcc->type()) {
-                  //these accounts have private keys
-                  case Accounts::AssetAccountType::Plain:
-                  case Accounts::AssetAccountType::Imports:
-                     break;
-
-                  //these accounts do not carry private keys
-                  case Accounts::AssetAccountType::ECDH:
-                  case Accounts::AssetAccountType::ImportsWO:
-                     continue;
-
-                  default:
-                     LOGWARN << "trying to export private keys" <<
-                        " from unsupported account type";
-                     continue;
-               }
-
-               //getDecryptedPrivateKeyForAsset will fill missing private keys
-               //run backwards the assets to compute missing keys in batch
-               //rather than sequentially
-               //TODO: add progressCallback logic to extend/fillPrivateKey
-               auto lastIdx = assetAcc->getLastComputedIndex();
-               for (int32_t i = lastIdx; i >= 0; i--) {
-                  auto assetPtr = assetAcc->getAssetForKey(i);
-                  auto assetSingle = std::dynamic_pointer_cast<
-                     Assets::AssetEntry_Single>(assetPtr);
-                  if (!assetSingle) {
-                     continue;
-                  }
-
-                  const auto& assetID = assetPtr->getID();
-                  const auto& privKey =
-                     wltSingle->getDecryptedPrivateKeyForAsset(assetSingle);
-
-                  ExportedKeyData entry;
-                  entry.assetId = assetID.getSerializedKey(PROTO_ASSETID_PREFIX);
-                  entry.privKey = SecureBinaryData(privKey);
-                  entry.index = assetSingle->getIndex();
-
-                  //human readable address, type and public key, derived on the
-                  //fly for the account's default address type
-                  try {
-                     auto addrEntry = accPtr->getAddressEntryForID(assetID);
-                     if (addrEntry != nullptr) {
-                        entry.addrType = (uint32_t)addrEntry->getType();
-
-                        //public key is dictated by the address entry
-                        try {
-                           auto addrNested = std::dynamic_pointer_cast<
-                              AddressEntry_Nested>(addrEntry);
-                           if (addrNested != nullptr) {
-                              entry.pubKey = addrNested->getPredecessor()->
-                                 getPreimage();
-                           } else {
-                              entry.pubKey = addrEntry->getPreimage();
-                           }
-                        } catch (const AddressException&) {
-                           //no public key for this address type, leave empty
-                        }
-
-                        try {
-                           entry.addressString = addrEntry->getAddress();
-                        } catch (const AddressException&) {
-                           //address type yields no human readable string
-                        }
-                     }
-                  } catch (const std::exception&) {
-                     //asset has no instantiable address, leave blank
-                  }
-
-                  exportedKeys.emplace_back(std::move(entry));
-               }
-            }
-         }
-         //lock released, DecryptedDataContainer wiped
+         exportedKeys = collectExportedKeys(wltSingle, true, lbd);
 
       } catch (const std::exception& e) {
          error = e.what();
       }
 
-      //build reply
-      capnp::MallocMessageBuilder message;
-      auto fromBridge = message.initRoot<FromBridge>();
-      auto reply = fromBridge.initReply();
-      reply.setReferenceId(msgId);
+      auto serialized = buildExportedKeysReply(
+         msgId, exportedKeys, error, false);
+      this->writeToClient(serialized);
+   };
 
-      if (!error.empty()) {
-         reply.setSuccess(false);
-         reply.setError(error);
-      } else {
-         reply.setSuccess(true);
-         auto walletReply = reply.initWallet();
-         auto capnKeys = walletReply.initExportPrivateKeys(exportedKeys.size());
-         for (size_t i = 0; i < exportedKeys.size(); i++) {
-            auto capnKey = capnKeys[i];
-            const auto& entry = exportedKeys[i];
-            capnKey.setAssetId(capnp::Data::Builder(
-               (uint8_t*)entry.assetId.getPtr(), entry.assetId.getSize()));
-            capnKey.setPrivKey(capnp::Data::Builder(
-               (uint8_t*)entry.privKey.getPtr(), entry.privKey.getSize()));
-            if (!entry.pubKey.empty()) {
-               capnKey.setPublicKey(capnp::Data::Builder(
-                  (uint8_t*)entry.pubKey.getPtr(), entry.pubKey.getSize()));
-            }
-            capnKey.setAddressString(entry.addressString);
-            capnKey.setAddrType(entry.addrType);
-            capnKey.setIndex(entry.index);
+   std::thread thr(func);
+   if (thr.joinable()) {
+      thr.detach();
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+void CppBridge::exportPublicKeys(const Wallets::WalletId& wltId,
+   MessageId msgId)
+{
+   auto func = [this, wltId, msgId]()
+   {
+      std::vector<ExportedKeyData> exportedKeys;
+      std::string error;
+
+      try {
+         auto wltContainer = wltManager_->getWalletContainer(wltId);
+         auto wltPtr = wltContainer->getWalletPtr();
+         auto wltSingle = std::dynamic_pointer_cast<
+            Wallets::AssetWallet_Single>(wltPtr);
+         if (!wltSingle) {
+            throw std::runtime_error("wallet is not an AssetWallet_Single");
          }
+
+         exportedKeys = collectExportedKeys(wltSingle, false,
+            [](const std::set<Wallets::EncryptionKeyId>&)->Passphrase::Result{
+               return {{}, false};
+            });
+
+      } catch (const std::exception& e) {
+         error = e.what();
       }
 
-      auto serialized = serializeCapnp(message);
+      auto serialized = buildExportedKeysReply(
+         msgId, exportedKeys, error, true);
       this->writeToClient(serialized);
-      //exportedKeys destroyed here; SecureBinaryData destructor zeroes memory
    };
 
    std::thread thr(func);

--- a/cppForSwig/BridgeAPI/CppBridge.cpp
+++ b/cppForSwig/BridgeAPI/CppBridge.cpp
@@ -870,22 +870,27 @@ void CppBridge::exportPrivateKeys(const Wallets::WalletId& wltId,
                   entry.privKey = SecureBinaryData(privKey);
                   entry.index = assetSingle->getIndex();
 
-                  //public key (compressed)
-                  try {
-                     auto pubKeyPtr = assetSingle->getPubKey();
-                     if (pubKeyPtr != nullptr) {
-                        entry.pubKey = pubKeyPtr->getCompressedKey();
-                     }
-                  } catch (const std::exception&) {
-                     //no public key available, leave empty
-                  }
-
-                  //human readable address and type, derived on the fly for
-                  //the account's default address type
+                  //human readable address, type and public key, derived on the
+                  //fly for the account's default address type
                   try {
                      auto addrEntry = accPtr->getAddressEntryForID(assetID);
                      if (addrEntry != nullptr) {
                         entry.addrType = (uint32_t)addrEntry->getType();
+
+                        //public key is dictated by the address entry
+                        try {
+                           auto addrNested = std::dynamic_pointer_cast<
+                              AddressEntry_Nested>(addrEntry);
+                           if (addrNested != nullptr) {
+                              entry.pubKey = addrNested->getPredecessor()->
+                                 getPreimage();
+                           } else {
+                              entry.pubKey = addrEntry->getPreimage();
+                           }
+                        } catch (const AddressException&) {
+                           //no public key for this address type, leave empty
+                        }
+
                         try {
                            entry.addressString = addrEntry->getAddress();
                         } catch (const AddressException&) {

--- a/cppForSwig/BridgeAPI/CppBridge.cpp
+++ b/cppForSwig/BridgeAPI/CppBridge.cpp
@@ -760,8 +760,19 @@ void CppBridge::exportPrivateKeys(const Wallets::WalletId& wltId,
 {
    auto func = [this, wltId, callbackId, msgId]()
    {
-      // (assetId serialized with PROTO_ASSETID_PREFIX, private key copy)
-      std::vector<std::pair<BinaryData, SecureBinaryData>> keyPairs;
+      //one entry per exported key: the serialized asset id (with
+      //PROTO_ASSETID_PREFIX), the decrypted private key and the public
+      //metadata needed to render the key without the in-use address map
+      struct ExportedKeyData
+      {
+         BinaryData assetId;
+         SecureBinaryData privKey;
+         BinaryData pubKey;
+         std::string addressString;
+         uint32_t addrType = 0;
+         int32_t index = 0;
+      };
+      std::vector<ExportedKeyData> exportedKeys;
       std::string error;
 
       std::shared_ptr<BridgePassphrasePrompt> passPromptObj;
@@ -851,12 +862,41 @@ void CppBridge::exportPrivateKeys(const Wallets::WalletId& wltId,
                   }
 
                   const auto& assetID = assetPtr->getID();
-                  const auto& serAssetId = assetID.getSerializedKey(
-                     PROTO_ASSETID_PREFIX);
                   const auto& privKey =
                      wltSingle->getDecryptedPrivateKeyForAsset(assetSingle);
 
-                  keyPairs.emplace_back(serAssetId, SecureBinaryData(privKey));
+                  ExportedKeyData entry;
+                  entry.assetId = assetID.getSerializedKey(PROTO_ASSETID_PREFIX);
+                  entry.privKey = SecureBinaryData(privKey);
+                  entry.index = assetSingle->getIndex();
+
+                  //public key (compressed)
+                  try {
+                     auto pubKeyPtr = assetSingle->getPubKey();
+                     if (pubKeyPtr != nullptr) {
+                        entry.pubKey = pubKeyPtr->getCompressedKey();
+                     }
+                  } catch (const std::exception&) {
+                     //no public key available, leave empty
+                  }
+
+                  //human readable address and type, derived on the fly for
+                  //the account's default address type
+                  try {
+                     auto addrEntry = accPtr->getAddressEntryForID(assetID);
+                     if (addrEntry != nullptr) {
+                        entry.addrType = (uint32_t)addrEntry->getType();
+                        try {
+                           entry.addressString = addrEntry->getAddress();
+                        } catch (const AddressException&) {
+                           //address type yields no human readable string
+                        }
+                     }
+                  } catch (const std::exception&) {
+                     //asset has no instantiable address, leave blank
+                  }
+
+                  exportedKeys.emplace_back(std::move(entry));
                }
             }
          }
@@ -878,21 +918,27 @@ void CppBridge::exportPrivateKeys(const Wallets::WalletId& wltId,
       } else {
          reply.setSuccess(true);
          auto walletReply = reply.initWallet();
-         auto capnKeys = walletReply.initExportPrivateKeys(keyPairs.size());
-         for (size_t i = 0; i < keyPairs.size(); i++) {
+         auto capnKeys = walletReply.initExportPrivateKeys(exportedKeys.size());
+         for (size_t i = 0; i < exportedKeys.size(); i++) {
             auto capnKey = capnKeys[i];
-            const auto& id  = keyPairs[i].first;
-            const auto& key = keyPairs[i].second;
+            const auto& entry = exportedKeys[i];
             capnKey.setAssetId(capnp::Data::Builder(
-               (uint8_t*)id.getPtr(), id.getSize()));
+               (uint8_t*)entry.assetId.getPtr(), entry.assetId.getSize()));
             capnKey.setPrivKey(capnp::Data::Builder(
-               (uint8_t*)key.getPtr(), key.getSize()));
+               (uint8_t*)entry.privKey.getPtr(), entry.privKey.getSize()));
+            if (!entry.pubKey.empty()) {
+               capnKey.setPublicKey(capnp::Data::Builder(
+                  (uint8_t*)entry.pubKey.getPtr(), entry.pubKey.getSize()));
+            }
+            capnKey.setAddressString(entry.addressString);
+            capnKey.setAddrType(entry.addrType);
+            capnKey.setIndex(entry.index);
          }
       }
 
       auto serialized = serializeCapnp(message);
       this->writeToClient(serialized);
-      //keyPairs destroyed here; SecureBinaryData destructor zeroes memory
+      //exportedKeys destroyed here; SecureBinaryData destructor zeroes memory
    };
 
    std::thread thr(func);

--- a/cppForSwig/BridgeAPI/CppBridge.cpp
+++ b/cppForSwig/BridgeAPI/CppBridge.cpp
@@ -899,7 +899,7 @@ namespace {
 
    BinaryData buildExportedKeysReply(MessageId msgId,
       const std::vector<ExportedKeyData>& exportedKeys,
-      const std::string& error, bool publicExport)
+      const std::string& error)
    {
       capnp::MallocMessageBuilder message;
       auto fromBridge = message.initRoot<FromBridge>();
@@ -912,18 +912,10 @@ namespace {
       } else {
          reply.setSuccess(true);
          auto walletReply = reply.initWallet();
-         if (publicExport) {
-            auto capnKeys = walletReply.initExportPublicKeys(exportedKeys.size());
-            for (size_t i = 0; i < exportedKeys.size(); i++) {
-               auto capnKey = capnKeys[i];
-               populateExportedKey(capnKey, exportedKeys[i]);
-            }
-         } else {
-            auto capnKeys = walletReply.initExportPrivateKeys(exportedKeys.size());
-            for (size_t i = 0; i < exportedKeys.size(); i++) {
-               auto capnKey = capnKeys[i];
-               populateExportedKey(capnKey, exportedKeys[i]);
-            }
+         auto capnKeys = walletReply.initExportKeys(exportedKeys.size());
+         for (size_t i = 0; i < exportedKeys.size(); i++) {
+            auto capnKey = capnKeys[i];
+            populateExportedKey(capnKey, exportedKeys[i]);
          }
       }
 
@@ -932,10 +924,10 @@ namespace {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-void CppBridge::exportPrivateKeys(const Wallets::WalletId& wltId,
-   const CallbackId& callbackId, MessageId msgId)
+void CppBridge::exportKeys(const Wallets::WalletId& wltId,
+   bool includePrivateKeys, const CallbackId& callbackId, MessageId msgId)
 {
-   auto func = [this, wltId, callbackId, msgId]()
+   auto func = [this, wltId, includePrivateKeys, callbackId, msgId]()
    {
       std::vector<ExportedKeyData> exportedKeys;
       std::string error;
@@ -963,63 +955,31 @@ void CppBridge::exportPrivateKeys(const Wallets::WalletId& wltId,
             throw std::runtime_error("wallet is not an AssetWallet_Single");
          }
 
-         if (!wltSingle->getRoot()->hasPrivateKey()) {
-            throw std::runtime_error("this is a WO wallet");
+         if (includePrivateKeys) {
+            if (!wltSingle->getRoot()->hasPrivateKey()) {
+               throw std::runtime_error("this is a WO wallet");
+            }
+
+            passPromptObj = std::make_shared<BridgePassphrasePrompt>(
+               callbackId, [this](ServerPushWrapper wrapper){
+                  this->callbackWriter(wrapper);
+               });
+            auto lbd = passPromptObj->getLambda();
+            ExportKeysCleanup cleanupGuard{passPromptObj};
+
+            exportedKeys = collectExportedKeys(wltSingle, true, lbd);
+         } else {
+            exportedKeys = collectExportedKeys(wltSingle, false,
+               [](const std::set<Wallets::EncryptionKeyId>&)->Passphrase::Result{
+                  return {{}, false};
+               });
          }
-
-         passPromptObj = std::make_shared<BridgePassphrasePrompt>(
-            callbackId, [this](ServerPushWrapper wrapper){
-               this->callbackWriter(wrapper);
-            });
-         auto lbd = passPromptObj->getLambda();
-         ExportKeysCleanup cleanupGuard{passPromptObj};
-
-         exportedKeys = collectExportedKeys(wltSingle, true, lbd);
 
       } catch (const std::exception& e) {
          error = e.what();
       }
 
-      auto serialized = buildExportedKeysReply(
-         msgId, exportedKeys, error, false);
-      this->writeToClient(serialized);
-   };
-
-   std::thread thr(func);
-   if (thr.joinable()) {
-      thr.detach();
-   }
-}
-
-////////////////////////////////////////////////////////////////////////////////
-void CppBridge::exportPublicKeys(const Wallets::WalletId& wltId,
-   MessageId msgId)
-{
-   auto func = [this, wltId, msgId]()
-   {
-      std::vector<ExportedKeyData> exportedKeys;
-      std::string error;
-
-      try {
-         auto wltContainer = wltManager_->getWalletContainer(wltId);
-         auto wltPtr = wltContainer->getWalletPtr();
-         auto wltSingle = std::dynamic_pointer_cast<
-            Wallets::AssetWallet_Single>(wltPtr);
-         if (!wltSingle) {
-            throw std::runtime_error("wallet is not an AssetWallet_Single");
-         }
-
-         exportedKeys = collectExportedKeys(wltSingle, false,
-            [](const std::set<Wallets::EncryptionKeyId>&)->Passphrase::Result{
-               return {{}, false};
-            });
-
-      } catch (const std::exception& e) {
-         error = e.what();
-      }
-
-      auto serialized = buildExportedKeysReply(
-         msgId, exportedKeys, error, true);
+      auto serialized = buildExportedKeysReply(msgId, exportedKeys, error);
       this->writeToClient(serialized);
    };
 

--- a/cppForSwig/BridgeAPI/CppBridge.h
+++ b/cppForSwig/BridgeAPI/CppBridge.h
@@ -199,6 +199,7 @@ namespace Armory
             const CallbackId&, MessageId);
          void exportPrivateKeys(const Wallets::WalletId&,
             const CallbackId&, MessageId);
+         void exportPublicKeys(const Wallets::WalletId&, MessageId);
 
          //ledgers
          const std::string& getLedgerDelegateId(void);

--- a/cppForSwig/BridgeAPI/CppBridge.h
+++ b/cppForSwig/BridgeAPI/CppBridge.h
@@ -197,9 +197,8 @@ namespace Armory
          void importWallet(const std::filesystem::path&, MessageId);
          void forkWatchingOnly(const Wallets::WalletId&,
             const CallbackId&, MessageId);
-         void exportPrivateKeys(const Wallets::WalletId&,
-            const CallbackId&, MessageId);
-         void exportPublicKeys(const Wallets::WalletId&, MessageId);
+         void exportKeys(const Wallets::WalletId&, bool includePrivateKeys,
+            const CallbackId& callbackId, MessageId);
 
          //ledgers
          const std::string& getLedgerDelegateId(void);

--- a/cppForSwig/BridgeAPI/ProtoCommandParser.cpp
+++ b/cppForSwig/BridgeAPI/ProtoCommandParser.cpp
@@ -678,16 +678,17 @@ namespace
             break;
          }
 
-         case WalletRequest::EXPORT_PRIVATE_KEYS:
+         case WalletRequest::EXPORT_KEYS:
          {
-            std::string callbackId{request.getExportPrivateKeys()};
-            bridge->exportPrivateKeys(walletId, callbackId, referenceId);
-            break;
-         }
-
-         case WalletRequest::EXPORT_PUBLIC_KEYS:
-         {
-            bridge->exportPublicKeys(walletId, referenceId);
+            auto exportRequest = request.getExportKeys();
+            const bool includePrivateKeys = exportRequest.which() ==
+               WalletRequest::ExportKeyRequest::WITH_PRIVATE_KEYS;
+            std::string callbackId;
+            if (includePrivateKeys) {
+               callbackId = exportRequest.getWithPrivateKeys();
+            }
+            bridge->exportKeys(walletId, includePrivateKeys,
+               callbackId, referenceId);
             break;
          }
 

--- a/cppForSwig/BridgeAPI/ProtoCommandParser.cpp
+++ b/cppForSwig/BridgeAPI/ProtoCommandParser.cpp
@@ -685,6 +685,12 @@ namespace
             break;
          }
 
+         case WalletRequest::EXPORT_PUBLIC_KEYS:
+         {
+            bridge->exportPublicKeys(walletId, referenceId);
+            break;
+         }
+
          default:
             capnp::MallocMessageBuilder message;
             auto fromBridge = message.initRoot<FromBridge>();

--- a/cppForSwig/capnp/Bridge.capnp
+++ b/cppForSwig/capnp/Bridge.capnp
@@ -507,8 +507,12 @@ struct WalletReply {
    }
 
    struct ExportedPrivateKey {
-      assetId  @0 : Data;
-      privKey  @1 : Data;
+      assetId        @0 : Data;
+      privKey        @1 : Data;
+      publicKey      @2 : Data;
+      addressString  @3 : Text;
+      addrType       @4 : UInt32;
+      index          @5 : Int32;
    }
 
    # reply

--- a/cppForSwig/capnp/Bridge.capnp
+++ b/cppForSwig/capnp/Bridge.capnp
@@ -460,6 +460,13 @@ struct WalletRequest {
       description    @1 : Text;
    }
 
+   struct ExportKeyRequest {
+      union {
+         publicDataOnly @0 : Void;
+         withPrivateKeys @1 : Types.CallbackId;
+      }
+   }
+
    walletId                         @0 : Types.WalletId;
    accountId                        @1 : Types.AccountId;
    union {
@@ -490,8 +497,7 @@ struct WalletRequest {
       getUnlockTime                 @19: Void;
       forkWatchingOnly              @20: Types.CallbackId;
       hasImports                    @21: Void;
-      exportPrivateKeys             @22: Types.CallbackId;
-      exportPublicKeys              @23: Void;
+      exportKeys                    @22: ExportKeyRequest;
    }
 }
 
@@ -541,9 +547,8 @@ struct WalletReply {
       getUnlockTime                 @14: UInt32; #unlock time in ms
       forkWatchingOnly              @15: Text; #path to new WO wallet
       hasImports                    @16: Bool;
-      exportPrivateKeys             @17: List(ExportedPrivateKey);
-      # Reuses ExportedPrivateKey; privKey is empty for public-only export.
-      exportPublicKeys              @18: List(ExportedPrivateKey);
+      # privKey is empty for public-only export.
+      exportKeys                    @17: List(ExportedPrivateKey);
    }
 }
 

--- a/cppForSwig/capnp/Bridge.capnp
+++ b/cppForSwig/capnp/Bridge.capnp
@@ -491,6 +491,7 @@ struct WalletRequest {
       forkWatchingOnly              @20: Types.CallbackId;
       hasImports                    @21: Void;
       exportPrivateKeys             @22: Types.CallbackId;
+      exportPublicKeys              @23: Void;
    }
 }
 
@@ -541,6 +542,8 @@ struct WalletReply {
       forkWatchingOnly              @15: Text; #path to new WO wallet
       hasImports                    @16: Bool;
       exportPrivateKeys             @17: List(ExportedPrivateKey);
+      # Reuses ExportedPrivateKey; privKey is empty for public-only export.
+      exportPublicKeys              @18: List(ExportedPrivateKey);
    }
 }
 

--- a/cppForSwig/gtest/BridgeTests.cpp
+++ b/cppForSwig/gtest/BridgeTests.cpp
@@ -8,6 +8,7 @@
 
 #include <cstdlib>
 #include <queue>
+#include <set>
 #include <algorithm>
 
 #include "TestUtils.h"
@@ -1157,7 +1158,7 @@ namespace {
 
 
    //-----------------------------------------------------------------------
-   // exportPrivateKeys / exportPublicKeys helpers
+   // exportKeys helpers
    //-----------------------------------------------------------------------
    constexpr uint8_t PROTO_ASSETID_PREFIX = 0xAF;
 
@@ -1231,7 +1232,50 @@ namespace {
       }
    }
 
-   void assertExportedKeyMatchesExpected(const ExportedKey& exported,
+   std::pair<size_t, std::map<BinaryData, ExportedKey>> buildExpectedExportKeys(
+      const Wallets::AssetWallet_Single& assetWlt)
+   {
+      size_t expectedKeyCount = 0;
+      std::map<BinaryData, ExportedKey> expectedKeys;
+
+      for (const auto& addrAccId : assetWlt.getAccountIDs()) {
+         auto accPtr = assetWlt.getAccountForID(addrAccId);
+         if (!accPtr) {
+            continue;
+         }
+         for (const auto& assetAccId : accPtr->getAccountIdSet()) {
+            auto assetAcc = accPtr->getAccountForID(assetAccId);
+            if (!assetAcc) {
+               continue;
+            }
+            auto lastIdx = assetAcc->getLastComputedIndex();
+            for (int32_t i = 0; i <= lastIdx; i++) {
+               auto assetPtr = assetAcc->getAssetForKey(i);
+               if (!assetPtr || !assetPtr->hasPrivateKey()) {
+                  continue;
+               }
+               auto assetSingle = std::dynamic_pointer_cast<
+                  Assets::AssetEntry_Single>(assetPtr);
+               if (!assetSingle) {
+                  continue;
+               }
+               ++expectedKeyCount;
+               const auto& assetID = assetPtr->getID();
+
+               ExportedKey expected;
+               expected.assetId = assetID.getSerializedKey(
+                  PROTO_ASSETID_PREFIX);
+               expected.index = assetSingle->getIndex();
+               fillExpectedExportMetadata(expected, accPtr, assetID);
+               expectedKeys.emplace(expected.assetId, std::move(expected));
+            }
+         }
+      }
+
+      return {expectedKeyCount, std::move(expectedKeys)};
+   }
+
+   void expectExportedKeyMatchesExpected(const ExportedKey& exported,
       const ExportedKey& expected)
    {
       EXPECT_EQ(exported.assetId, expected.assetId);
@@ -1241,17 +1285,41 @@ namespace {
       EXPECT_EQ(exported.pubKey, expected.pubKey);
    }
 
-   ExportResult exportPrivateKeys(
+   void verifyExportSetMatchesExpected(
+      const std::vector<ExportedKey>& exported,
+      const std::map<BinaryData, ExportedKey>& expected,
+      bool requirePrivateKeys = false)
+   {
+      ASSERT_EQ(exported.size(), expected.size());
+      std::set<BinaryData> seenIds;
+      for (const auto& key : exported) {
+         EXPECT_GE(key.assetId.getSize(), 1ULL);
+         if (requirePrivateKeys) {
+            EXPECT_GE(key.privKey.getSize(), 32ULL);
+         } else {
+            EXPECT_TRUE(key.privKey.empty());
+         }
+
+         auto it = expected.find(key.assetId);
+         ASSERT_NE(it, expected.end())
+            << "unexpected asset id: " << key.assetId.toHexStr();
+         expectExportedKeyMatchesExpected(key, it->second);
+         seenIds.insert(key.assetId);
+      }
+      EXPECT_EQ(seenIds.size(), expected.size());
+   }
+
+   ExportResult exportKeys(
       std::shared_ptr<Bridge::CppBridge> bridge,
       const std::string& walletId,
-      const std::string& passphrase,
+      bool publicOnly,
+      const std::string& passphrase = {},
       bool provideCorrectPass = true)
    {
       ExportResult out;
       auto callbackId = Cryptography::PRNG::fortuna.generateRandom(10).toHexStr();
       uint64_t refId = rand();
 
-      //send export request
       {
          capnp::MallocMessageBuilder message;
          auto toBridge = message.initRoot<Codec::Bridge::ToBridge>();
@@ -1259,16 +1327,45 @@ namespace {
          auto request = toBridge.initWallet();
          request.setWalletId(walletId);
 
-         request.setExportPrivateKeys(callbackId);
+         auto exportReq = request.initExportKeys();
+         if (publicOnly) {
+            exportReq.setPublicDataOnly();
+         } else {
+            exportReq.setWithPrivateKeys(callbackId);
+         }
 
          auto rawReq = serializeCapnp(message);
          pushRequest(bridge, rawReq);
       }
 
-      //Process the notification flow until the terminal reply arrives.
-      //The flow is deterministic: either the wallet unlocks and a
-      //successful reply shows up, or the unlock is rejected, a cleanup
-      //notification is sent and the reply reports success == false.
+      if (publicOnly) {
+         auto result = waitOnReply();
+         kj::ArrayPtr<const capnp::word> words(
+            reinterpret_cast<const capnp::word*>(result->data.getPtr()),
+            result->data.getSize() / sizeof(capnp::word));
+         capnp::FlatArrayMessageReader reader(words);
+         auto fromBridge = reader.getRoot<Codec::Bridge::FromBridge>();
+
+         if (fromBridge.which() != Codec::Bridge::FromBridge::REPLY) {
+            out.error = "unexpected message type";
+            return out;
+         }
+
+         auto reply = fromBridge.getReply();
+         out.success = reply.getSuccess();
+         if (!out.success) {
+            out.error = reply.getError();
+            return out;
+         }
+
+         auto walletReply = reply.getWallet();
+         auto capnKeys = walletReply.getExportKeys();
+         for (auto k : capnKeys) {
+            out.keys.emplace_back(parseCapnExportedKey(k));
+         }
+         return out;
+      }
+
       while (true) {
          auto result = waitOnReply();
          kj::ArrayPtr<const capnp::word> words(
@@ -1278,7 +1375,6 @@ namespace {
 
          auto fromBridge = reader.getRoot<Codec::Bridge::FromBridge>();
 
-         //terminal message: the only place a reply is parsed
          if (fromBridge.which() == Codec::Bridge::FromBridge::REPLY) {
             auto reply = fromBridge.getReply();
             out.success = reply.getSuccess();
@@ -1286,7 +1382,7 @@ namespace {
                out.error = reply.getError();
             } else {
                auto walletReply = reply.getWallet();
-               auto capnKeys = walletReply.getExportPrivateKeys();
+               auto capnKeys = walletReply.getExportKeys();
                for (auto k : capnKeys) {
                   out.keys.emplace_back(parseCapnExportedKey(k));
                }
@@ -1320,7 +1416,6 @@ namespace {
             auto rawNotif = serializeCapnp(notifMsg);
             pushRequest(bridge, rawNotif);
          } else if (notifType == Codec::Bridge::Notification::CLEANUP) {
-            //unlock rejected; keep reading for the terminal reply
             continue;
          } else {
             out.error = "unexpected notification type";
@@ -1331,50 +1426,20 @@ namespace {
       return out;
    }
 
+   ExportResult exportPrivateKeys(
+      std::shared_ptr<Bridge::CppBridge> bridge,
+      const std::string& walletId,
+      const std::string& passphrase,
+      bool provideCorrectPass = true)
+   {
+      return exportKeys(bridge, walletId, false, passphrase, provideCorrectPass);
+   }
+
    ExportResult exportPublicKeys(
       std::shared_ptr<Bridge::CppBridge> bridge,
       const std::string& walletId)
    {
-      ExportResult out;
-      uint64_t refId = rand();
-
-      {
-         capnp::MallocMessageBuilder message;
-         auto toBridge = message.initRoot<Codec::Bridge::ToBridge>();
-         toBridge.setReferenceId(refId);
-         auto request = toBridge.initWallet();
-         request.setWalletId(walletId);
-         request.setExportPublicKeys();
-
-         auto rawReq = serializeCapnp(message);
-         pushRequest(bridge, rawReq);
-      }
-
-      auto result = waitOnReply();
-      kj::ArrayPtr<const capnp::word> words(
-         reinterpret_cast<const capnp::word*>(result->data.getPtr()),
-         result->data.getSize() / sizeof(capnp::word));
-      capnp::FlatArrayMessageReader reader(words);
-      auto fromBridge = reader.getRoot<Codec::Bridge::FromBridge>();
-
-      if (fromBridge.which() != Codec::Bridge::FromBridge::REPLY) {
-         out.error = "unexpected message type";
-         return out;
-      }
-
-      auto reply = fromBridge.getReply();
-      out.success = reply.getSuccess();
-      if (!out.success) {
-         out.error = reply.getError();
-         return out;
-      }
-
-      auto walletReply = reply.getWallet();
-      auto capnKeys = walletReply.getExportPublicKeys();
-      for (auto k : capnKeys) {
-         out.keys.emplace_back(parseCapnExportedKey(k));
-      }
-      return out;
+      return exportKeys(bridge, walletId, true);
    }
 
    WalletData extendAddressPool(
@@ -5757,10 +5822,7 @@ TEST_F(BridgeWalletTests, ChangeWalletPassphrase)
 ////////////////////////////////////////////////////////////////////////////////
 TEST_F(BridgeWalletTests, ExportPrivateKeysEncrypted)
 {
-   /* 1. create an encrypted wallet and count its full set of private keys.
-      The count is derived by walking the wallet the same way the bridge
-      does, so the export can be checked against every computed key rather
-      than an arbitrary lower bound. */
+   /* 1. create an encrypted wallet and count its full set of private keys. */
    std::string walletId;
    std::string privPass{"privPass1"};
    unsigned lookup = 4;
@@ -5780,38 +5842,10 @@ TEST_F(BridgeWalletTests, ExportPrivateKeysEncrypted)
       auto assetWlt = Wallets::AssetWallet_Single::createFromSeed(
          std::move(seed), params);
       walletId = assetWlt->getID();
-
-      for (const auto& addrAccId : assetWlt->getAccountIDs()) {
-         auto accPtr = assetWlt->getAccountForID(addrAccId);
-         ASSERT_NE(accPtr, nullptr);
-         for (const auto& assetAccId : accPtr->getAccountIdSet()) {
-            auto assetAcc = accPtr->getAccountForID(assetAccId);
-            ASSERT_NE(assetAcc, nullptr);
-            auto lastIdx = assetAcc->getLastComputedIndex();
-            for (int32_t i = 0; i <= lastIdx; i++) {
-               auto assetPtr = assetAcc->getAssetForKey(i);
-               if (assetPtr && assetPtr->hasPrivateKey()) {
-                  ++expectedKeyCount;
-                  auto assetSingle = std::dynamic_pointer_cast<
-                     Assets::AssetEntry_Single>(assetPtr);
-                  ASSERT_NE(assetSingle, nullptr);
-                  const auto& assetID = assetPtr->getID();
-
-                  ExportedKey expected;
-                  expected.assetId = assetID.getSerializedKey(
-                     PROTO_ASSETID_PREFIX);
-                  expected.index = assetSingle->getIndex();
-                  fillExpectedExportMetadata(expected, accPtr, assetID);
-                  expectedKeys.emplace(expected.assetId, std::move(expected));
-               }
-            }
-         }
-      }
+      std::tie(expectedKeyCount, expectedKeys) = buildExpectedExportKeys(*assetWlt);
    }
    ASSERT_FALSE(walletId.empty());
-   //the wallet must hold more than a single key, otherwise the "export all"
-   //behaviour is not actually being exercised
-   ASSERT_GT(expectedKeyCount, 1ULL);
+   ASSERT_EQ(expectedKeyCount, static_cast<size_t>(lookup));
 
    /* 2. load into bridge */
    auto wltList = listWallets(bridge_);
@@ -5826,18 +5860,11 @@ TEST_F(BridgeWalletTests, ExportPrivateKeysEncrypted)
    {
       auto result = exportPrivateKeys(bridge_, walletId, privPass, true);
       ASSERT_TRUE(result.success) << "export failed: " << result.error;
-      ASSERT_EQ(result.keys.size(), expectedKeyCount);
+      verifyExportSetMatchesExpected(result.keys, expectedKeys, true);
 
       for (const auto& exported : result.keys) {
-         EXPECT_GE(exported.assetId.getSize(), 1ULL);
-         EXPECT_GE(exported.privKey.getSize(), 32ULL);
-         auto it = expectedKeys.find(exported.assetId);
-         ASSERT_NE(it, expectedKeys.end())
-            << "unexpected asset id: " << exported.assetId.toHexStr();
-         assertExportedKeyMatchesExpected(exported, it->second);
          originalKeys.emplace(exported.assetId, exported.privKey);
       }
-      ASSERT_EQ(originalKeys.size(), result.keys.size());
    }
 
    /* 4. export with wrong passphrase: unlock is rejected */
@@ -5868,14 +5895,10 @@ TEST_F(BridgeWalletTests, ExportPrivateKeysEncrypted)
    {
       auto result = exportPrivateKeys(bridge_, walletId, privPass, true);
       ASSERT_TRUE(result.success) << "export failed: " << result.error;
+      verifyExportSetMatchesExpected(result.keys, expectedKeys, true);
 
       std::map<BinaryData, BinaryData> restoredKeys;
       for (const auto& exported : result.keys) {
-         auto it = expectedKeys.find(exported.assetId);
-         ASSERT_NE(it, expectedKeys.end())
-            << "restored an unexpected asset id: "
-            << exported.assetId.toHexStr();
-         assertExportedKeyMatchesExpected(exported, it->second);
          restoredKeys.emplace(exported.assetId, exported.privKey);
       }
 
@@ -5921,35 +5944,9 @@ TEST_F(BridgeWalletTests, ExportPublicKeysNoUnlock)
       auto assetWlt = Wallets::AssetWallet_Single::createFromSeed(
          std::move(seed), params);
       walletId = assetWlt->getID();
-
-      for (const auto& addrAccId : assetWlt->getAccountIDs()) {
-         auto accPtr = assetWlt->getAccountForID(addrAccId);
-         ASSERT_NE(accPtr, nullptr);
-         for (const auto& assetAccId : accPtr->getAccountIdSet()) {
-            auto assetAcc = accPtr->getAccountForID(assetAccId);
-            ASSERT_NE(assetAcc, nullptr);
-            auto lastIdx = assetAcc->getLastComputedIndex();
-            for (int32_t i = 0; i <= lastIdx; i++) {
-               auto assetPtr = assetAcc->getAssetForKey(i);
-               if (assetPtr && assetPtr->hasPrivateKey()) {
-                  ++expectedKeyCount;
-                  auto assetSingle = std::dynamic_pointer_cast<
-                     Assets::AssetEntry_Single>(assetPtr);
-                  ASSERT_NE(assetSingle, nullptr);
-                  const auto& assetID = assetPtr->getID();
-
-                  ExportedKey expected;
-                  expected.assetId = assetID.getSerializedKey(
-                     PROTO_ASSETID_PREFIX);
-                  expected.index = assetSingle->getIndex();
-                  fillExpectedExportMetadata(expected, accPtr, assetID);
-                  expectedKeys.emplace(expected.assetId, std::move(expected));
-               }
-            }
-         }
-      }
+      std::tie(expectedKeyCount, expectedKeys) = buildExpectedExportKeys(*assetWlt);
    }
-   ASSERT_GT(expectedKeyCount, 1ULL);
+   ASSERT_EQ(expectedKeyCount, static_cast<size_t>(lookup));
 
    auto wltList = listWallets(bridge_);
    ASSERT_EQ(wltList.size(), 1ULL);
@@ -5958,15 +5955,7 @@ TEST_F(BridgeWalletTests, ExportPublicKeysNoUnlock)
 
    auto result = exportPublicKeys(bridge_, walletId);
    ASSERT_TRUE(result.success) << "export failed: " << result.error;
-   ASSERT_EQ(result.keys.size(), expectedKeyCount);
-
-   for (const auto& exported : result.keys) {
-      EXPECT_TRUE(exported.privKey.empty());
-      auto it = expectedKeys.find(exported.assetId);
-      ASSERT_NE(it, expectedKeys.end())
-         << "unexpected asset id: " << exported.assetId.toHexStr();
-      assertExportedKeyMatchesExpected(exported, it->second);
-   }
+   verifyExportSetMatchesExpected(result.keys, expectedKeys, false);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cppForSwig/gtest/BridgeTests.cpp
+++ b/cppForSwig/gtest/BridgeTests.cpp
@@ -18,6 +18,7 @@
 
 #include <Wallets/Accounts/AddressAccounts.h>
 #include <Wallets/Accounts/AccountTypes.h>
+#include <Wallets/Addresses.h>
 #include <Wallets/WalletFileInterface.h>
 #include <Wallets/Seeds/Seeds.h>
 #include <Wallets/AuthorizedPeers.h>
@@ -1156,13 +1157,89 @@ namespace {
 
 
    //-----------------------------------------------------------------------
-   // exportPrivateKeys helper — mirrors changeWalletPassphrase pattern
+   // exportPrivateKeys / exportPublicKeys helpers
    //-----------------------------------------------------------------------
+   constexpr uint8_t PROTO_ASSETID_PREFIX = 0xAF;
+
+   struct ExportedKey {
+      BinaryData assetId;
+      BinaryData privKey;
+      BinaryData pubKey;
+      std::string addressString;
+      uint32_t addrType = 0;
+      int32_t index = 0;
+   };
+
    struct ExportResult {
       bool success = false;
       std::string error;
-      std::vector<std::pair<BinaryData, BinaryData>> keys;
+      std::vector<ExportedKey> keys;
    };
+
+   ExportedKey parseCapnExportedKey(
+      const Codec::Bridge::WalletReply::ExportedPrivateKey::Reader& k)
+   {
+      ExportedKey key;
+      auto capnId = k.getAssetId();
+      key.assetId = BinaryData(capnId.begin(), capnId.size());
+      auto capnPriv = k.getPrivKey();
+      if (capnPriv.size() > 0) {
+         key.privKey = BinaryData(capnPriv.begin(), capnPriv.size());
+      }
+      auto capnPub = k.getPublicKey();
+      if (capnPub.size() > 0) {
+         key.pubKey = BinaryData(capnPub.begin(), capnPub.size());
+      }
+      key.addressString = std::string(k.getAddressString());
+      key.addrType = k.getAddrType();
+      key.index = k.getIndex();
+      return key;
+   }
+
+   void fillExpectedExportMetadata(ExportedKey& key,
+      const std::shared_ptr<Accounts::AddressAccount>& accPtr,
+      const Wallets::AssetId& assetID)
+   {
+      try {
+         auto addrEntry = accPtr->getAddressEntryForID(assetID);
+         if (addrEntry == nullptr) {
+            return;
+         }
+
+         uint32_t addrType = (uint32_t)addrEntry->getType();
+         auto addrNested = std::dynamic_pointer_cast<
+            AddressEntry_Nested>(addrEntry);
+         if (addrNested != nullptr) {
+            addrType |= (uint32_t)addrNested->getPredecessor()->getType();
+         }
+         key.addrType = addrType;
+
+         try {
+            if (addrNested != nullptr) {
+               key.pubKey = addrNested->getPredecessor()->getPreimage();
+            } else {
+               key.pubKey = addrEntry->getPreimage();
+            }
+         } catch (const AddressException&) {
+         }
+
+         try {
+            key.addressString = addrEntry->getAddress();
+         } catch (const AddressException&) {
+         }
+      } catch (const std::exception&) {
+      }
+   }
+
+   void assertExportedKeyMatchesExpected(const ExportedKey& exported,
+      const ExportedKey& expected)
+   {
+      EXPECT_EQ(exported.assetId, expected.assetId);
+      EXPECT_EQ(exported.index, expected.index);
+      EXPECT_EQ(exported.addressString, expected.addressString);
+      EXPECT_EQ(exported.addrType, expected.addrType);
+      EXPECT_EQ(exported.pubKey, expected.pubKey);
+   }
 
    ExportResult exportPrivateKeys(
       std::shared_ptr<Bridge::CppBridge> bridge,
@@ -1211,11 +1288,7 @@ namespace {
                auto walletReply = reply.getWallet();
                auto capnKeys = walletReply.getExportPrivateKeys();
                for (auto k : capnKeys) {
-                  auto capnId  = k.getAssetId();
-                  auto capnKey = k.getPrivKey();
-                  out.keys.emplace_back(
-                     BinaryData(capnId.begin(),  capnId.size()),
-                     BinaryData(capnKey.begin(), capnKey.size()));
+                  out.keys.emplace_back(parseCapnExportedKey(k));
                }
             }
             break;
@@ -1257,6 +1330,53 @@ namespace {
 
       return out;
    }
+
+   ExportResult exportPublicKeys(
+      std::shared_ptr<Bridge::CppBridge> bridge,
+      const std::string& walletId)
+   {
+      ExportResult out;
+      uint64_t refId = rand();
+
+      {
+         capnp::MallocMessageBuilder message;
+         auto toBridge = message.initRoot<Codec::Bridge::ToBridge>();
+         toBridge.setReferenceId(refId);
+         auto request = toBridge.initWallet();
+         request.setWalletId(walletId);
+         request.setExportPublicKeys();
+
+         auto rawReq = serializeCapnp(message);
+         pushRequest(bridge, rawReq);
+      }
+
+      auto result = waitOnReply();
+      kj::ArrayPtr<const capnp::word> words(
+         reinterpret_cast<const capnp::word*>(result->data.getPtr()),
+         result->data.getSize() / sizeof(capnp::word));
+      capnp::FlatArrayMessageReader reader(words);
+      auto fromBridge = reader.getRoot<Codec::Bridge::FromBridge>();
+
+      if (fromBridge.which() != Codec::Bridge::FromBridge::REPLY) {
+         out.error = "unexpected message type";
+         return out;
+      }
+
+      auto reply = fromBridge.getReply();
+      out.success = reply.getSuccess();
+      if (!out.success) {
+         out.error = reply.getError();
+         return out;
+      }
+
+      auto walletReply = reply.getWallet();
+      auto capnKeys = walletReply.getExportPublicKeys();
+      for (auto k : capnKeys) {
+         out.keys.emplace_back(parseCapnExportedKey(k));
+      }
+      return out;
+   }
+
    WalletData extendAddressPool(
       std::shared_ptr<Bridge::CppBridge> bridge,
       const std::string& walletId, const std::string& accountId,
@@ -5645,6 +5765,7 @@ TEST_F(BridgeWalletTests, ExportPrivateKeysEncrypted)
    std::string privPass{"privPass1"};
    unsigned lookup = 4;
    size_t expectedKeyCount = 0;
+   std::map<BinaryData, ExportedKey> expectedKeys;
 
    {
       Wallets::IO::CreateWalletParams params{
@@ -5671,6 +5792,17 @@ TEST_F(BridgeWalletTests, ExportPrivateKeysEncrypted)
                auto assetPtr = assetAcc->getAssetForKey(i);
                if (assetPtr && assetPtr->hasPrivateKey()) {
                   ++expectedKeyCount;
+                  auto assetSingle = std::dynamic_pointer_cast<
+                     Assets::AssetEntry_Single>(assetPtr);
+                  ASSERT_NE(assetSingle, nullptr);
+                  const auto& assetID = assetPtr->getID();
+
+                  ExportedKey expected;
+                  expected.assetId = assetID.getSerializedKey(
+                     PROTO_ASSETID_PREFIX);
+                  expected.index = assetSingle->getIndex();
+                  fillExpectedExportMetadata(expected, accPtr, assetID);
+                  expectedKeys.emplace(expected.assetId, std::move(expected));
                }
             }
          }
@@ -5696,12 +5828,15 @@ TEST_F(BridgeWalletTests, ExportPrivateKeysEncrypted)
       ASSERT_TRUE(result.success) << "export failed: " << result.error;
       ASSERT_EQ(result.keys.size(), expectedKeyCount);
 
-      for (const auto& kp : result.keys) {
-         EXPECT_GE(kp.first.getSize(), 1ULL);    // assetId non-empty
-         EXPECT_GE(kp.second.getSize(), 32ULL);  // privKey >= 32 bytes
-         originalKeys.emplace(kp.first, kp.second);
+      for (const auto& exported : result.keys) {
+         EXPECT_GE(exported.assetId.getSize(), 1ULL);
+         EXPECT_GE(exported.privKey.getSize(), 32ULL);
+         auto it = expectedKeys.find(exported.assetId);
+         ASSERT_NE(it, expectedKeys.end())
+            << "unexpected asset id: " << exported.assetId.toHexStr();
+         assertExportedKeyMatchesExpected(exported, it->second);
+         originalKeys.emplace(exported.assetId, exported.privKey);
       }
-      //no duplicate asset ids
       ASSERT_EQ(originalKeys.size(), result.keys.size());
    }
 
@@ -5735,8 +5870,13 @@ TEST_F(BridgeWalletTests, ExportPrivateKeysEncrypted)
       ASSERT_TRUE(result.success) << "export failed: " << result.error;
 
       std::map<BinaryData, BinaryData> restoredKeys;
-      for (const auto& kp : result.keys) {
-         restoredKeys.emplace(kp.first, kp.second);
+      for (const auto& exported : result.keys) {
+         auto it = expectedKeys.find(exported.assetId);
+         ASSERT_NE(it, expectedKeys.end())
+            << "restored an unexpected asset id: "
+            << exported.assetId.toHexStr();
+         assertExportedKeyMatchesExpected(exported, it->second);
+         restoredKeys.emplace(exported.assetId, exported.privKey);
       }
 
       //every key the restored wallet did recompute must match the original
@@ -5757,6 +5897,176 @@ TEST_F(BridgeWalletTests, ExportPrivateKeysEncrypted)
          << "restored " << restoredKeys.size() << " keys, expected "
          << originalKeys.size();
    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+TEST_F(BridgeWalletTests, ExportPublicKeysNoUnlock)
+{
+   std::string walletId;
+   std::string privPass{"privPass1"};
+   unsigned lookup = 4;
+   size_t expectedKeyCount = 0;
+   std::map<BinaryData, ExportedKey> expectedKeys;
+
+   {
+      Wallets::IO::CreateWalletParams params{
+         homedir,
+         {500ms, 0, SecureBinaryData::fromString(privPass)},
+         {1ms, 0, {}},
+         nullptr, lookup
+      };
+
+      std::unique_ptr<Seeds::ClearTextSeed> seed(
+         new Seeds::ClearTextSeed_Armory());
+      auto assetWlt = Wallets::AssetWallet_Single::createFromSeed(
+         std::move(seed), params);
+      walletId = assetWlt->getID();
+
+      for (const auto& addrAccId : assetWlt->getAccountIDs()) {
+         auto accPtr = assetWlt->getAccountForID(addrAccId);
+         ASSERT_NE(accPtr, nullptr);
+         for (const auto& assetAccId : accPtr->getAccountIdSet()) {
+            auto assetAcc = accPtr->getAccountForID(assetAccId);
+            ASSERT_NE(assetAcc, nullptr);
+            auto lastIdx = assetAcc->getLastComputedIndex();
+            for (int32_t i = 0; i <= lastIdx; i++) {
+               auto assetPtr = assetAcc->getAssetForKey(i);
+               if (assetPtr && assetPtr->hasPrivateKey()) {
+                  ++expectedKeyCount;
+                  auto assetSingle = std::dynamic_pointer_cast<
+                     Assets::AssetEntry_Single>(assetPtr);
+                  ASSERT_NE(assetSingle, nullptr);
+                  const auto& assetID = assetPtr->getID();
+
+                  ExportedKey expected;
+                  expected.assetId = assetID.getSerializedKey(
+                     PROTO_ASSETID_PREFIX);
+                  expected.index = assetSingle->getIndex();
+                  fillExpectedExportMetadata(expected, accPtr, assetID);
+                  expectedKeys.emplace(expected.assetId, std::move(expected));
+               }
+            }
+         }
+      }
+   }
+   ASSERT_GT(expectedKeyCount, 1ULL);
+
+   auto wltList = listWallets(bridge_);
+   ASSERT_EQ(wltList.size(), 1ULL);
+   auto wallets = loadWallets(bridge_);
+   ASSERT_EQ(wallets.size(), 1ULL);
+
+   auto result = exportPublicKeys(bridge_, walletId);
+   ASSERT_TRUE(result.success) << "export failed: " << result.error;
+   ASSERT_EQ(result.keys.size(), expectedKeyCount);
+
+   for (const auto& exported : result.keys) {
+      EXPECT_TRUE(exported.privKey.empty());
+      auto it = expectedKeys.find(exported.assetId);
+      ASSERT_NE(it, expectedKeys.end())
+         << "unexpected asset id: " << exported.assetId.toHexStr();
+      assertExportedKeyMatchesExpected(exported, it->second);
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+TEST_F(BridgeWalletTests, ExportPublicKeysLegacy)
+{
+   std::filesystem::path legacyWalletFile{"input_files/legacy.wallet"sv};
+   const std::string walletId{"28m472Xbm"sv};
+   std::string fileName = std::string{"armory_"} + walletId + "_.wallet";
+   const std::filesystem::path wltPath{fileName};
+   std::filesystem::copy(legacyWalletFile, homedir / wltPath);
+
+   uint64_t refId = rand();
+   {
+      capnp::MallocMessageBuilder message;
+      auto toBridge = message.initRoot<Codec::Bridge::ToBridge>();
+      toBridge.setReferenceId(refId);
+      auto request = toBridge.initUtils();
+      request.setImportWallet((homedir / wltPath).string());
+      pushRequest(bridge_, serializeCapnp(message));
+   }
+
+   auto result = waitOnReply();
+   kj::ArrayPtr<const capnp::word> words(
+      reinterpret_cast<const capnp::word*>(result->data.getPtr()),
+      result->data.getSize() / sizeof(capnp::word));
+   capnp::FlatArrayMessageReader reader(words);
+   auto fromBridge = reader.getRoot<Codec::Bridge::FromBridge>();
+   auto reply = fromBridge.getReply();
+   ASSERT_TRUE(reply.getSuccess());
+
+   auto callbackId = Cryptography::PRNG::fortuna.generateRandom(10).toHexStr();
+   refId = rand();
+   {
+      capnp::MallocMessageBuilder message;
+      auto toBridge = message.initRoot<Codec::Bridge::ToBridge>();
+      toBridge.setReferenceId(refId);
+      auto mgrRequest = toBridge.initWalletManager();
+      auto migrationRequest = mgrRequest.initMigrateWallet();
+      migrationRequest.setWalletPath(wltPath.filename().string());
+      migrationRequest.setCallbackId(callbackId);
+      pushRequest(bridge_, serializeCapnp(message));
+   }
+
+   {
+      auto unlockReply = waitOnReply();
+      kj::ArrayPtr<const capnp::word> unlockWords(
+         reinterpret_cast<const capnp::word*>(unlockReply->data.getPtr()),
+         unlockReply->data.getSize() / sizeof(capnp::word));
+      capnp::FlatArrayMessageReader unlockReader(unlockWords);
+      auto unlockBridge = unlockReader.getRoot<Codec::Bridge::FromBridge>();
+      ASSERT_EQ(unlockBridge.which(), Codec::Bridge::FromBridge::NOTIFICATION);
+      auto notif = unlockBridge.getNotification();
+      ASSERT_EQ(notif.which(), Codec::Bridge::Notification::UNLOCK_REQUEST);
+
+      capnp::MallocMessageBuilder message;
+      auto toBridge = message.initRoot<Codec::Bridge::ToBridge>();
+      auto notifReply = toBridge.initNotification();
+      notifReply.setSuccess(true);
+      notifReply.setCounter(notif.getCounter());
+      notifReply.setUnlockRequest("testnet");
+      pushRequest(bridge_, serializeCapnp(message));
+   }
+
+   progressWalletCreation(bridge_, callbackId, "newpass", 250ms, 32, 104);
+
+   {
+      auto migResult = waitOnReply();
+      kj::ArrayPtr<const capnp::word> migWords(
+         reinterpret_cast<const capnp::word*>(migResult->data.getPtr()),
+         migResult->data.getSize() / sizeof(capnp::word));
+      capnp::FlatArrayMessageReader migReader(migWords);
+      auto migBridge = migReader.getRoot<Codec::Bridge::FromBridge>();
+      ASSERT_EQ(migBridge.which(), Codec::Bridge::FromBridge::REPLY);
+      auto migReply = migBridge.getReply();
+      ASSERT_TRUE(migReply.getSuccess());
+   }
+
+   auto wallets = loadWallets(bridge_);
+   ASSERT_EQ(wallets.size(), 1ULL);
+   ASSERT_EQ(wallets.begin()->first, walletId);
+
+   auto exportResult = exportPublicKeys(bridge_, walletId);
+   ASSERT_TRUE(exportResult.success) << exportResult.error;
+   ASSERT_GT(exportResult.keys.size(), 0ULL);
+
+   const uint32_t legacyUncompressedP2PKH = uint32_t(
+      AddressEntryType::P2PKH | AddressEntryType::Uncompressed);
+
+   bool foundUncompressed = false;
+   for (const auto& exported : exportResult.keys) {
+      EXPECT_TRUE(exported.privKey.empty());
+      EXPECT_NE(exported.addrType, 0u);
+      if (!exported.pubKey.empty()) {
+         EXPECT_EQ(exported.pubKey.getSize(), 65ULL);
+         EXPECT_EQ(exported.addrType, legacyUncompressedP2PKH);
+         foundUncompressed = true;
+      }
+      EXPECT_FALSE(exported.addressString.empty());
+   }
+   EXPECT_TRUE(foundUncompressed);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cppForSwig/gtest/BridgeTests.cpp
+++ b/cppForSwig/gtest/BridgeTests.cpp
@@ -1275,6 +1275,50 @@ namespace {
       return {expectedKeyCount, std::move(expectedKeys)};
    }
 
+   void fillExpectedPrivateKeys(
+      Wallets::AssetWallet_Single& assetWlt,
+      const SecureBinaryData& privPass,
+      std::map<BinaryData, ExportedKey>& expectedKeys)
+   {
+      auto lock = assetWlt.lockDecryptedContainer(
+         [&privPass](const std::set<Wallets::EncryptionKeyId>&)->Passphrase::Result
+         { return {privPass, true}; }
+      );
+
+      for (const auto& addrAccId : assetWlt.getAccountIDs()) {
+         auto accPtr = assetWlt.getAccountForID(addrAccId);
+         if (!accPtr) {
+            continue;
+         }
+         for (const auto& assetAccId : accPtr->getAccountIdSet()) {
+            auto assetAcc = accPtr->getAccountForID(assetAccId);
+            if (!assetAcc) {
+               continue;
+            }
+            auto lastIdx = assetAcc->getLastComputedIndex();
+            for (int32_t i = 0; i <= lastIdx; i++) {
+               auto assetPtr = assetAcc->getAssetForKey(i);
+               if (!assetPtr || !assetPtr->hasPrivateKey()) {
+                  continue;
+               }
+               auto assetSingle = std::dynamic_pointer_cast<
+                  Assets::AssetEntry_Single>(assetPtr);
+               if (!assetSingle) {
+                  continue;
+               }
+               const auto& assetID = assetPtr->getID();
+               auto serId = assetID.getSerializedKey(PROTO_ASSETID_PREFIX);
+               auto it = expectedKeys.find(serId);
+               if (it == expectedKeys.end()) {
+                  continue;
+               }
+               it->second.privKey = assetWlt.getDecryptedPrivateKeyForAsset(
+                  assetSingle);
+            }
+         }
+      }
+   }
+
    void expectExportedKeyMatchesExpected(const ExportedKey& exported,
       const ExportedKey& expected)
    {
@@ -1294,15 +1338,21 @@ namespace {
       std::set<BinaryData> seenIds;
       for (const auto& key : exported) {
          EXPECT_GE(key.assetId.getSize(), 1ULL);
-         if (requirePrivateKeys) {
-            EXPECT_GE(key.privKey.getSize(), 32ULL);
-         } else {
-            EXPECT_TRUE(key.privKey.empty());
-         }
 
          auto it = expected.find(key.assetId);
          ASSERT_NE(it, expected.end())
             << "unexpected asset id: " << key.assetId.toHexStr();
+
+         if (requirePrivateKeys) {
+            EXPECT_GE(key.privKey.getSize(), 32ULL);
+            ASSERT_FALSE(it->second.privKey.empty())
+               << "expected private key missing for asset "
+               << key.assetId.toHexStr();
+            EXPECT_EQ(key.privKey, it->second.privKey);
+         } else {
+            EXPECT_TRUE(key.privKey.empty());
+         }
+
          expectExportedKeyMatchesExpected(key, it->second);
          seenIds.insert(key.assetId);
       }
@@ -5843,6 +5893,8 @@ TEST_F(BridgeWalletTests, ExportPrivateKeysEncrypted)
          std::move(seed), params);
       walletId = assetWlt->getID();
       std::tie(expectedKeyCount, expectedKeys) = buildExpectedExportKeys(*assetWlt);
+      fillExpectedPrivateKeys(*assetWlt,
+         SecureBinaryData::fromString(privPass), expectedKeys);
    }
    ASSERT_FALSE(walletId.empty());
    ASSERT_EQ(expectedKeyCount, static_cast<size_t>(lookup));

--- a/qtdialogs/DlgShowKeyList.py
+++ b/qtdialogs/DlgShowKeyList.py
@@ -177,7 +177,7 @@ class DlgShowKeyList(ArmoryDialog):
    def _startPublicExport(self):
       def onKeysReceived(reply):
          if reply.success:
-            self._entries = self._parseExportItems(reply.wallet.exportPublicKeys)
+            self._entries = self._parseExportItems(reply.wallet.exportKeys)
             self.executeMethod(self._onPublicKeysReady)
          else:
             err = getattr(reply, 'error', None) or self.tr('Export failed.')
@@ -194,7 +194,7 @@ class DlgShowKeyList(ArmoryDialog):
 
       def onKeysReceived(reply):
          if reply.success:
-            self._mergePrivateKeys(reply.wallet.exportPrivateKeys)
+            self._mergePrivateKeys(reply.wallet.exportKeys)
             self._privKeysLoaded = True
             self._privateExportInProgress = False
             self.executeMethod(self._onPrivateKeysReady)
@@ -252,9 +252,6 @@ class DlgShowKeyList(ArmoryDialog):
          self.chkList[name].blockSignals(True)
          self.chkList[name].setChecked(True)
          self.chkList[name].blockSignals(False)
-      self.chkList['PubKey'].blockSignals(True)
-      self.chkList['PubKey'].setChecked(False)
-      self.chkList['PubKey'].blockSignals(False)
       self.rewriteList()
 
    #############################################################################
@@ -290,6 +287,13 @@ class DlgShowKeyList(ArmoryDialog):
          RightNow(), self.main.getPreferredDateFormat()))
       L.append('Wallet ID:     ' + self.wlt.walletId)
       L.append('Wallet Name:   ' + self.wlt.labelName)
+      addrTypes = self.wlt.getAddressTypes()
+      if addrTypes:
+         typeNames = [getNameForAddrType(t) for t in addrTypes]
+         L.append('Eligible types:' + ' ' + ', '.join(typeNames))
+      defaultType = self.wlt.getDefaultAddressType()
+      if defaultType:
+         L.append('Default type:  ' + getNameForAddrType(defaultType))
       L.append('')
 
       self.havePriv = False

--- a/qtdialogs/DlgShowKeyList.py
+++ b/qtdialogs/DlgShowKeyList.py
@@ -10,52 +10,47 @@
 #                                                                            #
 ##############################################################################
 
+from qtpy import QtCore, QtWidgets
+
 from qtdialogs.ArmoryDialog import ArmoryDialog
+from qtdialogs.MsgBoxWithDNAA import MsgBoxWithDNAA
+from qtdialogs.qtdefines import (
+   GETFONT, MSGBOX, STRETCH, STYLE_SUNKEN, USERMODE,
+   VERTICAL, HORIZONTAL, QRichLabel, makeLayoutFrame, tightSizeNChar,
+)
 from armoryengine.AddressUtils import encodePrivKeyBase58
-from armoryengine.WalletUtils import determineWalletType, WalletTypes
+from armoryengine.ArmoryUtils import (
+   RightNow, binary_to_hex, hash160, unixTimeToFormatStr, LOGERROR,
+)
+from armoryengine.Settings import TheSettings
+
 
 ################################################################################
 class DlgShowKeyList(ArmoryDialog):
+   """
+   Lists every key in the wallet. All wallets are bridge wallets: the private
+   keys (and their public metadata) are fetched from CppBridge through the
+   exportPrivateKeys callback flow, which prompts for the passphrase when the
+   wallet is encrypted. The list is rendered directly from the export reply so
+   that every key is shown, regardless of address use state.
+   """
    def __init__(self, wlt, parent=None, main=None):
       super(DlgShowKeyList, self).__init__(parent, main)
 
       self.wlt = wlt
+      self.watchingOnly = bool(getattr(self.wlt, 'watchingOnly', False))
 
-      self.havePriv = ((not self.wlt.useEncryption) or not (self.wlt.isLocked))
-
-      wltType = determineWalletType(self.wlt)
-      if wltType in (WalletTypes.Offline, WalletTypes.WatchOnly):
-         self.havePriv = False
-
-
-      # NOTE/WARNING:  We have to make copies (in RAM) of the unencrypted
-      #                keys, or else we will have to type in our address
-      #                every 10s if we want to modify the key list.  This
-      #                isn't likely a big problem, but it's not ideal,
-      #                either.  Not much I can do about, though...
-      #                (at least:  once this dialog is closed, all the
-      #                garbage should be collected...)
-      self.addrCopies = []
-      for addr in self.wlt.getLinearAddrList(withAddrPool=True):
-         self.addrCopies.append(addr.copy())
-      self.rootKeyCopy = self.wlt.addrMap['ROOT'].copy()
-
-      backupVersion = BACKUP_TYPE_135A
-      testChain = DeriveChaincodeFromRootKey(self.rootKeyCopy.binPrivKey32_Plain)
-      self.needChaincode = (not testChain == self.rootKeyCopy.chaincode)
-      if not self.needChaincode:
-         backupVersion = BACKUP_TYPE_135C
+      # exported keys, populated asynchronously from the bridge. Each entry is
+      # a dict: assetId, privKey, pubKey (bytes), address (str), index (int).
+      self._entries = []
+      self.havePriv = False
+      self._unlockHandler = None
 
       self.strDescrReg = (self.tr(
          'The textbox below shows all keys that are part of this wallet, '
          'which includes both permanent keys and imported keys.  If you '
          'simply want to backup your wallet and you have no imported keys '
-         'then all data below is reproducible from a plain paper backup. '
-         '<br><br> '
-         'If you have imported addresses to backup, and/or you '
-         'would like to export your private keys to another '
-         'wallet service or application, then you can save this data '
-         'to disk, or copy&paste it into the other application.'))
+         'then all data below is reproducible from a plain paper backup.'))
       self.strDescrWarn = (self.tr(
          '<br><br>'
          '<font color="red">Warning:</font> The text box below contains '
@@ -67,86 +62,60 @@ class DlgShowKeyList(ArmoryDialog):
       self.lblDescr = QRichLabel('')
       self.lblDescr.setAlignment(QtCore.Qt.AlignLeft | QtCore.Qt.AlignTop)
 
-
       txtFont = GETFONT('Fixed', 8)
       self.txtBox = QtWidgets.QTextEdit()
       self.txtBox.setReadOnly(True)
       self.txtBox.setFont(txtFont)
       w, h = tightSizeNChar(txtFont, 110)
-      self.txtBox.setFont(txtFont)
       self.txtBox.setMinimumWidth(w)
       self.txtBox.setMaximumWidth(w)
       self.txtBox.setMinimumHeight(int(h * 3.2))
-      self.txtBox.setSizePolicy(QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Preferred)
+      self.txtBox.setSizePolicy(
+         QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Preferred)
 
-      # Create a list of checkboxes and then some ID word to identify what
-      # to put there
+      # Column selection checkboxes
       self.chkList = {}
-      self.chkList['AddrStr'] = QtWidgets.QCheckBox(self.tr('Address String'))
+      self.chkList['AddrStr']    = QtWidgets.QCheckBox(self.tr('Address String'))
       self.chkList['PubKeyHash'] = QtWidgets.QCheckBox(self.tr('Hash160'))
-      self.chkList['PrivCrypt'] = QtWidgets.QCheckBox(self.tr('Private Key (Encrypted)'))
-      self.chkList['PrivHexBE'] = QtWidgets.QCheckBox(self.tr('Private Key (Plain Hex)'))
-      self.chkList['PrivB58'] = QtWidgets.QCheckBox(self.tr('Private Key (Plain Base58)'))
-      self.chkList['PubKey'] = QtWidgets.QCheckBox(self.tr('Public Key (BE)'))
+      self.chkList['PrivHexBE']  = QtWidgets.QCheckBox(self.tr('Private Key (Plain Hex)'))
+      self.chkList['PrivB58']    = QtWidgets.QCheckBox(self.tr('Private Key (Plain Base58)'))
+      self.chkList['PubKey']     = QtWidgets.QCheckBox(self.tr('Public Key (BE)'))
       self.chkList['ChainIndex'] = QtWidgets.QCheckBox(self.tr('Chain Index'))
 
       self.chkList['AddrStr'   ].setChecked(True)
       self.chkList['PubKeyHash'].setChecked(False)
-      self.chkList['PrivB58'   ].setChecked(self.havePriv)
-      self.chkList['PrivCrypt' ].setChecked(False)
-      self.chkList['PrivHexBE' ].setChecked(self.havePriv)
-      self.chkList['PubKey'    ].setChecked(not self.havePriv)
+      self.chkList['PrivB58'   ].setChecked(False)
+      self.chkList['PrivHexBE' ].setChecked(False)
+      self.chkList['PubKey'    ].setChecked(True)
       self.chkList['ChainIndex'].setChecked(False)
 
-      namelist = ['AddrStr', 'PubKeyHash', 'PrivB58', 'PrivCrypt', \
+      namelist = ['AddrStr', 'PubKeyHash', 'PrivB58',
                   'PrivHexBE', 'PubKey', 'ChainIndex']
 
       for name in self.chkList.keys():
          self.chkList[name].toggled.connect(self.rewriteList)
 
-
-      self.chkImportedOnly = QtWidgets.QCheckBox(self.tr('Imported Addresses Only'))
-      self.chkWithAddrPool = QtWidgets.QCheckBox(self.tr('Include Unused (Address Pool)'))
-      self.chkDispRootKey = QtWidgets.QCheckBox(self.tr('Include Paper Backup Root'))
       self.chkOmitSpaces = QtWidgets.QCheckBox(self.tr('Omit spaces in key data'))
-      self.chkDispRootKey.setChecked(True)
-      self.chkImportedOnly.toggled.connect(self.rewriteList)
-      self.chkWithAddrPool.toggled.connect(self.rewriteList)
-      self.chkDispRootKey.toggled.connect(self.rewriteList)
       self.chkOmitSpaces.toggled.connect(self.rewriteList)
-      # self.chkCSV = QtWidgets.QCheckBox('Display in CSV format')
 
-      if not self.havePriv:
-         self.chkDispRootKey.setChecked(False)
-         self.chkDispRootKey.setEnabled(False)
-
+      # The private key columns become available once the export completes.
+      # Watch-only wallets never expose private keys.
+      self.chkList['PrivHexBE'].setEnabled(False)
+      self.chkList['PrivB58'  ].setEnabled(False)
 
       std = (self.main.usermode == USERMODE.Standard)
       adv = (self.main.usermode == USERMODE.Advanced)
-      dev = (self.main.usermode == USERMODE.Expert)
       if std:
          self.chkList['PubKeyHash'].setVisible(False)
-         self.chkList['PrivCrypt' ].setVisible(False)
          self.chkList['ChainIndex'].setVisible(False)
       elif adv:
          self.chkList['PubKeyHash'].setVisible(False)
          self.chkList['ChainIndex'].setVisible(False)
 
-      # We actually just want to remove these entirely
-      # (either we need to display all data needed for decryption,
-      # besides passphrase,  or we shouldn't show any of it)
-      self.chkList['PrivCrypt' ].setVisible(False)
-
       chkBoxList = [self.chkList[n] for n in namelist]
-      chkBoxList.append('Line')
-      chkBoxList.append(self.chkImportedOnly)
-      chkBoxList.append(self.chkWithAddrPool)
-      chkBoxList.append(self.chkDispRootKey)
-
       frmChks = makeLayoutFrame(VERTICAL, chkBoxList, STYLE_SUNKEN)
 
-
-      btnGoBack = QtWidgets.QPushButton(self.tr('<<< Go Back'))
+      btnGoBack   = QtWidgets.QPushButton(self.tr('<<< Go Back'))
       btnSaveFile = QtWidgets.QPushButton(self.tr('Save to File...'))
       btnCopyClip = QtWidgets.QPushButton(self.tr('Copy to Clipboard'))
       self.lblCopied = QRichLabel('')
@@ -166,17 +135,11 @@ class DlgShowKeyList(ArmoryDialog):
 
       frmDescr = makeLayoutFrame(HORIZONTAL, [self.lblDescr], STYLE_SUNKEN)
 
-      if not self.havePriv or (self.wlt.useEncryption and self.wlt.isLocked):
-         self.chkList['PrivHexBE'].setEnabled(False)
-         self.chkList['PrivHexBE'].setChecked(False)
-         self.chkList['PrivB58'  ].setEnabled(False)
-         self.chkList['PrivB58'  ].setChecked(False)
-
       dlgLayout = QtWidgets.QGridLayout()
-      dlgLayout.addWidget(frmDescr, 0, 0, 1, 1)
-      dlgLayout.addWidget(frmChks, 0, 1, 1, 1)
+      dlgLayout.addWidget(frmDescr,    0, 0, 1, 1)
+      dlgLayout.addWidget(frmChks,     0, 1, 1, 1)
       dlgLayout.addWidget(self.txtBox, 1, 0, 1, 2)
-      dlgLayout.addWidget(frmGoBack, 2, 0, 1, 2)
+      dlgLayout.addWidget(frmGoBack,   2, 0, 1, 2)
       dlgLayout.setRowStretch(0, 0)
       dlgLayout.setRowStretch(1, 1)
       dlgLayout.setRowStretch(2, 0)
@@ -185,103 +148,94 @@ class DlgShowKeyList(ArmoryDialog):
       self.rewriteList()
       self.setWindowTitle(self.tr('All Wallet Keys'))
 
+      if self.watchingOnly:
+         self.txtBox.setText(self.tr(
+            'This is a watch-only wallet: it holds no private keys.'))
+      else:
+         self._startBridgeExport()
+
+   #############################################################################
+   def _startBridgeExport(self):
+      from qtdialogs.DlgUnlockWallet import UnlockWalletHandler
+      self._unlockHandler = UnlockWalletHandler(
+         self.wlt.walletId, self.tr('Export Key List'), self)
+
+      def onKeysReceived(reply):
+         if reply.success:
+            entries = []
+            for item in reply.wallet.exportPrivateKeys:
+               entries.append({
+                  'assetId': bytes(item.assetId),
+                  'privKey': bytes(item.privKey),
+                  'pubKey':  bytes(item.publicKey),
+                  'address': item.addressString,
+                  'index':   item.index,
+               })
+            self._entries = entries
+            self.executeMethod(self._onKeysReady)
+         else:
+            err = getattr(reply, 'error', None) or self.tr('Export failed.')
+            LOGERROR('exportPrivateKeys failed: %s', err)
+            self.executeMethod(self._onExportFailed, str(err))
+
+      self.wlt.exportPrivateKeys(onKeysReceived, self._unlockHandler)
+
+   #############################################################################
+   def _onExportFailed(self, errMsg):
+      self.txtBox.setText(
+         self.tr('Could not export private keys from this wallet.') +
+         '\n\n' + errMsg)
+
+   #############################################################################
+   def _onKeysReady(self):
+      # Enable and pre-check the private key columns now that keys are present.
+      self.chkList['PrivB58'  ].setEnabled(True)
+      self.chkList['PrivB58'  ].setChecked(True)
+      self.chkList['PrivHexBE'].setEnabled(True)
+      self.chkList['PrivHexBE'].setChecked(True)
+      self.chkList['PubKey'   ].setChecked(False)
+      self.rewriteList()
+
+   #############################################################################
    def rewriteList(self, *args):
       """
-      Write out all the wallet data
+      Write out the full key list from the cached export entries.
       """
       whitespace = '' if self.chkOmitSpaces.isChecked() else ' '
 
-      def fmtBin(s, nB=4, sw=False):
-         h = binary_to_hex(s)
-         if sw:
-            h = hex_switchEndian(h)
+      def fmtBin(b, nB=4):
+         h = binary_to_hex(b)
          return whitespace.join([h[i:i + nB] for i in range(0, len(h), nB)])
 
       L = []
-      L.append('Created:       ' + unixTimeToFormatStr(RightNow(), self.main.getPreferredDateFormat()))
-      L.append('Wallet ID:     ' + self.wlt.uniqueIDB58)
+      L.append('Created:       ' + unixTimeToFormatStr(
+         RightNow(), self.main.getPreferredDateFormat()))
+      L.append('Wallet ID:     ' + self.wlt.walletId)
       L.append('Wallet Name:   ' + self.wlt.labelName)
       L.append('')
 
-      if self.chkDispRootKey.isChecked():
-         binPriv0 = self.rootKeyCopy.binPrivKey32_Plain.toBinStr()[:16]
-         binPriv1 = self.rootKeyCopy.binPrivKey32_Plain.toBinStr()[16:]
-         binChain0 = self.rootKeyCopy.chaincode.toBinStr()[:16]
-         binChain1 = self.rootKeyCopy.chaincode.toBinStr()[16:]
-         binPriv0Chk = computeChecksum(binPriv0, nBytes=2)
-         binPriv1Chk = computeChecksum(binPriv1, nBytes=2)
-         binChain0Chk = computeChecksum(binChain0, nBytes=2)
-         binChain1Chk = computeChecksum(binChain1, nBytes=2)
-
-         binPriv0 = binary_to_easyType16(binPriv0 + binPriv0Chk)
-         binPriv1 = binary_to_easyType16(binPriv1 + binPriv1Chk)
-         binChain0 = binary_to_easyType16(binChain0 + binChain0Chk)
-         binChain1 = binary_to_easyType16(binChain1 + binChain1Chk)
-
-         L.append('-' * 80)
-         L.append('The following is the same information contained on your paper backup.')
-         L.append('All NON-imported addresses in your wallet are backed up by this data.')
-         L.append('')
-         L.append('Root Key:     ' + ' '.join([binPriv0[i:i + 4]  for i in range(0, 36, 4)]))
-         L.append('              ' + ' '.join([binPriv1[i:i + 4]  for i in range(0, 36, 4)]))
-         if self.needChaincode:
-            L.append('Chain Code:   ' + ' '.join([binChain0[i:i + 4] for i in range(0, 36, 4)]))
-            L.append('              ' + ' '.join([binChain1[i:i + 4] for i in range(0, 36, 4)]))
-         L.append('-' * 80)
-         L.append('')
-
-         # Cleanup all that sensitive data laying around in RAM
-         binPriv0, binPriv1 = None, None
-         binChain0, binChain1 = None, None
-         binPriv0Chk, binPriv1Chk = None, None
-         binChain0Chk, binChain1Chk = None, None
-
       self.havePriv = False
-      topChain = self.wlt.getHighestUsedIndex()
-      extraLbl = ''
+      for entry in self._entries:
+         privKey = entry['privKey']
+         pubKey  = entry['pubKey']
 
-      for addr in self.addrCopies:
-         try:
-            cppAddrObj = self.wlt.cppWallet.getAddrObjByIndex(addr.chainIndex)
-         except:
-            addrIndex = self.wlt.cppWallet.getAssetIndexForAddr(addr.getAddr160())
-            cppAddrObj = self.wlt.cppWallet.getAddrObjByIndex(addrIndex)
-
-         # Address pool
-         if self.chkWithAddrPool.isChecked():
-            if addr.chainIndex > topChain:
-               extraLbl = '   (Unused/Address Pool)'
-         else:
-            if addr.chainIndex > topChain:
-               continue
-
-         # Imported Addresses
-         if self.chkImportedOnly.isChecked():
-            if not addr.chainIndex == -2:
-               continue
-         else:
-            if addr.chainIndex == -2:
-               extraLbl = '   (Imported)'
-
-         if self.chkList['AddrStr'   ].isChecked():
-            L.append(cppAddrObj.getScrAddr() + extraLbl)
-         if self.chkList['PubKeyHash'].isChecked():
-            L.append('   Hash160   : ' + fmtBin(addr.getAddr160()))
-         if self.chkList['PrivB58'   ].isChecked():
-            pB58 = encodePrivKeyBase58(addr.binPrivKey32_Plain.toBinStr())
-            pB58Stretch = whitespace.join([pB58[i:i + 6] for i in range(0, len(pB58), 6)])
+         if self.chkList['AddrStr'].isChecked():
+            L.append((entry['address'] or self.tr('(no address)')))
+         if self.chkList['PubKeyHash'].isChecked() and pubKey:
+            L.append('   Hash160   : ' + fmtBin(hash160(pubKey)))
+         if self.chkList['PrivB58'].isChecked() and privKey:
+            pB58 = encodePrivKeyBase58(privKey)
+            pB58Stretch = whitespace.join(
+               [pB58[i:i + 6] for i in range(0, len(pB58), 6)])
             L.append('   PrivBase58: ' + pB58Stretch)
             self.havePriv = True
-         if self.chkList['PrivCrypt' ].isChecked():
-            L.append('   PrivCrypt : ' + fmtBin(addr.binPrivKey32_Encr.toBinStr()))
-         if self.chkList['PrivHexBE' ].isChecked():
-            L.append('   PrivHexBE : ' + fmtBin(addr.binPrivKey32_Plain.toBinStr()))
+         if self.chkList['PrivHexBE'].isChecked() and privKey:
+            L.append('   PrivHexBE : ' + fmtBin(privKey))
             self.havePriv = True
-         if self.chkList['PubKey'    ].isChecked():
-            L.append('   PublicX   : ' + fmtBin(addr.binPublicKey65.toBinStr()[1:33 ]))
-            L.append('   PublicY   : ' + fmtBin(addr.binPublicKey65.toBinStr()[  33:]))
+         if self.chkList['PubKey'].isChecked() and pubKey:
+            L.append('   PublicKey : ' + fmtBin(pubKey))
          if self.chkList['ChainIndex'].isChecked():
-            L.append('   ChainIndex: ' + str(addr.chainIndex))
+            L.append('   ChainIndex: ' + str(entry['index']))
 
       self.txtBox.setText('\n'.join(L))
       if self.havePriv:
@@ -289,48 +243,47 @@ class DlgShowKeyList(ArmoryDialog):
       else:
          self.lblDescr.setText(self.strDescrReg)
 
+   #############################################################################
    def saveToFile(self):
       if self.havePriv:
          if not TheSettings.getSettingOrSetDefault('DNAA_WarnPrintKeys', False):
-            result = MsgBoxWithDNAA(self, self.main, MSGBOX.Warning, title=self.tr('Plaintext Private Keys'), \
-                  msg=self.tr('<font color="red"><b>REMEMBER:</b></font> The data you '
-                  'are about to save contains private keys.  Please make sure '
-                  'that only trusted persons will have access to this file. '
-                  '<br><br>Are you sure you want to continue?'), \
-                  dnaaMsg=None, wCancel=True)
+            result = MsgBoxWithDNAA(self, self.main, MSGBOX.Warning,
+               title=self.tr('Plaintext Private Keys'),
+               msg=self.tr('<font color="red"><b>REMEMBER:</b></font> The data you '
+               'are about to save contains private keys.  Please make sure '
+               'that only trusted persons will have access to this file. '
+               '<br><br>Are you sure you want to continue?'),
+               dnaaMsg=None, wCancel=True)
             if not result[0]:
                return
             TheSettings.set('DNAA_WarnPrintKeys', result[1])
 
-      wltID = self.wlt.uniqueIDB58
-      fn = self.main.getFileSave(title=self.tr('Save Key List'), \
-                                 ffilter=[self.tr('Text Files (*.txt)')], \
+      wltID = self.wlt.walletId
+      fn = self.main.getFileSave(title=self.tr('Save Key List'),
+                                 ffilter=[self.tr('Text Files (*.txt)')],
                                  defaultFilename=('keylist_%s_.txt' % wltID))
       if len(fn) > 0:
-         fileobj = open(fn, 'w')
-         fileobj.write(str(self.txtBox.toPlainText()))
-         fileobj.close()
+         with open(fn, 'w') as fileobj:
+            fileobj.write(str(self.txtBox.toPlainText()))
 
-
-
+   #############################################################################
    def copyToClipboard(self):
       clipb = QtWidgets.QApplication.clipboard()
       clipb.clear()
       clipb.setText(str(self.txtBox.toPlainText()))
       self.lblCopied.setText(self.tr('<i>Copied!</i>'))
 
-
+   #############################################################################
    def cleanup(self):
-      self.rootKeyCopy.binPrivKey32_Plain.destroy()
-      for addr in self.addrCopies:
-         addr.binPrivKey32_Plain.destroy()
-      self.rootKeyCopy = None
-      self.addrCopies = None
+      # Drop the plaintext private keys held in the entry cache.
+      self._entries = []
 
+   #############################################################################
    def accept(self):
       self.cleanup()
       super(DlgShowKeyList, self).accept()
 
+   #############################################################################
    def reject(self):
       self.cleanup()
       super(DlgShowKeyList, self).reject()

--- a/qtdialogs/DlgShowKeyList.py
+++ b/qtdialogs/DlgShowKeyList.py
@@ -10,6 +10,8 @@
 #                                                                            #
 ##############################################################################
 
+from html import escape
+
 from qtpy import QtCore, QtWidgets
 
 from qtdialogs.ArmoryDialog import ArmoryDialog
@@ -20,7 +22,8 @@ from qtdialogs.qtdefines import (
 )
 from armoryengine.AddressUtils import encodePrivKeyBase58
 from armoryengine.ArmoryUtils import (
-   RightNow, binary_to_hex, hash160, unixTimeToFormatStr, LOGERROR,
+   RightNow, binary_to_hex, getNameForAddrType, hash160,
+   unixTimeToFormatStr, LOGERROR,
 )
 from armoryengine.Settings import TheSettings
 
@@ -28,11 +31,10 @@ from armoryengine.Settings import TheSettings
 ################################################################################
 class DlgShowKeyList(ArmoryDialog):
    """
-   Lists every key in the wallet. All wallets are bridge wallets: the private
-   keys (and their public metadata) are fetched from CppBridge through the
-   exportPrivateKeys callback flow, which prompts for the passphrase when the
-   wallet is encrypted. The list is rendered directly from the export reply so
-   that every key is shown, regardless of address use state.
+   Lists every key in the wallet. Public metadata is fetched from CppBridge
+   through exportPublicKeys without unlocking the wallet. Private keys are
+   fetched only when the user explicitly enables a private-key column, via
+   exportPrivateKeys and the unlock callback flow.
    """
    def __init__(self, wlt, parent=None, main=None):
       super(DlgShowKeyList, self).__init__(parent, main)
@@ -41,10 +43,13 @@ class DlgShowKeyList(ArmoryDialog):
       self.watchingOnly = bool(getattr(self.wlt, 'watchingOnly', False))
 
       # exported keys, populated asynchronously from the bridge. Each entry is
-      # a dict: assetId, privKey, pubKey (bytes), address (str), index (int).
+      # a dict: assetId, privKey, pubKey (bytes), address (str), index (int),
+      # addrType (int).
       self._entries = []
       self.havePriv = False
       self._unlockHandler = None
+      self._privKeysLoaded = False
+      self._privateExportInProgress = False
 
       self.strDescrReg = (self.tr(
          'The textbox below shows all keys that are part of this wallet, '
@@ -76,6 +81,7 @@ class DlgShowKeyList(ArmoryDialog):
       # Column selection checkboxes
       self.chkList = {}
       self.chkList['AddrStr']    = QtWidgets.QCheckBox(self.tr('Address String'))
+      self.chkList['AddrType']   = QtWidgets.QCheckBox(self.tr('Address Type'))
       self.chkList['PubKeyHash'] = QtWidgets.QCheckBox(self.tr('Hash160'))
       self.chkList['PrivHexBE']  = QtWidgets.QCheckBox(self.tr('Private Key (Plain Hex)'))
       self.chkList['PrivB58']    = QtWidgets.QCheckBox(self.tr('Private Key (Plain Base58)'))
@@ -83,25 +89,24 @@ class DlgShowKeyList(ArmoryDialog):
       self.chkList['ChainIndex'] = QtWidgets.QCheckBox(self.tr('Chain Index'))
 
       self.chkList['AddrStr'   ].setChecked(True)
+      self.chkList['AddrType'  ].setChecked(True)
       self.chkList['PubKeyHash'].setChecked(False)
       self.chkList['PrivB58'   ].setChecked(False)
       self.chkList['PrivHexBE' ].setChecked(False)
       self.chkList['PubKey'    ].setChecked(True)
       self.chkList['ChainIndex'].setChecked(False)
 
-      namelist = ['AddrStr', 'PubKeyHash', 'PrivB58',
+      namelist = ['AddrStr', 'AddrType', 'PubKeyHash', 'PrivB58',
                   'PrivHexBE', 'PubKey', 'ChainIndex']
 
       for name in self.chkList.keys():
-         self.chkList[name].toggled.connect(self.rewriteList)
+         if name in ('PrivB58', 'PrivHexBE'):
+            self.chkList[name].toggled.connect(self._onPrivColumnToggled)
+         else:
+            self.chkList[name].toggled.connect(self.rewriteList)
 
       self.chkOmitSpaces = QtWidgets.QCheckBox(self.tr('Omit spaces in key data'))
       self.chkOmitSpaces.toggled.connect(self.rewriteList)
-
-      # The private key columns become available once the export completes.
-      # Watch-only wallets never expose private keys.
-      self.chkList['PrivHexBE'].setEnabled(False)
-      self.chkList['PrivB58'  ].setEnabled(False)
 
       std = (self.main.usermode == USERMODE.Standard)
       adv = (self.main.usermode == USERMODE.Advanced)
@@ -152,49 +157,122 @@ class DlgShowKeyList(ArmoryDialog):
          self.txtBox.setText(self.tr(
             'This is a watch-only wallet: it holds no private keys.'))
       else:
-         self._startBridgeExport()
+         self._startPublicExport()
 
    #############################################################################
-   def _startBridgeExport(self):
+   def _parseExportItems(self, items):
+      entries = []
+      for item in items:
+         entries.append({
+            'assetId': bytes(item.assetId),
+            'privKey': bytes(item.privKey),
+            'pubKey':  bytes(item.publicKey),
+            'address': item.addressString,
+            'index':   item.index,
+            'addrType': item.addrType,
+         })
+      return entries
+
+   #############################################################################
+   def _startPublicExport(self):
+      def onKeysReceived(reply):
+         if reply.success:
+            self._entries = self._parseExportItems(reply.wallet.exportPublicKeys)
+            self.executeMethod(self._onPublicKeysReady)
+         else:
+            err = getattr(reply, 'error', None) or self.tr('Export failed.')
+            LOGERROR('exportPublicKeys failed: %s', err)
+            self.executeMethod(self._onPublicExportFailed, str(err))
+
+      self.wlt.exportPublicKeys(onKeysReceived)
+
+   #############################################################################
+   def _startPrivateExport(self):
       from qtdialogs.DlgUnlockWallet import UnlockWalletHandler
       self._unlockHandler = UnlockWalletHandler(
          self.wlt.walletId, self.tr('Export Key List'), self)
 
       def onKeysReceived(reply):
          if reply.success:
-            entries = []
-            for item in reply.wallet.exportPrivateKeys:
-               entries.append({
-                  'assetId': bytes(item.assetId),
-                  'privKey': bytes(item.privKey),
-                  'pubKey':  bytes(item.publicKey),
-                  'address': item.addressString,
-                  'index':   item.index,
-               })
-            self._entries = entries
-            self.executeMethod(self._onKeysReady)
+            self._mergePrivateKeys(reply.wallet.exportPrivateKeys)
+            self._privKeysLoaded = True
+            self._privateExportInProgress = False
+            self.executeMethod(self._onPrivateKeysReady)
          else:
             err = getattr(reply, 'error', None) or self.tr('Export failed.')
             LOGERROR('exportPrivateKeys failed: %s', err)
-            self.executeMethod(self._onExportFailed, str(err))
+            self.executeMethod(self._onPrivateExportFailed, str(err))
 
       self.wlt.exportPrivateKeys(onKeysReceived, self._unlockHandler)
 
    #############################################################################
-   def _onExportFailed(self, errMsg):
+   def _mergePrivateKeys(self, items):
+      privByAsset = {}
+      for item in items:
+         assetId = bytes(item.assetId)
+         privByAsset[assetId] = bytes(item.privKey)
+
+      if len(privByAsset) != len(self._entries):
+         LOGERROR('private export returned %d keys, expected %d',
+            len(privByAsset), len(self._entries))
+
+      for entry in self._entries:
+         privKey = privByAsset.get(entry['assetId'])
+         if privKey is not None:
+            entry['privKey'] = privKey
+
+   #############################################################################
+   def _onPublicExportFailed(self, errMsg):
       self.txtBox.setText(
-         self.tr('Could not export private keys from this wallet.') +
+         self.tr('Could not export public key data from this wallet.') +
          '\n\n' + errMsg)
 
    #############################################################################
-   def _onKeysReady(self):
-      # Enable and pre-check the private key columns now that keys are present.
-      self.chkList['PrivB58'  ].setEnabled(True)
-      self.chkList['PrivB58'  ].setChecked(True)
-      self.chkList['PrivHexBE'].setEnabled(True)
-      self.chkList['PrivHexBE'].setChecked(True)
-      self.chkList['PubKey'   ].setChecked(False)
+   def _onPrivateExportFailed(self, errMsg):
+      self._privateExportInProgress = False
+      for name in ('PrivB58', 'PrivHexBE'):
+         chk = self.chkList[name]
+         chk.blockSignals(True)
+         chk.setChecked(False)
+         chk.blockSignals(False)
       self.rewriteList()
+      self.lblDescr.setText(
+         self.strDescrReg +
+         '<br><br><font color="red">' +
+         self.tr('Private key export was not completed:') +
+         '</font> ' + escape(errMsg))
+
+   #############################################################################
+   def _onPublicKeysReady(self):
+      self.rewriteList()
+
+   #############################################################################
+   def _onPrivateKeysReady(self):
+      for name in ('PrivB58', 'PrivHexBE'):
+         self.chkList[name].blockSignals(True)
+         self.chkList[name].setChecked(True)
+         self.chkList[name].blockSignals(False)
+      self.chkList['PubKey'].blockSignals(True)
+      self.chkList['PubKey'].setChecked(False)
+      self.chkList['PubKey'].blockSignals(False)
+      self.rewriteList()
+
+   #############################################################################
+   def _onPrivColumnToggled(self, checked):
+      if not checked:
+         self.rewriteList()
+         return
+
+      if self._privKeysLoaded or self._privateExportInProgress:
+         self.rewriteList()
+         return
+
+      sender = self.sender()
+      sender.blockSignals(True)
+      sender.setChecked(False)
+      sender.blockSignals(False)
+      self._privateExportInProgress = True
+      self._startPrivateExport()
 
    #############################################################################
    def rewriteList(self, *args):
@@ -218,9 +296,13 @@ class DlgShowKeyList(ArmoryDialog):
       for entry in self._entries:
          privKey = entry['privKey']
          pubKey  = entry['pubKey']
+         addrType = entry.get('addrType', 0)
 
          if self.chkList['AddrStr'].isChecked():
             L.append((entry['address'] or self.tr('(no address)')))
+         # addrType 0 means metadata was unavailable, not AddressEntryType::Default
+         if self.chkList['AddrType'].isChecked() and addrType:
+            L.append('   AddrType  : ' + getNameForAddrType(addrType))
          if self.chkList['PubKeyHash'].isChecked() and pubKey:
             L.append('   Hash160   : ' + fmtBin(hash160(pubKey)))
          if self.chkList['PrivB58'].isChecked() and privKey:
@@ -277,6 +359,7 @@ class DlgShowKeyList(ArmoryDialog):
    def cleanup(self):
       # Drop the plaintext private keys held in the entry cache.
       self._entries = []
+      self._privateExportInProgress = False
 
    #############################################################################
    def accept(self):

--- a/qtdialogs/DlgWalletDetails.py
+++ b/qtdialogs/DlgWalletDetails.py
@@ -537,21 +537,8 @@ class DlgWalletDetails(ArmoryDialog):
          pass  # not sure that I don't handle everything in the dialog itself
 
    def execKeyList(self):
-      if self.wlt.useEncryption and self.wlt.isLocked:
-         dlg = DlgUnlockWallet(self.wlt, self, self.main, self.tr('Unlock Private Keys'))
-         if not dlg.exec_():
-            if self.main.usermode == USERMODE.Expert:
-               QtWidgets.QMessageBox.warning(self, self.tr('Unlock Failed'), self.tr(
-                  'Wallet was not unlocked.  The public keys and addresses '
-                  'will still be shown, but private keys will not be available '
-                  'unless you reopen the dialog with the correct passphrase'),
-                  QtWidgets.QMessageBox.Ok)
-            else:
-               QtWidgets.QMessageBox.warning(self, self.tr('Unlock Failed'), self.tr(
-                  'Wallet could not be unlocked to display individual keys.'),
-                  QtWidgets.QMessageBox.Ok)
-               return
-
+      # DlgShowKeyList drives the unlock itself through the CppBridge callback
+      # flow, so there is no need to unlock the wallet here.
       dlg = DlgShowKeyList(self.wlt, self, self.main)
       dlg.exec_()
 

--- a/ui/WalletFrames.py
+++ b/ui/WalletFrames.py
@@ -23,7 +23,6 @@ from armorycolors import htmlColor
 from ui.QtExecuteSignal import TheSignalExecution
 from ui.CoinControlUI import CoinControlDlg, RBFDlg
 
-from qtdialogs.DlgUnlockWallet import DlgUnlockWallet
 from qtdialogs.DlgShowKeyList import DlgShowKeyList
 from qtdialogs.qtdefines import AdvancedOptionsFrame, ArmoryFrame, \
    VERTICAL, HORIZONTAL, STRETCH, MIN_PASSWD_WIDTH, \
@@ -1115,22 +1114,8 @@ class WalletBackupFrame(ArmoryFrame):
          isBackupCreated = self.main.makeWalletCopy(
             self, self.wlt, 'Encrypt', 'encrypt')
       elif self.optIndivKeyListTop.isChecked():
-         if self.wlt.useEncryption and self.wlt.isLocked:
-            dlg = DlgUnlockWallet(self.wlt, self, self.main,
-               'Unlock Private Keys')
-            if not dlg.exec_():
-               if self.main.usermode == USERMODE.Expert:
-                  QtWidgets.QMessageBox.warning(self, self.tr('Unlock Failed'),
-                     self.tr( 'Wallet was not unlocked.  The public keys and '
-                     'addresses will still be shown, but private keys will '
-                     'not be available unless you reopen the dialog with the '
-                     'correct passphrase.'), QtWidgets.QMessageBox.Ok)
-               else:
-                  QtWidgets.QMessageBox.warning(self, self.tr('Unlock Failed'),
-                     self.tr( 'Wallet could not be unlocked to display '
-                     'individual keys.'), QtWidgets.QMessageBox.Ok)
-                  if self.main.usermode == USERMODE.Standard:
-                     return
+         # DlgShowKeyList drives the unlock itself through the CppBridge
+         # callback flow, so there is no need to unlock the wallet here.
          DlgShowKeyList(self.wlt, self.parent(), self.main).exec_()
          isBackupCreated = True
       if isBackupCreated:


### PR DESCRIPTION
Wire the Export Key Lists GUI to the bridge batch export and render every key from the enriched export reply, without relying on the in-use address map.

The `ExportedPrivateKey` reply is extended with public key and address metadata so the dialog can render the full key list on an offline instance. `DlgShowKeyList` is rewritten to fetch keys through the `exportPrivateKeys` callback unlock flow and render directly from that reply. Redundant manual `DlgUnlockWallet.exec_()` calls before opening the key list are removed from `DlgWalletDetails` and `WalletFrames`.

Rebased onto `0.97_rc2` after #767 merged and goatpig's key-filling fix (`65058b5b`).

Fixes #755.

Tested by rebuilding `CppBridge` after the capnp enrichment, running `py_compile` on the changed Python modules, smoke-testing `DlgShowKeyList` offscreen with fake export data, and manually testing with an encrypted wallet: Backup → Export Key Lists, passphrase prompt, full key list with PrivBase58 and PrivHexBE, wrong passphrase rejected, and column toggles / save-to-file working.