### PR TITLE
Improve multi-account wallet representation and scoped key export

### DIFF
--- a/ArmoryQt.py
+++ b/ArmoryQt.py
@@ -357,9 +357,9 @@ class ArmoryMainWindow(QtWidgets.QMainWindow):
 
       self.walletsView.hideColumn(0)
       if self.usermode == USERMODE.Standard:
-         initialColResize(self.walletsView, [20, 0, 0.35, 0.2, 0.2])
+         initialColResize(self.walletsView, [20, 0, 0.28, 0.16, 0.16, 0.18])
       else:
-         initialColResize(self.walletsView, [20, 0.15, 0.30, 0.2, 0.20])
+         initialColResize(self.walletsView, [20, 0.12, 0.22, 0.10, 0.14, 90])
 
 
       if TheSettings.hasSetting('LastFilterState'):

--- a/armoryengine/CppBridge.py
+++ b/armoryengine/CppBridge.py
@@ -915,11 +915,11 @@ class BridgeWalletWrapper(ProtoWrapper):
       self.accountId = accountId
 
    ####
-   def _getPacket(self):
+   def _getPacket(self, omitAccountId=False):
       packet = Bridge.ToBridge.new_message()
       wltCapn = packet.init("wallet")
       wltCapn.walletId  = self.walletId
-      if self.accountId:
+      if self.accountId and not omitAccountId:
          wltCapn.accountId = self.accountId
       return packet
 
@@ -1109,8 +1109,9 @@ class BridgeWalletWrapper(ProtoWrapper):
       return reply.wallet.hasImports
 
    ####
-   def exportKeys(self, callback: callable, publicOnly=False, unlockHandler=None):
-      packet = self._getPacket()
+   def exportKeys(self, callback: callable, publicOnly=False, unlockHandler=None,
+      omitAccountId=False):
+      packet = self._getPacket(omitAccountId=omitAccountId)
       exportReq = packet.wallet.init('exportKeys')
       if publicOnly:
          exportReq.publicDataOnly = None
@@ -1119,12 +1120,14 @@ class BridgeWalletWrapper(ProtoWrapper):
       self.send(packet, callback=callback)
 
    ####
-   def exportPrivateKeys(self, callback: callable, unlockHandler):
-      self.exportKeys(callback, publicOnly=False, unlockHandler=unlockHandler)
+   def exportPrivateKeys(self, callback: callable, unlockHandler,
+      omitAccountId=False):
+      self.exportKeys(callback, publicOnly=False, unlockHandler=unlockHandler,
+         omitAccountId=omitAccountId)
 
    ####
-   def exportPublicKeys(self, callback: callable):
-      self.exportKeys(callback, publicOnly=True)
+   def exportPublicKeys(self, callback: callable, omitAccountId=False):
+      self.exportKeys(callback, publicOnly=True, omitAccountId=omitAccountId)
 
 ################################################################################
 class BridgeCoinSelectionWrapper(ProtoWrapper):

--- a/armoryengine/PyBtcWallet.py
+++ b/armoryengine/PyBtcWallet.py
@@ -167,6 +167,9 @@ class PyBtcWallet(object):
       self.watchingOnly = payload.watchingOnly
       self.addressTypes = payload.addressTypes
       self.defaultAddressType = payload.defaultAddressType
+      self.accountName = getattr(payload, 'accountName', '') or ''
+      self.seedTypeName = getattr(payload, 'seedTypeName', '') or ''
+      self.derivationScheme = getattr(payload, 'derivationScheme', '') or ''
       self.kdfMemoryReq = payload.kdfMemReq * (1024**2)
 
       #addrMap and chainIndexMap
@@ -664,18 +667,21 @@ class PyBtcWallet(object):
          passphrase, unlockHandler)
 
    ####
-   def exportKeys(self, callback, publicOnly=False, unlockHandler=None):
+   def exportKeys(self, callback, publicOnly=False, unlockHandler=None,
+      omitAccountId=False):
       return self.bridgeWalletObj.exportKeys(
-         callback, publicOnly=publicOnly, unlockHandler=unlockHandler)
+         callback, publicOnly=publicOnly, unlockHandler=unlockHandler,
+         omitAccountId=omitAccountId)
 
    ####
-   def exportPrivateKeys(self, callback, unlockHandler):
+   def exportPrivateKeys(self, callback, unlockHandler, omitAccountId=False):
       return self.exportKeys(callback, publicOnly=False,
-         unlockHandler=unlockHandler)
+         unlockHandler=unlockHandler, omitAccountId=omitAccountId)
 
    ####
-   def exportPublicKeys(self, callback):
-      return self.exportKeys(callback, publicOnly=True)
+   def exportPublicKeys(self, callback, omitAccountId=False):
+      return self.exportKeys(callback, publicOnly=True,
+         omitAccountId=omitAccountId)
 
    #############################################################################
    ## helpers

--- a/armoryengine/WalletUtils.py
+++ b/armoryengine/WalletUtils.py
@@ -181,6 +181,11 @@ class WalletMap(object):
    def hasWallet(self, wltId: str):
       return wltId in self._wltIdToDbId
 
+   def getAccountsForWallet(self, wltId: str):
+      if wltId not in self._wltIdToDbId:
+         return {}
+      return dict(self._wltIdToDbId[wltId])
+
    ## visibility ##
    def isVisible(self, index):
       if index >= len(self._dbIdList):

--- a/armorymodels.py
+++ b/armorymodels.py
@@ -38,7 +38,7 @@ from qtdialogs.qtdefines import GETFONT, CHANGE_ADDR_DESCR_STRING, \
 
 from qtdialogs.ArmoryDialog import ArmoryDialog
 
-WLTVIEWCOLS = enum('Visible', 'ID', 'Name', 'Secure', 'Bal')
+WLTVIEWCOLS = enum('Visible', 'ID', 'Name', 'Secure', 'Bal', 'Account')
 LEDGERCOLS  = enum('NumConf', 'UnixTime', 'DateStr', 'TxDir', 'WltName',
    'Comment', 'Amount', 'isOther', 'WltID', 'TxHash', 'isCoinbase', 'toSelf',
    'optInRBF', 'isChainedZC')
@@ -65,7 +65,7 @@ class AllWalletsDispModel(QtCore.QAbstractTableModel):
       return self.wallets.count()
 
    def columnCount(self, index=QtCore.QModelIndex()):
-      return 5
+      return 6
 
    def data(self, index, role=QtCore.Qt.DisplayRole):
       bdmState = TheBDM.getState()
@@ -98,9 +98,17 @@ class AllWalletsDispModel(QtCore.QAbstractTableModel):
             else:
                dispStr = 'Scanning: %d%%' % (mainWnd.walletSideScanProgress[wltID])
                return str(dispStr)
+         elif col==COL.Account:
+            acctName = getattr(wlt, 'accountName', '') or ''
+            if acctName:
+               return str(acctName)
+            acctId = getattr(wlt, 'accountId', '') or ''
+            if acctId and len(acctId) > 10:
+               return str(acctId[:10] + '...')
+            return str(acctId)
 
       elif role==QtCore.Qt.TextAlignmentRole:
-         if col in (COL.ID, COL.Name):
+         if col in (COL.ID, COL.Name, COL.Account):
             return int(QtCore.Qt.AlignLeft | QtCore.Qt.AlignVCenter)
          elif col in (COL.Secure,):
             return int(QtCore.Qt.AlignHCenter | QtCore.Qt.AlignVCenter)
@@ -123,7 +131,8 @@ class AllWalletsDispModel(QtCore.QAbstractTableModel):
       return None
 
    def headerData(self, section, orientation, role=QtCore.Qt.DisplayRole):
-      colLabels = ['', self.tr('ID'), self.tr('Wallet Name'), self.tr('Security'), self.tr('Balance')]
+      colLabels = ['', self.tr('ID'), self.tr('Wallet Name'),
+         self.tr('Security'), self.tr('Balance'), self.tr('Account')]
       if role==QtCore.Qt.DisplayRole:
          if orientation==QtCore.Qt.Horizontal:
             return colLabels[section]

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,12 @@ Unreleased (0.97_rc2)
 == Added ==
    - Add exportKeys bridge request supporting public-only and passphrase-gated private key export.
    - Add Address Type column to the wallet key list dialog.
+   - Add accountId and isUsed fields to exported key metadata.
+   - Add accountName, seedTypeName, and derivationScheme fields to WalletData bridge payloads.
+   - Add Account column to the main wallet lobby table.
+   - Add account name and address type fields to the wallet properties dialog.
+   - Add multi-account export scope prompt, rich header metadata, large-wallet warning, and hide-unused filter to the key list dialog.
+   - Add WalletMap.getAccountsForWallet helper for sibling-account lookup.
 
 == Changed ==
    - Show key list public data on dialog open without unlocking the wallet.
@@ -11,6 +17,18 @@ Unreleased (0.97_rc2)
    - Show private key export failures in the key list dialog without clearing public data.
    - Stop unchecking the Public Key column when private keys are loaded in the key list dialog.
    - Guard private key export against duplicate unlock prompts when both priv-key columns are toggled quickly.
+   - Restrict key export to the requested account when accountId is set on the wallet request.
+   - Omit accountId from export bridge requests when exporting all accounts in a wallet file.
+   - Show human-readable account names in export-all key list section headers.
+   - Treat closing the multi-account export scope prompt as cancel rather than export-all.
+   - Enable public key export for watch-only wallets in the key list dialog.
+   - Clear cached private key bytes and text box contents when the key list dialog closes.
+   - Fix BIP32 account naming to accept any hardened account index, not only account 0'.
+   - Derive seedTypeName from account purpose names instead of labeling multi-account wallets BIP32 Structured.
+   - Fix bip32NameFromRootPath to infer BIP purpose from the first three derivation path elements.
+   - Fix unlockControlHeader to look up wallet files by filename.
+   - Fix setup manager unlock and migrate button handlers to capture each wallet row.
+   - Fix unlock dialog handling of multiple encryption keys in one control-header unlock.
 
 v0.96.5, released December 23rd 2018
 == Added ==

--- a/changelog.txt
+++ b/changelog.txt
@@ -31,6 +31,8 @@ Unreleased (0.97_rc2)
    - Move wallet display-name logic into Wallets classes with getDisplayName methods.
    - Hold the wallet decryption lock through key-export serialization to avoid extra private-key copies.
    - Take std::filesystem::path in WalletManager::unlockControlHeader.
+   - Show Armory Legacy and N/A derivation-scheme display names for legacy and import accounts.
+   - Pass exported private keys as BinaryDataRef instead of naked SecureBinaryData pointers.
    - Fix setup manager unlock and migrate button handlers to capture each wallet row.
    - Label receive and change key chains separately in the key list export.
    - Rename wallet properties and key list address-type labels to eligible address type and default address types.

--- a/changelog.txt
+++ b/changelog.txt
@@ -26,8 +26,11 @@ Unreleased (0.97_rc2)
    - Clear cached private key bytes and text box contents when the key list dialog closes.
    - Fix BIP32 account naming to accept any hardened account index, not only account 0'.
    - Derive seedTypeName from account purpose names instead of labeling multi-account wallets BIP32 Structured.
-   - Fix bip32NameFromRootPath to infer BIP purpose from the first three derivation path elements.
+   - Infer BIP purpose display names from the first three derivation path elements.
    - Fix unlockControlHeader to look up wallet files by filename.
+   - Move wallet display-name logic into Wallets classes with getDisplayName methods.
+   - Hold the wallet decryption lock through key-export serialization to avoid extra private-key copies.
+   - Take std::filesystem::path in WalletManager::unlockControlHeader.
    - Fix setup manager unlock and migrate button handlers to capture each wallet row.
    - Label receive and change key chains separately in the key list export.
    - Rename wallet properties and key list address-type labels to eligible address type and default address types.

--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@ Unreleased (0.97_rc2)
    - Add account name and address type fields to the wallet properties dialog.
    - Add multi-account export scope prompt, rich header metadata, large-wallet warning, and hide-unused filter to the key list dialog.
    - Add WalletMap.getAccountsForWallet helper for sibling-account lookup.
+   - Add chainRole field to exported key metadata for receive and change key chains.
 
 == Changed ==
    - Show key list public data on dialog open without unlocking the wallet.
@@ -28,7 +29,9 @@ Unreleased (0.97_rc2)
    - Fix bip32NameFromRootPath to infer BIP purpose from the first three derivation path elements.
    - Fix unlockControlHeader to look up wallet files by filename.
    - Fix setup manager unlock and migrate button handlers to capture each wallet row.
-   - Fix unlock dialog handling of multiple encryption keys in one control-header unlock.
+   - Label receive and change key chains separately in the key list export.
+   - Rename wallet properties and key list address-type labels to eligible address type and default address types.
+   - Widen the lobby Account column for BIP purpose account names.
 
 v0.96.5, released December 23rd 2018
 == Added ==

--- a/cppForSwig/BridgeAPI/CppBridge.cpp
+++ b/cppForSwig/BridgeAPI/CppBridge.cpp
@@ -71,13 +71,9 @@ namespace
       return BinaryData(bytes.begin(), bytes.end());
    }
 
-   std::string inferAccountDisplayName(
-      const std::shared_ptr<Accounts::AddressAccount>&,
-      const Wallets::AddressAccountId&);
-   std::string inferSeedTypeName(
-      const std::shared_ptr<Wallets::AssetWallet_Single>&);
-   std::string inferDerivationScheme(
-      const std::shared_ptr<Accounts::AddressAccount>&);
+   std::string chainRoleForAssetAccount(
+      const std::shared_ptr<Accounts::AddressAccount>& accPtr,
+      const Wallets::AssetAccountId& assetAccId);
 
    void addressToCapnp(WalletData::AddressData::Builder& capnAddress,
       std::shared_ptr<AddressEntry> addrPtr,
@@ -221,9 +217,9 @@ namespace
       capnWallet.setDefaultAddressType(
          (uint32_t)accPtr->getDefaultAddressType());
 
-      capnWallet.setAccountName(inferAccountDisplayName(accPtr, accId));
-      capnWallet.setSeedTypeName(inferSeedTypeName(wltSingle));
-      capnWallet.setDerivationScheme(inferDerivationScheme(accPtr));
+      capnWallet.setAccountName(accPtr->getDisplayName());
+      capnWallet.setSeedTypeName(wltSingle->getSeedTypeDisplayName());
+      capnWallet.setDerivationScheme(accPtr->getDerivationSchemeDisplay());
 
       //address use count
       auto assetAccountPtr = accPtr->getOuterAccount();
@@ -653,7 +649,7 @@ void CppBridge::unlockControlHeader(const std::string& path,
       };
 
       try {
-         wltManager_->unlockControlHeader(path, lbd);
+         wltManager_->unlockControlHeader(std::filesystem::path(path), lbd);
          notifySuccess(true, {});
       } catch (const std::exception& e) {
          notifySuccess(false, e.what());
@@ -772,7 +768,7 @@ namespace {
    struct ExportedKeyData
    {
       BinaryData assetId;
-      SecureBinaryData privKey;
+      const SecureBinaryData* privKeyRef = nullptr;
       BinaryData pubKey;
       std::string addressString;
       uint32_t addrType = 0;
@@ -796,136 +792,6 @@ namespace {
       }
       if (assetAccId == innerId) {
          return "Change";
-      }
-      return {};
-   }
-
-   std::string formatDerivationPath(const std::vector<uint32_t>& path)
-   {
-      if (path.empty()) {
-         return {};
-      }
-      std::string result = "m";
-      for (const auto node : path) {
-         result += '/';
-         if (node >= 0x80000000) {
-            result += std::to_string(node & 0x7FFFFFFF);
-            result += '\'';
-         } else {
-            result += std::to_string(node);
-         }
-      }
-      return result;
-   }
-
-   std::string bip32NameFromRootPath(const std::vector<uint32_t>& rootPath)
-   {
-      // Account roots may be stored at the external-chain level
-      // (purpose'/coin'/account'/0), so read purpose/coin/account from the
-      // first three path elements.
-      if (rootPath.size() < 3) {
-         return "BIP32";
-      }
-      const auto coinType = Armory::Config::BitcoinSettings::getCoinType();
-      if (rootPath[1] != coinType || !(rootPath[2] & 0x80000000)) {
-         return "BIP32";
-      }
-      switch (rootPath[0]) {
-         case 0x8000002C:
-            return "BIP44";
-         case 0x80000031:
-            return "BIP49";
-         case 0x80000054:
-            return "BIP84";
-         default:
-            return "BIP32";
-      }
-   }
-
-   std::string inferAccountDisplayName(
-      const std::shared_ptr<Accounts::AddressAccount>& accPtr,
-      const Wallets::AddressAccountId& accId)
-   {
-      if (accPtr->isLegacy()) {
-         return "Armory Legacy";
-      }
-      try {
-         auto outerAcc = accPtr->getOuterAccount();
-         auto root = outerAcc->getRoot();
-         auto rootBip32 = std::dynamic_pointer_cast<
-            Assets::AssetEntry_BIP32Root>(root);
-         if (rootBip32 != nullptr) {
-            return bip32NameFromRootPath(rootBip32->getDerivationPath());
-         }
-      } catch (const std::exception&) {
-      }
-      const auto hex = accId.toHexStr();
-      if (hex.size() > 8) {
-         return hex.substr(0, 8) + "...";
-      }
-      return hex;
-   }
-
-   std::string inferSeedTypeName(
-      const std::shared_ptr<Wallets::AssetWallet_Single>& wltSingle)
-   {
-      if (wltSingle == nullptr) {
-         return {};
-      }
-      auto root = wltSingle->getRoot();
-      if (auto legacyRoot = std::dynamic_pointer_cast<
-         Assets::AssetEntry_ArmoryLegacyRoot>(root)) {
-         switch (legacyRoot->getSeedType()) {
-            case Seeds::LegacyType::Armory135:
-               return "Armory Legacy (1.35)";
-            case Seeds::LegacyType::Armory200:
-               return "Armory Legacy (2.00)";
-            default:
-               return "Armory Legacy";
-         }
-      }
-      if (std::dynamic_pointer_cast<Assets::AssetEntry_BIP32Root>(root)) {
-         std::set<std::string> purposeNames;
-         for (const auto& accId : wltSingle->getAccountIDs()) {
-            auto accPtr = wltSingle->getAccountForID(accId);
-            if (accPtr == nullptr || accPtr->isLegacy()) {
-               continue;
-            }
-            try {
-               auto outerAcc = accPtr->getOuterAccount();
-               auto accRoot = outerAcc->getRoot();
-               auto rootBip32 = std::dynamic_pointer_cast<
-                  Assets::AssetEntry_BIP32Root>(accRoot);
-               if (rootBip32 != nullptr) {
-                  purposeNames.insert(
-                     bip32NameFromRootPath(rootBip32->getDerivationPath()));
-               }
-            } catch (const std::exception&) {
-            }
-         }
-         if (purposeNames.size() == 1) {
-            return *purposeNames.begin();
-         }
-         return "BIP32";
-      }
-      return {};
-   }
-
-   std::string inferDerivationScheme(
-      const std::shared_ptr<Accounts::AddressAccount>& accPtr)
-   {
-      if (accPtr->isLegacy()) {
-         return {};
-      }
-      try {
-         auto outerAcc = accPtr->getOuterAccount();
-         auto root = outerAcc->getRoot();
-         auto rootBip32 = std::dynamic_pointer_cast<
-            Assets::AssetEntry_BIP32Root>(root);
-         if (rootBip32 != nullptr) {
-            return formatDerivationPath(rootBip32->getDerivationPath());
-         }
-      } catch (const std::exception&) {
       }
       return {};
    }
@@ -968,15 +834,12 @@ namespace {
       }
    }
 
-   std::vector<ExportedKeyData> collectExportedKeys(
+   void collectExportedKeys(
       const std::shared_ptr<Wallets::AssetWallet_Single>& wltSingle,
       const Wallets::AddressAccountId& scopeAccId,
       bool includePrivateKeys,
-      const std::function<Passphrase::Result(
-         const std::set<Wallets::EncryptionKeyId>&)>& decryptLbd)
+      std::vector<ExportedKeyData>& exportedKeys)
    {
-      std::vector<ExportedKeyData> exportedKeys;
-
       std::vector<Wallets::AddressAccountId> accountIdsToWalk;
       if (scopeAccId.isValid()) {
          accountIdsToWalk.push_back(scopeAccId);
@@ -1034,9 +897,8 @@ namespace {
                   entry.chainRole = chainRoleForAssetAccount(accPtr, assetAccId);
 
                   if (includePrivateKeys) {
-                     const auto& privKey =
-                        wltSingle->getDecryptedPrivateKeyForAsset(assetSingle);
-                     entry.privKey = SecureBinaryData(privKey);
+                     entry.privKeyRef =
+                        &wltSingle->getDecryptedPrivateKeyForAsset(assetSingle);
                   }
 
                   fillExportedKeyMetadata(entry, accPtr, assetID);
@@ -1046,14 +908,7 @@ namespace {
          }
       };
 
-      if (includePrivateKeys) {
-         auto lock = wltSingle->lockDecryptedContainer(decryptLbd);
-         walkWallet();
-      } else {
-         walkWallet();
-      }
-
-      return exportedKeys;
+      walkWallet();
    }
 
    void populateExportedKey(WalletReply::ExportedPrivateKey::Builder& capnKey,
@@ -1061,9 +916,9 @@ namespace {
    {
       capnKey.setAssetId(capnp::Data::Builder(
          (uint8_t*)entry.assetId.getPtr(), entry.assetId.getSize()));
-      if (!entry.privKey.empty()) {
+      if (entry.privKeyRef != nullptr && !entry.privKeyRef->empty()) {
          capnKey.setPrivKey(capnp::Data::Builder(
-            (uint8_t*)entry.privKey.getPtr(), entry.privKey.getSize()));
+            (uint8_t*)entry.privKeyRef->getPtr(), entry.privKeyRef->getSize()));
       }
       if (!entry.pubKey.empty()) {
          capnKey.setPublicKey(capnp::Data::Builder(
@@ -1111,7 +966,7 @@ void CppBridge::exportKeys(const Wallets::WalletId& wltId,
    auto func = [this, wltId, accId, includePrivateKeys, callbackId, msgId]()
    {
       std::vector<ExportedKeyData> exportedKeys;
-      std::string error;
+      BinaryData serialized;
 
       std::shared_ptr<BridgePassphrasePrompt> passPromptObj;
 
@@ -1147,20 +1002,18 @@ void CppBridge::exportKeys(const Wallets::WalletId& wltId,
                });
             auto lbd = passPromptObj->getLambda();
             ExportKeysCleanup cleanupGuard{passPromptObj};
-
-            exportedKeys = collectExportedKeys(wltSingle, accId, true, lbd);
+            auto lock = wltSingle->lockDecryptedContainer(lbd);
+            collectExportedKeys(wltSingle, accId, true, exportedKeys);
+            serialized = buildExportedKeysReply(msgId, exportedKeys, "");
          } else {
-            exportedKeys = collectExportedKeys(wltSingle, accId, false,
-               [](const std::set<Wallets::EncryptionKeyId>&)->Passphrase::Result{
-                  return {{}, false};
-               });
+            collectExportedKeys(wltSingle, accId, false, exportedKeys);
+            serialized = buildExportedKeysReply(msgId, exportedKeys, "");
          }
 
       } catch (const std::exception& e) {
-         error = e.what();
+         serialized = buildExportedKeysReply(msgId, {}, e.what());
       }
 
-      auto serialized = buildExportedKeysReply(msgId, exportedKeys, error);
       this->writeToClient(serialized);
    };
 

--- a/cppForSwig/BridgeAPI/CppBridge.cpp
+++ b/cppForSwig/BridgeAPI/CppBridge.cpp
@@ -779,7 +779,26 @@ namespace {
       int32_t index = 0;
       std::string accountId;
       bool isUsed = false;
+      std::string chainRole;
    };
+
+   std::string chainRoleForAssetAccount(
+      const std::shared_ptr<Accounts::AddressAccount>& accPtr,
+      const Wallets::AssetAccountId& assetAccId)
+   {
+      const auto& outerId = accPtr->getOuterAccountID();
+      const auto& innerId = accPtr->getInnerAccountID();
+      if (outerId == innerId) {
+         return {};
+      }
+      if (assetAccId == outerId) {
+         return "Receive";
+      }
+      if (assetAccId == innerId) {
+         return "Change";
+      }
+      return {};
+   }
 
    std::string formatDerivationPath(const std::vector<uint32_t>& path)
    {
@@ -1012,6 +1031,7 @@ namespace {
                   entry.index = assetSingle->getIndex();
                   entry.accountId = addrAccId.toHexStr();
                   entry.isUsed = accPtr->isAssetInUse(assetID);
+                  entry.chainRole = chainRoleForAssetAccount(accPtr, assetAccId);
 
                   if (includePrivateKeys) {
                      const auto& privKey =
@@ -1054,6 +1074,7 @@ namespace {
       capnKey.setIndex(entry.index);
       capnKey.setAccountId(entry.accountId);
       capnKey.setIsUsed(entry.isUsed);
+      capnKey.setChainRole(entry.chainRole);
    }
 
    BinaryData buildExportedKeysReply(MessageId msgId,

--- a/cppForSwig/BridgeAPI/CppBridge.cpp
+++ b/cppForSwig/BridgeAPI/CppBridge.cpp
@@ -23,6 +23,7 @@
 #include <BlockchainDatabase/txio.h>
 
 #include <Wallets/Seeds/Backups.h>
+#include <Wallets/Seeds/Seeds.h>
 #include <Wallets/IOHeader.h>
 #include <Wallets/WalletIdTypes.h>
 #include <Wallets/KDF.h>
@@ -69,6 +70,14 @@ namespace
       auto bytes = flat.asBytes();
       return BinaryData(bytes.begin(), bytes.end());
    }
+
+   std::string inferAccountDisplayName(
+      const std::shared_ptr<Accounts::AddressAccount>&,
+      const Wallets::AddressAccountId&);
+   std::string inferSeedTypeName(
+      const std::shared_ptr<Wallets::AssetWallet_Single>&);
+   std::string inferDerivationScheme(
+      const std::shared_ptr<Accounts::AddressAccount>&);
 
    void addressToCapnp(WalletData::AddressData::Builder& capnAddress,
       std::shared_ptr<AddressEntry> addrPtr,
@@ -211,6 +220,10 @@ namespace
       }
       capnWallet.setDefaultAddressType(
          (uint32_t)accPtr->getDefaultAddressType());
+
+      capnWallet.setAccountName(inferAccountDisplayName(accPtr, accId));
+      capnWallet.setSeedTypeName(inferSeedTypeName(wltSingle));
+      capnWallet.setDerivationScheme(inferDerivationScheme(accPtr));
 
       //address use count
       auto assetAccountPtr = accPtr->getOuterAccount();
@@ -764,7 +777,139 @@ namespace {
       std::string addressString;
       uint32_t addrType = 0;
       int32_t index = 0;
+      std::string accountId;
+      bool isUsed = false;
    };
+
+   std::string formatDerivationPath(const std::vector<uint32_t>& path)
+   {
+      if (path.empty()) {
+         return {};
+      }
+      std::string result = "m";
+      for (const auto node : path) {
+         result += '/';
+         if (node >= 0x80000000) {
+            result += std::to_string(node & 0x7FFFFFFF);
+            result += '\'';
+         } else {
+            result += std::to_string(node);
+         }
+      }
+      return result;
+   }
+
+   std::string bip32NameFromRootPath(const std::vector<uint32_t>& rootPath)
+   {
+      // Account roots may be stored at the external-chain level
+      // (purpose'/coin'/account'/0), so read purpose/coin/account from the
+      // first three path elements.
+      if (rootPath.size() < 3) {
+         return "BIP32";
+      }
+      const auto coinType = Armory::Config::BitcoinSettings::getCoinType();
+      if (rootPath[1] != coinType || !(rootPath[2] & 0x80000000)) {
+         return "BIP32";
+      }
+      switch (rootPath[0]) {
+         case 0x8000002C:
+            return "BIP44";
+         case 0x80000031:
+            return "BIP49";
+         case 0x80000054:
+            return "BIP84";
+         default:
+            return "BIP32";
+      }
+   }
+
+   std::string inferAccountDisplayName(
+      const std::shared_ptr<Accounts::AddressAccount>& accPtr,
+      const Wallets::AddressAccountId& accId)
+   {
+      if (accPtr->isLegacy()) {
+         return "Armory Legacy";
+      }
+      try {
+         auto outerAcc = accPtr->getOuterAccount();
+         auto root = outerAcc->getRoot();
+         auto rootBip32 = std::dynamic_pointer_cast<
+            Assets::AssetEntry_BIP32Root>(root);
+         if (rootBip32 != nullptr) {
+            return bip32NameFromRootPath(rootBip32->getDerivationPath());
+         }
+      } catch (const std::exception&) {
+      }
+      const auto hex = accId.toHexStr();
+      if (hex.size() > 8) {
+         return hex.substr(0, 8) + "...";
+      }
+      return hex;
+   }
+
+   std::string inferSeedTypeName(
+      const std::shared_ptr<Wallets::AssetWallet_Single>& wltSingle)
+   {
+      if (wltSingle == nullptr) {
+         return {};
+      }
+      auto root = wltSingle->getRoot();
+      if (auto legacyRoot = std::dynamic_pointer_cast<
+         Assets::AssetEntry_ArmoryLegacyRoot>(root)) {
+         switch (legacyRoot->getSeedType()) {
+            case Seeds::LegacyType::Armory135:
+               return "Armory Legacy (1.35)";
+            case Seeds::LegacyType::Armory200:
+               return "Armory Legacy (2.00)";
+            default:
+               return "Armory Legacy";
+         }
+      }
+      if (std::dynamic_pointer_cast<Assets::AssetEntry_BIP32Root>(root)) {
+         std::set<std::string> purposeNames;
+         for (const auto& accId : wltSingle->getAccountIDs()) {
+            auto accPtr = wltSingle->getAccountForID(accId);
+            if (accPtr == nullptr || accPtr->isLegacy()) {
+               continue;
+            }
+            try {
+               auto outerAcc = accPtr->getOuterAccount();
+               auto accRoot = outerAcc->getRoot();
+               auto rootBip32 = std::dynamic_pointer_cast<
+                  Assets::AssetEntry_BIP32Root>(accRoot);
+               if (rootBip32 != nullptr) {
+                  purposeNames.insert(
+                     bip32NameFromRootPath(rootBip32->getDerivationPath()));
+               }
+            } catch (const std::exception&) {
+            }
+         }
+         if (purposeNames.size() == 1) {
+            return *purposeNames.begin();
+         }
+         return "BIP32";
+      }
+      return {};
+   }
+
+   std::string inferDerivationScheme(
+      const std::shared_ptr<Accounts::AddressAccount>& accPtr)
+   {
+      if (accPtr->isLegacy()) {
+         return {};
+      }
+      try {
+         auto outerAcc = accPtr->getOuterAccount();
+         auto root = outerAcc->getRoot();
+         auto rootBip32 = std::dynamic_pointer_cast<
+            Assets::AssetEntry_BIP32Root>(root);
+         if (rootBip32 != nullptr) {
+            return formatDerivationPath(rootBip32->getDerivationPath());
+         }
+      } catch (const std::exception&) {
+      }
+      return {};
+   }
 
    void fillExportedKeyMetadata(ExportedKeyData& entry,
       const std::shared_ptr<Accounts::AddressAccount>& accPtr,
@@ -806,15 +951,25 @@ namespace {
 
    std::vector<ExportedKeyData> collectExportedKeys(
       const std::shared_ptr<Wallets::AssetWallet_Single>& wltSingle,
+      const Wallets::AddressAccountId& scopeAccId,
       bool includePrivateKeys,
       const std::function<Passphrase::Result(
          const std::set<Wallets::EncryptionKeyId>&)>& decryptLbd)
    {
       std::vector<ExportedKeyData> exportedKeys;
 
+      std::vector<Wallets::AddressAccountId> accountIdsToWalk;
+      if (scopeAccId.isValid()) {
+         accountIdsToWalk.push_back(scopeAccId);
+      } else {
+         for (const auto& addrAccId : wltSingle->getAccountIDs()) {
+            accountIdsToWalk.push_back(addrAccId);
+         }
+      }
+
       auto walkWallet = [&]()
       {
-         for (const auto& addrAccId : wltSingle->getAccountIDs()) {
+         for (const auto& addrAccId : accountIdsToWalk) {
             auto accPtr = wltSingle->getAccountForID(addrAccId);
             if (!accPtr) {
                continue;
@@ -855,6 +1010,8 @@ namespace {
                   ExportedKeyData entry;
                   entry.assetId = assetID.getSerializedKey(PROTO_ASSETID_PREFIX);
                   entry.index = assetSingle->getIndex();
+                  entry.accountId = addrAccId.toHexStr();
+                  entry.isUsed = accPtr->isAssetInUse(assetID);
 
                   if (includePrivateKeys) {
                      const auto& privKey =
@@ -895,6 +1052,8 @@ namespace {
       capnKey.setAddressString(entry.addressString);
       capnKey.setAddrType(entry.addrType);
       capnKey.setIndex(entry.index);
+      capnKey.setAccountId(entry.accountId);
+      capnKey.setIsUsed(entry.isUsed);
    }
 
    BinaryData buildExportedKeysReply(MessageId msgId,
@@ -925,9 +1084,10 @@ namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 void CppBridge::exportKeys(const Wallets::WalletId& wltId,
+   const Wallets::AddressAccountId& accId,
    bool includePrivateKeys, const CallbackId& callbackId, MessageId msgId)
 {
-   auto func = [this, wltId, includePrivateKeys, callbackId, msgId]()
+   auto func = [this, wltId, accId, includePrivateKeys, callbackId, msgId]()
    {
       std::vector<ExportedKeyData> exportedKeys;
       std::string error;
@@ -967,9 +1127,9 @@ void CppBridge::exportKeys(const Wallets::WalletId& wltId,
             auto lbd = passPromptObj->getLambda();
             ExportKeysCleanup cleanupGuard{passPromptObj};
 
-            exportedKeys = collectExportedKeys(wltSingle, true, lbd);
+            exportedKeys = collectExportedKeys(wltSingle, accId, true, lbd);
          } else {
-            exportedKeys = collectExportedKeys(wltSingle, false,
+            exportedKeys = collectExportedKeys(wltSingle, accId, false,
                [](const std::set<Wallets::EncryptionKeyId>&)->Passphrase::Result{
                   return {{}, false};
                });

--- a/cppForSwig/BridgeAPI/CppBridge.cpp
+++ b/cppForSwig/BridgeAPI/CppBridge.cpp
@@ -768,7 +768,7 @@ namespace {
    struct ExportedKeyData
    {
       BinaryData assetId;
-      const SecureBinaryData* privKeyRef = nullptr;
+      BinaryDataRef privKeyRef;
       BinaryData pubKey;
       std::string addressString;
       uint32_t addrType = 0;
@@ -878,6 +878,10 @@ namespace {
                      continue;
                }
 
+               //getDecryptedPrivateKeyForAsset will fill missing private keys
+               //run backwards the assets to compute missing keys in batch
+               //rather than sequentially
+               //TODO: add progressCallback logic to extend/fillPrivateKey
                auto lastIdx = assetAcc->getLastComputedIndex();
                for (int32_t i = lastIdx; i >= 0; i--) {
                   auto assetPtr = assetAcc->getAssetForKey(i);
@@ -898,7 +902,7 @@ namespace {
 
                   if (includePrivateKeys) {
                      entry.privKeyRef =
-                        &wltSingle->getDecryptedPrivateKeyForAsset(assetSingle);
+                        wltSingle->getDecryptedPrivateKeyForAsset(assetSingle);
                   }
 
                   fillExportedKeyMetadata(entry, accPtr, assetID);
@@ -916,9 +920,9 @@ namespace {
    {
       capnKey.setAssetId(capnp::Data::Builder(
          (uint8_t*)entry.assetId.getPtr(), entry.assetId.getSize()));
-      if (entry.privKeyRef != nullptr && !entry.privKeyRef->empty()) {
+      if (!entry.privKeyRef.empty()) {
          capnKey.setPrivKey(capnp::Data::Builder(
-            (uint8_t*)entry.privKeyRef->getPtr(), entry.privKeyRef->getSize()));
+            (uint8_t*)entry.privKeyRef.getPtr(), entry.privKeyRef.getSize()));
       }
       if (!entry.pubKey.empty()) {
          capnKey.setPublicKey(capnp::Data::Builder(

--- a/cppForSwig/BridgeAPI/CppBridge.h
+++ b/cppForSwig/BridgeAPI/CppBridge.h
@@ -197,7 +197,8 @@ namespace Armory
          void importWallet(const std::filesystem::path&, MessageId);
          void forkWatchingOnly(const Wallets::WalletId&,
             const CallbackId&, MessageId);
-         void exportKeys(const Wallets::WalletId&, bool includePrivateKeys,
+         void exportKeys(const Wallets::WalletId&,
+            const Wallets::AddressAccountId&, bool includePrivateKeys,
             const CallbackId& callbackId, MessageId);
 
          //ledgers

--- a/cppForSwig/BridgeAPI/ProtoCommandParser.cpp
+++ b/cppForSwig/BridgeAPI/ProtoCommandParser.cpp
@@ -687,7 +687,7 @@ namespace
             if (includePrivateKeys) {
                callbackId = exportRequest.getWithPrivateKeys();
             }
-            bridge->exportKeys(walletId, includePrivateKeys,
+            bridge->exportKeys(walletId, accountId, includePrivateKeys,
                callbackId, referenceId);
             break;
          }

--- a/cppForSwig/BridgeAPI/Wallets/Manager.cpp
+++ b/cppForSwig/BridgeAPI/Wallets/Manager.cpp
@@ -668,7 +668,8 @@ void WalletManager::unlockControlHeader(const std::string& path,
       throw std::runtime_error("tried to unlock control header with empty id/lambda");
    }
 
-   auto iter = walletFiles_.find(path);
+   const auto fileKey = std::filesystem::path(path).filename().string();
+   auto iter = walletFiles_.find(fileKey);
    if (iter == walletFiles_.end()) {
       throw std::runtime_error("this file is not a known wallet: " + path);
    }

--- a/cppForSwig/BridgeAPI/Wallets/Manager.cpp
+++ b/cppForSwig/BridgeAPI/Wallets/Manager.cpp
@@ -660,7 +660,7 @@ std::shared_ptr<WalletFileInfo> WalletManager::importFile(
 }
 
 /////////
-void WalletManager::unlockControlHeader(const std::string& path,
+void WalletManager::unlockControlHeader(const std::filesystem::path& path,
    const Passphrase::UnlockFunc& lbd)
 {
    //sanity checks
@@ -668,10 +668,9 @@ void WalletManager::unlockControlHeader(const std::string& path,
       throw std::runtime_error("tried to unlock control header with empty id/lambda");
    }
 
-   const auto fileKey = std::filesystem::path(path).filename().string();
-   auto iter = walletFiles_.find(fileKey);
+   auto iter = walletFiles_.find(path.filename().string());
    if (iter == walletFiles_.end()) {
-      throw std::runtime_error("this file is not a known wallet: " + path);
+      throw std::runtime_error("this file is not a known wallet: " + path.string());
    }
 
    auto infoObj = std::dynamic_pointer_cast<LMDBWalletInfo>(iter->second);

--- a/cppForSwig/BridgeAPI/Wallets/Manager.h
+++ b/cppForSwig/BridgeAPI/Wallets/Manager.h
@@ -96,7 +96,8 @@ namespace Armory
 
          /* pre wallets loading calls */
          std::map<std::string, std::shared_ptr<WalletFileInfo>> listWallets(void);
-         void unlockControlHeader(const std::string&, const Passphrase::UnlockFunc&);
+         void unlockControlHeader(const std::filesystem::path&,
+            const Passphrase::UnlockFunc&);
          const Wallets::WalletId& migrateWallet(const std::filesystem::path&,
             const Passphrase::UnlockFunc&,
             const Wallets::IO::CreateWalletParams&

--- a/cppForSwig/Wallets/Accounts/AccountTypes.cpp
+++ b/cppForSwig/Wallets/Accounts/AccountTypes.cpp
@@ -389,7 +389,7 @@ std::string AccountType_BIP32::name() const
    auto coinNode = *nodesIter++;
    auto lastNode = *nodesIter;
    const auto coinType = Armory::Config::BitcoinSettings::getCoinType();
-   if (coinNode.value != coinType || lastNode.value != 0x80000000) {
+   if (coinNode.value != coinType || !(lastNode.value & 0x80000000)) {
       return std::string{"BIP32"};
    }
    switch (baseNode.value)

--- a/cppForSwig/Wallets/Accounts/AccountTypes.h
+++ b/cppForSwig/Wallets/Accounts/AccountTypes.h
@@ -123,6 +123,7 @@ namespace Armory
          //virtuals
          virtual AccountTypeEnum type(void) const = 0;
          virtual std::string name(void) const = 0;
+         std::string getDisplayName(void) const { return name(); }
          virtual Wallets::AddressAccountId getAccountID(void) const = 0;
          virtual Wallets::AssetAccountId getOuterAccountID(void) const = 0;
          virtual Wallets::AssetAccountId getInnerAccountID(void) const = 0;

--- a/cppForSwig/Wallets/Accounts/AddressAccounts.cpp
+++ b/cppForSwig/Wallets/Accounts/AddressAccounts.cpp
@@ -1291,6 +1291,46 @@ bool AddressAccount::isLegacy() const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+std::string AddressAccount::getDisplayName() const
+{
+   if (isLegacy()) {
+      return "Armory Legacy";
+   }
+   try {
+      auto outerAcc = getOuterAccount();
+      auto root = outerAcc->getRoot();
+      auto rootBip32 = std::dynamic_pointer_cast<AssetEntry_BIP32Root>(root);
+      if (rootBip32 != nullptr) {
+         return rootBip32->getDisplayName();
+      }
+   } catch (const std::exception&) {
+   }
+   const auto hex = ID_.toHexStr();
+   if (hex.size() > 8) {
+      return hex.substr(0, 8) + "...";
+   }
+   return hex;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+std::string AddressAccount::getDerivationSchemeDisplay() const
+{
+   if (isLegacy()) {
+      return {};
+   }
+   try {
+      auto outerAcc = getOuterAccount();
+      auto root = outerAcc->getRoot();
+      auto rootBip32 = std::dynamic_pointer_cast<AssetEntry_BIP32Root>(root);
+      if (rootBip32 != nullptr) {
+         return rootBip32->getDerivationSchemeDisplay();
+      }
+   } catch (const std::exception&) {
+   }
+   return {};
+}
+
+////////////////////////////////////////////////////////////////////////////////
 AddressAccountPublicData::AddressAccountPublicData(
    const AddressAccountId& accId,
    const AssetAccountId& outId,

--- a/cppForSwig/Wallets/Accounts/AddressAccounts.cpp
+++ b/cppForSwig/Wallets/Accounts/AddressAccounts.cpp
@@ -1316,7 +1316,11 @@ std::string AddressAccount::getDisplayName() const
 std::string AddressAccount::getDerivationSchemeDisplay() const
 {
    if (isLegacy()) {
-      return {};
+      return "Armory Legacy";
+   }
+   if (ID_ == AddressAccountId{IMPORTS_ACCOUNT_PRIV} ||
+       ID_ == AddressAccountId{IMPORTS_ACCOUNT_PUB}) {
+      return "N/A";
    }
    try {
       auto outerAcc = getOuterAccount();

--- a/cppForSwig/Wallets/Accounts/AddressAccounts.h
+++ b/cppForSwig/Wallets/Accounts/AddressAccounts.h
@@ -244,6 +244,8 @@ namespace Armory
 
          bool hasBip32Path(const Signing::BIP32_AssetPath&) const;
          bool isLegacy(void) const;
+         std::string getDisplayName(void) const;
+         std::string getDerivationSchemeDisplay(void) const;
       };
    } //namespace Accounts
 } //namespace Armory

--- a/cppForSwig/Wallets/Assets.cpp
+++ b/cppForSwig/Wallets/Assets.cpp
@@ -8,6 +8,7 @@
 
 #include "Utils/BtcUtils.h"
 #include "Utils/Cryptography.h"
+#include "Utils/BitcoinSettings.h"
 #include "Assets.h"
 #include "ScriptRecipient.h"
 #include "BIP32_Node.h"
@@ -673,6 +674,56 @@ const SecureBinaryData& AssetEntry_RawScript::getScript() const
    return script_;
 }
 
+using namespace Armory::Assets;
+using namespace Armory::Wallets;
+using namespace std::string_view_literals;
+
+////////////////////////////////////////////////////////////////////////////////
+std::string Armory::Assets::bip32PurposeDisplayName(
+   const std::vector<uint32_t>& rootPath)
+{
+   // Account roots may be stored at the external-chain level
+   // (purpose'/coin'/account'/0), so read purpose/coin/account from the
+   // first three path elements.
+   if (rootPath.size() < 3) {
+      return "BIP32";
+   }
+   const auto coinType = Armory::Config::BitcoinSettings::getCoinType();
+   if (rootPath[1] != coinType || !(rootPath[2] & 0x80000000)) {
+      return "BIP32";
+   }
+   switch (rootPath[0]) {
+      case 0x8000002C:
+         return "BIP44";
+      case 0x80000031:
+         return "BIP49";
+      case 0x80000054:
+         return "BIP84";
+      default:
+         return "BIP32";
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+std::string Armory::Assets::formatBip32DerivationPath(
+   const std::vector<uint32_t>& path)
+{
+   if (path.empty()) {
+      return {};
+   }
+   std::string result = "m";
+   for (const auto node : path) {
+      result += '/';
+      if (node >= 0x80000000) {
+         result += std::to_string(node & 0x7FFFFFFF);
+         result += '\'';
+      } else {
+         result += std::to_string(node);
+      }
+   }
+   return result;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // AssetEntry_BIP32Root
 AssetEntry_BIP32Root::AssetEntry_BIP32Root(const Wallets::AssetId& id,
@@ -725,6 +776,18 @@ const SecureBinaryData& AssetEntry_BIP32Root::getChaincode() const
 const std::vector<uint32_t>& AssetEntry_BIP32Root::getDerivationPath() const
 {
    return derivationPath_;
+}
+
+////////
+std::string AssetEntry_BIP32Root::getDisplayName() const
+{
+   return bip32PurposeDisplayName(derivationPath_);
+}
+
+////////
+std::string AssetEntry_BIP32Root::getDerivationSchemeDisplay() const
+{
+   return formatBip32DerivationPath(derivationPath_);
 }
 
 ////////
@@ -832,6 +895,19 @@ Armory::Seeds::LegacyType
 AssetEntry_ArmoryLegacyRoot::getSeedType() const
 {
    return seedType_;
+}
+
+////////
+std::string AssetEntry_ArmoryLegacyRoot::getDisplayName() const
+{
+   switch (seedType_) {
+      case Seeds::LegacyType::Armory135:
+         return "Armory Legacy (1.35)";
+      case Seeds::LegacyType::Armory200:
+         return "Armory Legacy (2.00)";
+      default:
+         return "Armory Legacy";
+   }
 }
 
 ////////

--- a/cppForSwig/Wallets/Assets.h
+++ b/cppForSwig/Wallets/Assets.h
@@ -208,6 +208,9 @@ namespace Armory
          virtual std::shared_ptr<AssetEntry_Single> getPublicCopy(void);
       };
 
+      std::string bip32PurposeDisplayName(const std::vector<uint32_t>& rootPath);
+      std::string formatBip32DerivationPath(const std::vector<uint32_t>& path);
+
       //////////////////////////////////////////////////////////////////////////
       class AssetEntry_ArmoryLegacyRoot : public AssetEntry_Single
       {
@@ -228,6 +231,7 @@ namespace Armory
 
          Seeds::LegacyType getSeedType(void) const;
          const SecureBinaryData& getChaincode(void) const;
+         std::string getDisplayName(void) const;
       };
 
       //////////////////////////////////////////////////////////////////////////
@@ -287,6 +291,8 @@ namespace Armory
          std::string getXPub(void) const;
          const SecureBinaryData& getChaincode(void) const;
          const std::vector<uint32_t>& getDerivationPath(void) const;
+         std::string getDisplayName(void) const;
+         std::string getDerivationSchemeDisplay(void) const;
 
          //sanity check
          void checkSeedFingerprint(bool) const;

--- a/cppForSwig/Wallets/KDF.cpp
+++ b/cppForSwig/Wallets/KDF.cpp
@@ -369,6 +369,12 @@ const KdfId& KeyDerivationFunction_Romix::getId() const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+std::string KeyDerivationFunction_Romix::getDisplayName() const
+{
+   return "ROMIX";
+}
+
+////////////////////////////////////////////////////////////////////////////////
 bool KeyDerivationFunction_Romix::isSame(
    const KeyDerivationFunction* kdf) const
 {
@@ -429,6 +435,11 @@ KeyDerivationFunction_Passthrough::~KeyDerivationFunction_Passthrough()
 const KdfId& KeyDerivationFunction_Passthrough::getId() const
 {
    return id_;
+}
+
+std::string KeyDerivationFunction_Passthrough::getDisplayName() const
+{
+   return "Passthrough";
 }
 
 SecureBinaryData KeyDerivationFunction_Passthrough::deriveKey(

--- a/cppForSwig/Wallets/KDF.h
+++ b/cppForSwig/Wallets/KDF.h
@@ -97,6 +97,7 @@ namespace Armory
             bool operator<(const KeyDerivationFunction&);
 
             virtual const KdfId& getId(void) const = 0;
+            virtual std::string getDisplayName(void) const = 0;
             virtual BinaryData serialize(void) const = 0;
             static std::shared_ptr<KeyDerivationFunction>
                deserialize(const BinaryDataRef&);
@@ -129,6 +130,7 @@ namespace Armory
             bool isSimilar(const KeyDerivationFunction*) const override;
             BinaryData serialize(void) const override;
             const KdfId& getId(void) const override;
+            std::string getDisplayName(void) const override;
 
             //locals
             unsigned memTarget(void) const;
@@ -151,6 +153,7 @@ namespace Armory
             bool isSimilar(const KeyDerivationFunction*) const override;
             BinaryData serialize(void) const override;
             const KdfId& getId(void) const override;
+            std::string getDisplayName(void) const override;
          };
       } //namespace Encryption
    } //namespace Wallets

--- a/cppForSwig/Wallets/Wallets.cpp
+++ b/cppForSwig/Wallets/Wallets.cpp
@@ -1661,6 +1661,40 @@ std::shared_ptr<Seeds::EncryptedSeed> AssetWallet_Single::getEncryptedSeed() con
    return seed_;
 }
 
+////////
+std::string AssetWallet_Single::getSeedTypeDisplayName() const
+{
+   auto root = getRoot();
+   if (auto legacyRoot = std::dynamic_pointer_cast<
+      AssetEntry_ArmoryLegacyRoot>(root)) {
+      return legacyRoot->getDisplayName();
+   }
+   if (std::dynamic_pointer_cast<AssetEntry_BIP32Root>(root)) {
+      std::set<std::string> purposeNames;
+      for (const auto& accId : getAccountIDs()) {
+         auto accPtr = getAccountForID(accId);
+         if (accPtr == nullptr || accPtr->isLegacy()) {
+            continue;
+         }
+         try {
+            auto outerAcc = accPtr->getOuterAccount();
+            auto accRoot = outerAcc->getRoot();
+            auto rootBip32 = std::dynamic_pointer_cast<
+               AssetEntry_BIP32Root>(accRoot);
+            if (rootBip32 != nullptr) {
+               purposeNames.insert(rootBip32->getDisplayName());
+            }
+         } catch (const std::exception&) {
+         }
+      }
+      if (purposeNames.size() == 1) {
+         return *purposeNames.begin();
+      }
+      return "BIP32";
+   }
+   return {};
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 const AssetId& AssetWallet_Single::derivePrivKeyFromPath(
    const Signing::BIP32_AssetPath& path)

--- a/cppForSwig/Wallets/Wallets.h
+++ b/cppForSwig/Wallets/Wallets.h
@@ -342,6 +342,7 @@ namespace Armory
             const AssetId&) const;
 
          bool isWatchingOnly(void) const;
+         std::string getSeedTypeDisplayName(void) const;
          std::shared_ptr<Seeds::EncryptedSeed> getEncryptedSeed(void) const;
 
          //bip32 primitives

--- a/cppForSwig/capnp/Bridge.capnp
+++ b/cppForSwig/capnp/Bridge.capnp
@@ -526,6 +526,7 @@ struct WalletReply {
       index          @5 : Int32;
       accountId      @6 : Text;
       isUsed         @7 : Bool;
+      chainRole      @8 : Text;
    }
 
    # reply

--- a/cppForSwig/capnp/Bridge.capnp
+++ b/cppForSwig/capnp/Bridge.capnp
@@ -74,6 +74,10 @@ struct WalletData {
 
    addressData          @12: List(AddressData);
    comments             @13: List(Comment);
+
+   accountName          @16: Text;
+   seedTypeName         @17: Text;
+   derivationScheme     @18: Text;
 }
 
 struct WalletImportPreview {
@@ -520,6 +524,8 @@ struct WalletReply {
       addressString  @3 : Text;
       addrType       @4 : UInt32;
       index          @5 : Int32;
+      accountId      @6 : Text;
+      isUsed         @7 : Bool;
    }
 
    # reply

--- a/cppForSwig/gtest/BridgeTests.cpp
+++ b/cppForSwig/gtest/BridgeTests.cpp
@@ -1171,7 +1171,26 @@ namespace {
       int32_t index = 0;
       std::string accountId;
       bool isUsed = false;
+      std::string chainRole;
    };
+
+   std::string chainRoleForAssetAccount(
+      const std::shared_ptr<Accounts::AddressAccount>& accPtr,
+      const Wallets::AssetAccountId& assetAccId)
+   {
+      const auto& outerId = accPtr->getOuterAccountID();
+      const auto& innerId = accPtr->getInnerAccountID();
+      if (outerId == innerId) {
+         return {};
+      }
+      if (assetAccId == outerId) {
+         return "Receive";
+      }
+      if (assetAccId == innerId) {
+         return "Change";
+      }
+      return {};
+   }
 
    struct ExportResult {
       bool success = false;
@@ -1198,6 +1217,7 @@ namespace {
       key.index = k.getIndex();
       key.accountId = std::string(k.getAccountId());
       key.isUsed = k.getIsUsed();
+      key.chainRole = std::string(k.getChainRole());
       return key;
    }
 
@@ -1270,6 +1290,7 @@ namespace {
                expected.assetId = assetID.getSerializedKey(
                   PROTO_ASSETID_PREFIX);
                expected.index = assetSingle->getIndex();
+               expected.chainRole = chainRoleForAssetAccount(accPtr, assetAccId);
                fillExpectedExportMetadata(expected, accPtr, assetID);
                expectedKeys.emplace(expected.assetId, std::move(expected));
             }
@@ -1331,6 +1352,7 @@ namespace {
       EXPECT_EQ(exported.addressString, expected.addressString);
       EXPECT_EQ(exported.addrType, expected.addrType);
       EXPECT_EQ(exported.pubKey, expected.pubKey);
+      EXPECT_EQ(exported.chainRole, expected.chainRole);
    }
 
    void verifyExportSetMatchesExpected(
@@ -6179,6 +6201,18 @@ TEST_F(BridgeWalletTests, ExportPublicKeysScopedToAccount)
       EXPECT_EQ(key.accountId, accId);
       EXPECT_TRUE(key.privKey.empty());
    }
+
+   bool hasReceive = false;
+   bool hasChange = false;
+   for (const auto& key : scopedResult.keys) {
+      if (key.chainRole == "Receive") {
+         hasReceive = true;
+      } else if (key.chainRole == "Change") {
+         hasChange = true;
+      }
+   }
+   EXPECT_TRUE(hasReceive);
+   EXPECT_TRUE(hasChange);
 
    size_t scopedTotal = 0;
    for (const auto& id : accIds) {

--- a/cppForSwig/gtest/BridgeTests.cpp
+++ b/cppForSwig/gtest/BridgeTests.cpp
@@ -1169,6 +1169,8 @@ namespace {
       std::string addressString;
       uint32_t addrType = 0;
       int32_t index = 0;
+      std::string accountId;
+      bool isUsed = false;
    };
 
    struct ExportResult {
@@ -1194,6 +1196,8 @@ namespace {
       key.addressString = std::string(k.getAddressString());
       key.addrType = k.getAddrType();
       key.index = k.getIndex();
+      key.accountId = std::string(k.getAccountId());
+      key.isUsed = k.getIsUsed();
       return key;
    }
 
@@ -1364,7 +1368,8 @@ namespace {
       const std::string& walletId,
       bool publicOnly,
       const std::string& passphrase = {},
-      bool provideCorrectPass = true)
+      bool provideCorrectPass = true,
+      const std::string& accountId = {})
    {
       ExportResult out;
       auto callbackId = Cryptography::PRNG::fortuna.generateRandom(10).toHexStr();
@@ -1376,6 +1381,9 @@ namespace {
          toBridge.setReferenceId(refId);
          auto request = toBridge.initWallet();
          request.setWalletId(walletId);
+         if (!accountId.empty()) {
+            request.setAccountId(accountId);
+         }
 
          auto exportReq = request.initExportKeys();
          if (publicOnly) {
@@ -1480,16 +1488,19 @@ namespace {
       std::shared_ptr<Bridge::CppBridge> bridge,
       const std::string& walletId,
       const std::string& passphrase,
-      bool provideCorrectPass = true)
+      bool provideCorrectPass = true,
+      const std::string& accountId = {})
    {
-      return exportKeys(bridge, walletId, false, passphrase, provideCorrectPass);
+      return exportKeys(bridge, walletId, false, passphrase,
+         provideCorrectPass, accountId);
    }
 
    ExportResult exportPublicKeys(
       std::shared_ptr<Bridge::CppBridge> bridge,
-      const std::string& walletId)
+      const std::string& walletId,
+      const std::string& accountId = {})
    {
-      return exportKeys(bridge, walletId, true);
+      return exportKeys(bridge, walletId, true, {}, true, accountId);
    }
 
    WalletData extendAddressPool(
@@ -6141,6 +6152,80 @@ TEST_F(BridgeWalletTests, ExportPublicKeysLegacy)
       EXPECT_FALSE(exported.addressString.empty());
    }
    EXPECT_TRUE(foundUncompressed);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+TEST_F(BridgeWalletTests, ExportPublicKeysScopedToAccount)
+{
+   const std::string wltId = createAWallet(bridge_, 1ms, 4, true);
+   ASSERT_FALSE(wltId.empty());
+
+   auto wallets = loadWallets(bridge_);
+   ASSERT_GE(wallets.size(), 1ULL);
+
+   auto accIds = getWalletAccountIds(bridge_, wltId);
+   ASSERT_GE(accIds.size(), 2u);
+
+   auto allResult = exportPublicKeys(bridge_, wltId);
+   ASSERT_TRUE(allResult.success) << allResult.error;
+   ASSERT_GT(allResult.keys.size(), 0u);
+
+   const std::string accId = *accIds.begin();
+   auto scopedResult = exportPublicKeys(bridge_, wltId, accId);
+   ASSERT_TRUE(scopedResult.success) << scopedResult.error;
+   ASSERT_LT(scopedResult.keys.size(), allResult.keys.size());
+
+   for (const auto& key : scopedResult.keys) {
+      EXPECT_EQ(key.accountId, accId);
+      EXPECT_TRUE(key.privKey.empty());
+   }
+
+   size_t scopedTotal = 0;
+   for (const auto& id : accIds) {
+      auto result = exportPublicKeys(bridge_, wltId, id);
+      ASSERT_TRUE(result.success) << result.error;
+      scopedTotal += result.keys.size();
+      for (const auto& key : result.keys) {
+         EXPECT_EQ(key.accountId, id);
+      }
+   }
+   EXPECT_EQ(scopedTotal, allResult.keys.size());
+}
+
+////////////////////////////////////////////////////////////////////////////////
+TEST_F(BridgeWalletTests, ExportPrivateKeysScopedToAccount)
+{
+   const std::string wltId = createAWallet(bridge_, 1ms, 4, true);
+   ASSERT_FALSE(wltId.empty());
+
+   auto accIds = getWalletAccountIds(bridge_, wltId);
+   ASSERT_GE(accIds.size(), 2u);
+
+   auto allResult = exportPrivateKeys(bridge_, wltId, "pass1");
+   ASSERT_TRUE(allResult.success) << allResult.error;
+   ASSERT_GT(allResult.keys.size(), 0u);
+
+   const std::string accId = *accIds.begin();
+   auto scopedResult = exportPrivateKeys(bridge_, wltId, "pass1", true, accId);
+   ASSERT_TRUE(scopedResult.success) << scopedResult.error;
+   ASSERT_LT(scopedResult.keys.size(), allResult.keys.size());
+
+   for (const auto& key : scopedResult.keys) {
+      EXPECT_EQ(key.accountId, accId);
+      EXPECT_FALSE(key.privKey.empty());
+   }
+
+   size_t scopedTotal = 0;
+   for (const auto& id : accIds) {
+      auto result = exportPrivateKeys(bridge_, wltId, "pass1", true, id);
+      ASSERT_TRUE(result.success) << result.error;
+      scopedTotal += result.keys.size();
+      for (const auto& key : result.keys) {
+         EXPECT_EQ(key.accountId, id);
+         EXPECT_FALSE(key.privKey.empty());
+      }
+   }
+   EXPECT_EQ(scopedTotal, allResult.keys.size());
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cppForSwig/gtest/WalletTests.cpp
+++ b/cppForSwig/gtest/WalletTests.cpp
@@ -7124,11 +7124,17 @@ TEST_F(WalletsTest, WalletDisplayNames)
       std::move(legacySeed), legacyParams);
    auto legacyAcc = legacyWlt->getAccountForID(legacyWlt->getMainAccountID());
    EXPECT_EQ(legacyAcc->getDisplayName(), "Armory Legacy");
-   EXPECT_TRUE(legacyAcc->getDerivationSchemeDisplay().empty());
+   EXPECT_EQ(legacyAcc->getDerivationSchemeDisplay(), "Armory Legacy");
    auto legacyRoot = std::dynamic_pointer_cast<Assets::AssetEntry_ArmoryLegacyRoot>(
       legacyWlt->getRoot());
    ASSERT_NE(legacyRoot, nullptr);
-   EXPECT_EQ(legacyRoot->getDisplayName(), legacyWlt->getSeedTypeDisplayName());
+   EXPECT_EQ(legacyRoot->getDisplayName(), "Armory Legacy (2.00)");
+   EXPECT_EQ(legacyWlt->getSeedTypeDisplayName(), "Armory Legacy (2.00)");
+
+   auto importAccId = legacyWlt->setupImportAccount();
+   auto importAcc = legacyWlt->getAccountForID(importAccId);
+   ASSERT_NE(importAcc, nullptr);
+   EXPECT_EQ(importAcc->getDerivationSchemeDisplay(), "N/A");
 
    SecureBinaryData bip32Seed = READHEX("000102030405060708090a0b0c0d0e0f");
    auto bip32Dir = homedir_ / "display_bip32";

--- a/cppForSwig/gtest/WalletTests.cpp
+++ b/cppForSwig/gtest/WalletTests.cpp
@@ -7098,6 +7098,74 @@ TEST_F(WalletsTest, BIP32Name_HardenedAccountIndex)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+TEST_F(WalletsTest, WalletDisplayNames)
+{
+   using namespace Armory::Accounts;
+   const auto coinType = Armory::Config::BitcoinSettings::getCoinType();
+
+   EXPECT_EQ(Assets::bip32PurposeDisplayName(
+      {0x8000002C, coinType, 0x80000001}), "BIP44");
+   EXPECT_EQ(Assets::formatBip32DerivationPath(
+      {0x8000002C, 0x80000000, 0x80000000, 0}),
+      "m/44'/0'/0'/0");
+
+   auto legacyDir = homedir_ / "display_legacy";
+   std::filesystem::create_directories(legacyDir);
+   IO::CreateWalletParams legacyParams{
+      legacyDir,
+      Passphrase::SetNew{1ms, 0, SecureBinaryData::fromString("test")},
+      Passphrase::SetNew{1ms, 0, controlPass_},
+      nullptr, 4
+   };
+
+   std::unique_ptr<Seeds::ClearTextSeed> legacySeed(
+      new Seeds::ClearTextSeed_Armory());
+   auto legacyWlt = AssetWallet_Single::createFromSeed(
+      std::move(legacySeed), legacyParams);
+   auto legacyAcc = legacyWlt->getAccountForID(legacyWlt->getMainAccountID());
+   EXPECT_EQ(legacyAcc->getDisplayName(), "Armory Legacy");
+   EXPECT_TRUE(legacyAcc->getDerivationSchemeDisplay().empty());
+   auto legacyRoot = std::dynamic_pointer_cast<Assets::AssetEntry_ArmoryLegacyRoot>(
+      legacyWlt->getRoot());
+   ASSERT_NE(legacyRoot, nullptr);
+   EXPECT_EQ(legacyRoot->getDisplayName(), legacyWlt->getSeedTypeDisplayName());
+
+   SecureBinaryData bip32Seed = READHEX("000102030405060708090a0b0c0d0e0f");
+   auto bip32Dir = homedir_ / "display_bip32";
+   std::filesystem::create_directories(bip32Dir);
+   IO::CreateWalletParams bip32Params{
+      bip32Dir,
+      Passphrase::SetNew{1ms, 0, SecureBinaryData::fromString("test")},
+      Passphrase::SetNew{1ms, 0, controlPass_},
+      nullptr, 4
+   };
+   std::unique_ptr<Seeds::ClearTextSeed> bip32SeedObj(
+      new Seeds::ClearTextSeed_BIP32(
+         bip32Seed, Seeds::SeedType::BIP32_Structured));
+   auto bip32Wlt = AssetWallet_Single::createFromSeed(
+      std::move(bip32SeedObj), bip32Params);
+
+   std::set<std::string> accountNames;
+   for (const auto& accId : bip32Wlt->getAccountIDs()) {
+      auto accPtr = bip32Wlt->getAccountForID(accId);
+      if (accPtr->isLegacy()) {
+         continue;
+      }
+      accountNames.insert(accPtr->getDisplayName());
+      EXPECT_FALSE(accPtr->getDerivationSchemeDisplay().empty());
+   }
+   EXPECT_EQ(accountNames, (std::set<std::string>{"BIP44", "BIP49", "BIP84"}));
+   EXPECT_EQ(bip32Wlt->getSeedTypeDisplayName(), "BIP32");
+
+   auto passthroughKdf =
+      std::make_shared<Encryption::KeyDerivationFunction_Passthrough>();
+   EXPECT_EQ(passthroughKdf->getDisplayName(), "Passthrough");
+   auto romixKdf = std::make_shared<Encryption::KeyDerivationFunction_Romix>(
+      1ms, 0);
+   EXPECT_EQ(romixKdf->getDisplayName(), "ROMIX");
+}
+
+////////////////////////////////////////////////////////////////////////////////
 TEST_F(WalletsTest, BIP32_Chain)
 {
    //BIP32 test 1 seed

--- a/cppForSwig/gtest/WalletTests.cpp
+++ b/cppForSwig/gtest/WalletTests.cpp
@@ -7061,6 +7061,43 @@ TEST_F(WalletsTest, MultiplePassphrase)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+TEST_F(WalletsTest, BIP32Name_HardenedAccountIndex)
+{
+   using namespace Armory::Accounts;
+   const auto coinType = Armory::Config::BitcoinSettings::getCoinType();
+
+   {
+      std::vector<unsigned> path = { 0x8000002C, coinType, 0x80000000 };
+      auto account = AccountType_BIP32::makeFromDerPaths(0x12345678, {path});
+      EXPECT_EQ(account->name(), "BIP44");
+   }
+
+   {
+      std::vector<unsigned> path = { 0x8000002C, coinType, 0x80000001 };
+      auto account = AccountType_BIP32::makeFromDerPaths(0x12345678, {path});
+      EXPECT_EQ(account->name(), "BIP44");
+   }
+
+   {
+      std::vector<unsigned> path = { 0x80000031, coinType, 0x80000001 };
+      auto account = AccountType_BIP32::makeFromDerPaths(0x12345678, {path});
+      EXPECT_EQ(account->name(), "BIP49");
+   }
+
+   {
+      std::vector<unsigned> path = { 0x80000054, coinType, 0x80000002 };
+      auto account = AccountType_BIP32::makeFromDerPaths(0x12345678, {path});
+      EXPECT_EQ(account->name(), "BIP84");
+   }
+
+   {
+      std::vector<unsigned> path = { 0x8000002C, coinType, 1 };
+      auto account = AccountType_BIP32::makeFromDerPaths(0x12345678, {path});
+      EXPECT_EQ(account->name(), "BIP32");
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
 TEST_F(WalletsTest, BIP32_Chain)
 {
    //BIP32 test 1 seed

--- a/qtdialogs/DlgShowKeyList.py
+++ b/qtdialogs/DlgShowKeyList.py
@@ -270,6 +270,7 @@ class DlgShowKeyList(ArmoryDialog):
             'addrType': item.addrType,
             'accountId': item.accountId,
             'isUsed': item.isUsed,
+            'chainRole': getattr(item, 'chainRole', '') or '',
          })
       return entries
 
@@ -403,14 +404,15 @@ class DlgShowKeyList(ArmoryDialog):
       addrTypes = self.wlt.getAddressTypes()
       if addrTypes:
          typeNames = [getNameForAddrType(t) for t in addrTypes]
-         L.append('Eligible types:' + ' ' + ', '.join(typeNames))
+         L.append('Eligible address type:' + ' ' + ', '.join(typeNames))
       defaultType = self.wlt.getDefaultAddressType()
       if defaultType:
-         L.append('Default type:  ' + getNameForAddrType(defaultType))
+         L.append('Default address types: ' + getNameForAddrType(defaultType))
       L.append('')
 
       hideUnused = self.chkHideUnused.isChecked()
       lastAccountId = None
+      lastChainRole = None
       self.havePriv = False
       for entry in self._entries:
          if hideUnused and not entry.get('isUsed', False):
@@ -424,6 +426,15 @@ class DlgShowKeyList(ArmoryDialog):
             L.append('--- Account: ' + self._accountLabel(entryAccountId) +
                ' ---')
             lastAccountId = entryAccountId
+            lastChainRole = None
+
+         chainRole = entry.get('chainRole', '')
+         if chainRole and chainRole != lastChainRole:
+            if lastChainRole is not None or \
+                  (self._omitAccountId and entryAccountId):
+               L.append('')
+            L.append('--- ' + chainRole + ' ---')
+            lastChainRole = chainRole
 
          privKey = entry['privKey']
          pubKey  = entry['pubKey']

--- a/qtdialogs/DlgShowKeyList.py
+++ b/qtdialogs/DlgShowKeyList.py
@@ -12,7 +12,7 @@
 
 from html import escape
 
-from qtpy import QtCore, QtWidgets
+from qtpy import QtCore, QtGui, QtWidgets
 
 from qtdialogs.ArmoryDialog import ArmoryDialog
 from qtdialogs.MsgBoxWithDNAA import MsgBoxWithDNAA
@@ -26,6 +26,43 @@ from armoryengine.ArmoryUtils import (
    unixTimeToFormatStr, LOGERROR,
 )
 from armoryengine.Settings import TheSettings
+
+
+################################################################################
+class _ExportScopeDialog(ArmoryDialog):
+   """Ask whether to export one account or all accounts in a wallet file."""
+   EXPORT_ALL = 2
+
+   def __init__(self, parent, title, msg, thisAccountStr, allAccountsStr):
+      super(_ExportScopeDialog, self).__init__(parent)
+
+      msgIcon = QtWidgets.QLabel()
+      msgIcon.setPixmap(QtGui.QPixmap('./img/MsgBox_question64.png'))
+      msgIcon.setAlignment(QtCore.Qt.AlignHCenter | QtCore.Qt.AlignTop)
+
+      lblMsg = QtWidgets.QLabel(msg)
+      lblMsg.setTextFormat(QtCore.Qt.RichText)
+      lblMsg.setWordWrap(True)
+      lblMsg.setAlignment(QtCore.Qt.AlignLeft | QtCore.Qt.AlignVCenter)
+      lblMsg.setOpenExternalLinks(True)
+      w, h = tightSizeNChar(lblMsg, 70)
+      lblMsg.setMinimumSize(w, int(3.2 * h))
+
+      buttonbox = QtWidgets.QDialogButtonBox()
+      btnThis = QtWidgets.QPushButton(thisAccountStr)
+      btnAll = QtWidgets.QPushButton(allAccountsStr)
+      btnThis.clicked.connect(self.accept)
+      btnAll.clicked.connect(lambda: self.done(self.EXPORT_ALL))
+      buttonbox.addButton(btnThis, QtWidgets.QDialogButtonBox.AcceptRole)
+      buttonbox.addButton(btnAll, QtWidgets.QDialogButtonBox.ActionRole)
+
+      layout = QtWidgets.QGridLayout()
+      layout.addWidget(msgIcon, 0, 0, 1, 1)
+      layout.addWidget(lblMsg, 0, 1, 1, 1)
+      layout.addWidget(buttonbox, 1, 0, 1, 2)
+      layout.setSpacing(20)
+      self.setLayout(layout)
+      self.setWindowTitle(title)
 
 
 ################################################################################
@@ -50,12 +87,20 @@ class DlgShowKeyList(ArmoryDialog):
       self._unlockHandler = None
       self._privKeysLoaded = False
       self._privateExportInProgress = False
+      self._omitAccountId = False
+      self._accountDisplayNames = self._buildAccountDisplayNames()
+      self._exportCancelled = False
 
       self.strDescrReg = (self.tr(
          'The textbox below shows all keys that are part of this wallet, '
          'which includes both permanent keys and imported keys.  If you '
          'simply want to backup your wallet and you have no imported keys '
          'then all data below is reproducible from a plain paper backup.'))
+      if self.watchingOnly:
+         self.strDescrReg += (
+            '<br><br><i>' +
+            self.tr('This is a watch-only wallet: it holds no private keys.') +
+            '</i>')
       self.strDescrWarn = (self.tr(
          '<br><br>'
          '<font color="red">Warning:</font> The text box below contains '
@@ -96,6 +141,10 @@ class DlgShowKeyList(ArmoryDialog):
       self.chkList['PubKey'    ].setChecked(True)
       self.chkList['ChainIndex'].setChecked(False)
 
+      if self.watchingOnly:
+         for name in ('PrivB58', 'PrivHexBE'):
+            self.chkList[name].setEnabled(False)
+
       namelist = ['AddrStr', 'AddrType', 'PubKeyHash', 'PrivB58',
                   'PrivHexBE', 'PubKey', 'ChainIndex']
 
@@ -107,6 +156,9 @@ class DlgShowKeyList(ArmoryDialog):
 
       self.chkOmitSpaces = QtWidgets.QCheckBox(self.tr('Omit spaces in key data'))
       self.chkOmitSpaces.toggled.connect(self.rewriteList)
+
+      self.chkHideUnused = QtWidgets.QCheckBox(self.tr('Hide unused addresses'))
+      self.chkHideUnused.toggled.connect(self.rewriteList)
 
       std = (self.main.usermode == USERMODE.Standard)
       adv = (self.main.usermode == USERMODE.Advanced)
@@ -132,6 +184,7 @@ class DlgShowKeyList(ArmoryDialog):
          btnGoBack,
          STRETCH,
          self.chkOmitSpaces,
+         self.chkHideUnused,
          STRETCH,
          self.lblCopied,
          btnCopyClip,
@@ -153,11 +206,56 @@ class DlgShowKeyList(ArmoryDialog):
       self.rewriteList()
       self.setWindowTitle(self.tr('All Wallet Keys'))
 
-      if self.watchingOnly:
-         self.txtBox.setText(self.tr(
-            'This is a watch-only wallet: it holds no private keys.'))
+      scope = self._promptExportScope()
+      if scope is None:
+         self._exportCancelled = True
+         QtCore.QTimer.singleShot(0, self.reject)
       else:
+         self._omitAccountId = scope
          self._startPublicExport()
+
+   #############################################################################
+   def _buildAccountDisplayNames(self):
+      names = {}
+      if self.main is None:
+         return names
+      for accId, siblingWlt in self.main.wallets.getAccountsForWallet(
+            self.wlt.walletId).items():
+         names[accId] = getattr(siblingWlt, 'accountName', '') or accId
+      return names
+
+   #############################################################################
+   def _accountLabel(self, accountId):
+      return self._accountDisplayNames.get(accountId, accountId)
+
+   #############################################################################
+   def _promptExportScope(self):
+      """
+      Return True to omit accountId (export all accounts), False for this
+      account only, or None if the user cancelled.
+      """
+      if self.main is None:
+         return False
+      siblingMap = self.main.wallets.getAccountsForWallet(self.wlt.walletId)
+      if len(siblingMap) <= 1:
+         return False
+
+      msg = self.tr(
+         'This wallet file contains <b>{0}</b> accounts.<br><br>'
+         'Export keys from this account only, or from all accounts in the '
+         'wallet file?').format(len(siblingMap))
+      dlg = _ExportScopeDialog(
+         self,
+         self.tr('Multiple Accounts'),
+         msg,
+         self.tr('Export this account only'),
+         self.tr('Export all accounts'))
+      result = dlg.exec_()
+      if result == QtWidgets.QDialog.Accepted:
+         return False
+      if result == _ExportScopeDialog.EXPORT_ALL:
+         return True
+      return None
 
    #############################################################################
    def _parseExportItems(self, items):
@@ -170,6 +268,8 @@ class DlgShowKeyList(ArmoryDialog):
             'address': item.addressString,
             'index':   item.index,
             'addrType': item.addrType,
+            'accountId': item.accountId,
+            'isUsed': item.isUsed,
          })
       return entries
 
@@ -184,7 +284,8 @@ class DlgShowKeyList(ArmoryDialog):
             LOGERROR('exportPublicKeys failed: %s', err)
             self.executeMethod(self._onPublicExportFailed, str(err))
 
-      self.wlt.exportPublicKeys(onKeysReceived)
+      self.wlt.exportPublicKeys(onKeysReceived,
+         omitAccountId=self._omitAccountId)
 
    #############################################################################
    def _startPrivateExport(self):
@@ -203,7 +304,8 @@ class DlgShowKeyList(ArmoryDialog):
             LOGERROR('exportPrivateKeys failed: %s', err)
             self.executeMethod(self._onPrivateExportFailed, str(err))
 
-      self.wlt.exportPrivateKeys(onKeysReceived, self._unlockHandler)
+      self.wlt.exportPrivateKeys(onKeysReceived, self._unlockHandler,
+         omitAccountId=self._omitAccountId)
 
    #############################################################################
    def _mergePrivateKeys(self, items):
@@ -287,6 +389,17 @@ class DlgShowKeyList(ArmoryDialog):
          RightNow(), self.main.getPreferredDateFormat()))
       L.append('Wallet ID:     ' + self.wlt.walletId)
       L.append('Wallet Name:   ' + self.wlt.labelName)
+      seedType = getattr(self.wlt, 'seedTypeName', '') or ''
+      if seedType:
+         L.append('Seed type:     ' + seedType)
+      derivation = getattr(self.wlt, 'derivationScheme', '') or ''
+      if derivation:
+         L.append('Derivation:    ' + derivation)
+      acctName = getattr(self.wlt, 'accountName', '') or ''
+      if acctName and not self._omitAccountId:
+         L.append('Account type:  ' + acctName)
+      elif self._omitAccountId:
+         L.append('Account type:  ' + self.tr('(all accounts)'))
       addrTypes = self.wlt.getAddressTypes()
       if addrTypes:
          typeNames = [getNameForAddrType(t) for t in addrTypes]
@@ -296,8 +409,22 @@ class DlgShowKeyList(ArmoryDialog):
          L.append('Default type:  ' + getNameForAddrType(defaultType))
       L.append('')
 
+      hideUnused = self.chkHideUnused.isChecked()
+      lastAccountId = None
       self.havePriv = False
       for entry in self._entries:
+         if hideUnused and not entry.get('isUsed', False):
+            continue
+
+         entryAccountId = entry.get('accountId', '')
+         if self._omitAccountId and entryAccountId and \
+               entryAccountId != lastAccountId:
+            if lastAccountId is not None:
+               L.append('')
+            L.append('--- Account: ' + self._accountLabel(entryAccountId) +
+               ' ---')
+            lastAccountId = entryAccountId
+
          privKey = entry['privKey']
          pubKey  = entry['pubKey']
          addrType = entry.get('addrType', 0)
@@ -324,10 +451,17 @@ class DlgShowKeyList(ArmoryDialog):
             L.append('   ChainIndex: ' + str(entry['index']))
 
       self.txtBox.setText('\n'.join(L))
+      desc = self.strDescrReg
+      if len(self._entries) >= 500:
+         desc = (
+            '<font color="red"><b>' +
+            self.tr('Warning: this export contains {0} addresses. '
+                    'Display may be slow.').format(len(self._entries)) +
+            '</b></font><br><br>' + desc)
       if self.havePriv:
-         self.lblDescr.setText(self.strDescrReg + self.strDescrWarn)
+         self.lblDescr.setText(desc + self.strDescrWarn)
       else:
-         self.lblDescr.setText(self.strDescrReg)
+         self.lblDescr.setText(desc)
 
    #############################################################################
    def saveToFile(self):
@@ -361,8 +495,11 @@ class DlgShowKeyList(ArmoryDialog):
 
    #############################################################################
    def cleanup(self):
-      # Drop the plaintext private keys held in the entry cache.
+      for entry in self._entries:
+         if entry.get('privKey'):
+            entry['privKey'] = b''
       self._entries = []
+      self.txtBox.clear()
       self._privateExportInProgress = False
 
    #############################################################################

--- a/qtdialogs/DlgUnlockWallet.py
+++ b/qtdialogs/DlgUnlockWallet.py
@@ -119,6 +119,7 @@ class DlgUnlockWallet(ArmoryDialog):
       self.changeScramble()
       self.redrawKeys()
       self.encryptionKeyIds = []
+      self._lastPassphrase = None
 
       self.edtPasswd.textChanged.connect(self.updateUnlockButton)
       self.updateUnlockButton()
@@ -283,6 +284,7 @@ class DlgUnlockWallet(ArmoryDialog):
    #############################################################################
    def acceptPassphrase(self):
       passphraseStr = str(self.edtPasswd.text())
+      self._lastPassphrase = passphraseStr
 
       self.reply(passphraseStr)
       passphraseStr = ''
@@ -295,6 +297,7 @@ class DlgUnlockWallet(ArmoryDialog):
    #############################################################################
    def rejectPassphrase(self):
       self.edtPasswd.setText('')
+      self._lastPassphrase = None
       self.reply("")
       self.reject()
 
@@ -306,17 +309,21 @@ class DlgUnlockWallet(ArmoryDialog):
    def setIds(self, ids):
       if not ids:
          self.reject()
+         return
 
-      if not self.encryptionKeyIds:
+      if self.encryptionKeyIds and self.encryptionKeyIds != ids:
+         # Same unlock operation, another encryption key to prompt for.
          self.encryptionKeyIds = ids
-
-      if self.encryptionKeyIds == ids:
-         #success
+         if self._lastPassphrase:
+            self.reply(self._lastPassphrase)
+            return
+         self.edtPasswd.setText('')
+         self.updateUnlockButton()
          self.exec_()
-      else:
-         #failure
-         self.recycle()
-         self.show()
+         return
+
+      self.encryptionKeyIds = ids
+      self.exec_()
 
    #############################################################################
    def updateUnlockButton(self):

--- a/qtdialogs/DlgUnlockWallet.py
+++ b/qtdialogs/DlgUnlockWallet.py
@@ -119,7 +119,6 @@ class DlgUnlockWallet(ArmoryDialog):
       self.changeScramble()
       self.redrawKeys()
       self.encryptionKeyIds = []
-      self._lastPassphrase = None
 
       self.edtPasswd.textChanged.connect(self.updateUnlockButton)
       self.updateUnlockButton()
@@ -284,7 +283,6 @@ class DlgUnlockWallet(ArmoryDialog):
    #############################################################################
    def acceptPassphrase(self):
       passphraseStr = str(self.edtPasswd.text())
-      self._lastPassphrase = passphraseStr
 
       self.reply(passphraseStr)
       passphraseStr = ''
@@ -297,7 +295,6 @@ class DlgUnlockWallet(ArmoryDialog):
    #############################################################################
    def rejectPassphrase(self):
       self.edtPasswd.setText('')
-      self._lastPassphrase = None
       self.reply("")
       self.reject()
 
@@ -309,21 +306,15 @@ class DlgUnlockWallet(ArmoryDialog):
    def setIds(self, ids):
       if not ids:
          self.reject()
-         return
 
-      if self.encryptionKeyIds and self.encryptionKeyIds != ids:
-         # Same unlock operation, another encryption key to prompt for.
+      if not self.encryptionKeyIds:
          self.encryptionKeyIds = ids
-         if self._lastPassphrase:
-            self.reply(self._lastPassphrase)
-            return
-         self.edtPasswd.setText('')
-         self.updateUnlockButton()
-         self.exec_()
-         return
 
-      self.encryptionKeyIds = ids
-      self.exec_()
+      if self.encryptionKeyIds == ids:
+         self.exec_()
+      else:
+         self.recycle()
+         self.show()
 
    #############################################################################
    def updateUnlockButton(self):

--- a/qtdialogs/DlgUnlockWallet.py
+++ b/qtdialogs/DlgUnlockWallet.py
@@ -311,8 +311,10 @@ class DlgUnlockWallet(ArmoryDialog):
          self.encryptionKeyIds = ids
 
       if self.encryptionKeyIds == ids:
+         #success — matching encryption key set; run the modal unlock dialog
          self.exec_()
       else:
+         #failure — unexpected encryption key set; clear passphrase and re-show
          self.recycle()
          self.show()
 

--- a/qtdialogs/DlgWalletDetails.py
+++ b/qtdialogs/DlgWalletDetails.py
@@ -705,9 +705,9 @@ class DlgWalletDetails(ArmoryDialog):
 
       labelNames[WLTFIELDS.AccountName] = QtWidgets.QLabel(self.tr('Account:'))
       labelNames[WLTFIELDS.AddressTypes] = QtWidgets.QLabel(
-         self.tr('Address Types:'))
+         self.tr('Eligible address type:'))
       labelNames[WLTFIELDS.DefaultAddrType] = QtWidgets.QLabel(
-         self.tr('Default Address Type:'))
+         self.tr('Default address types:'))
 
       # TODO:  Add wallet path/location to this!
 

--- a/qtdialogs/DlgWalletDetails.py
+++ b/qtdialogs/DlgWalletDetails.py
@@ -12,7 +12,8 @@
 
 from qtpy import QtCore, QtWidgets
 
-from armoryengine.ArmoryUtils import getVersionString, coin2str, isASCII
+from armoryengine.ArmoryUtils import getVersionString, coin2str, isASCII, \
+   getNameForAddrType
 from armoryengine.AddressUtils import addrStr_to_hash160
 from armoryengine.BDM import TheBDM, BDM_UNINITIALIZED, BDM_OFFLINE, \
    BDM_SCANNING
@@ -610,7 +611,7 @@ class DlgWalletDetails(ArmoryDialog):
          if mem >= 1024 * 1024:
             kdfmemstr = str(mem / (1024 * 1024)) + ' MB'
 
-      tooltips = [[]] * 10
+      tooltips = [[]] * 13
       tooltips[WLTFIELDS.Name] = createToolTipWidget(self.tr(
             'This is the name stored with the wallet file.  Click on the '
             '"Change Labels" button on the right side of this '
@@ -680,7 +681,18 @@ class DlgWalletDetails(ArmoryDialog):
             'different wallet versions.  Not all functionality may be '
             'available with all wallet versions.  Creating a new wallet will '
             'always create the latest version.'))
-      labelNames = [[]] * 10
+
+      tooltips[WLTFIELDS.AccountName] = createToolTipWidget(self.tr(
+            'The account within this wallet file (for example BIP44, BIP49, '
+            'BIP84, or Armory Legacy).'))
+
+      tooltips[WLTFIELDS.AddressTypes] = createToolTipWidget(self.tr(
+            'Address types that this account can generate.'))
+
+      tooltips[WLTFIELDS.DefaultAddrType] = createToolTipWidget(self.tr(
+            'The default address type used when creating new addresses.'))
+
+      labelNames = [[]] * 13
       labelNames[WLTFIELDS.Name] = QtWidgets.QLabel(self.tr('Wallet Name:'))
       labelNames[WLTFIELDS.Descr] = QtWidgets.QLabel(self.tr('Description:'))
 
@@ -691,15 +703,32 @@ class DlgWalletDetails(ArmoryDialog):
 
       labelNames[WLTFIELDS.BelongsTo] = QtWidgets.QLabel(self.tr('Belongs to:'))
 
+      labelNames[WLTFIELDS.AccountName] = QtWidgets.QLabel(self.tr('Account:'))
+      labelNames[WLTFIELDS.AddressTypes] = QtWidgets.QLabel(
+         self.tr('Address Types:'))
+      labelNames[WLTFIELDS.DefaultAddrType] = QtWidgets.QLabel(
+         self.tr('Default Address Type:'))
+
       # TODO:  Add wallet path/location to this!
 
       if dispCrypto:
          labelNames[WLTFIELDS.Time] = QtWidgets.QLabel(self.tr('Unlock Time:'))
          labelNames[WLTFIELDS.Mem] = QtWidgets.QLabel(self.tr('Unlock Memory:'))
 
-      self.labelValues = [[]] * 10
+      self.labelValues = [[]] * 13
       self.labelValues[WLTFIELDS.Name] = QtWidgets.QLabel(self.wlt.labelName)
       self.labelValues[WLTFIELDS.Descr] = QtWidgets.QLabel(self.wlt.labelDescr)
+
+      acctDisp = getattr(self.wlt, 'accountName', '') or \
+         getattr(self.wlt, 'accountId', '') or ''
+      addrTypesDisp = ', '.join(
+         getNameForAddrType(t) for t in self.wlt.getAddressTypes())
+      defaultAddrDisp = getNameForAddrType(self.wlt.getDefaultAddressType())
+
+      self.labelValues[WLTFIELDS.AccountName] = QtWidgets.QLabel(acctDisp)
+      self.labelValues[WLTFIELDS.AddressTypes] = QtWidgets.QLabel(addrTypesDisp)
+      self.labelValues[WLTFIELDS.DefaultAddrType] = QtWidgets.QLabel(
+         defaultAddrDisp)
 
       self.labelValues[WLTFIELDS.WltID] = QtWidgets.QLabel(self.wlt.walletId)
       self.labelValues[WLTFIELDS.Secure] = QtWidgets.QLabel(self.typestr)
@@ -786,6 +815,18 @@ class DlgWalletDetails(ArmoryDialog):
       layout.addWidget(tooltips[WLTFIELDS.Descr], 2, 0)
       layout.addWidget(labelNames[WLTFIELDS.Descr], 2, 1)
       layout.addWidget(self.labelValues[WLTFIELDS.Descr], 2, 2, 4, 1)
+
+      layout.addWidget(tooltips[WLTFIELDS.AccountName], 6, 0)
+      layout.addWidget(labelNames[WLTFIELDS.AccountName], 6, 1)
+      layout.addWidget(self.labelValues[WLTFIELDS.AccountName], 6, 2)
+
+      layout.addWidget(tooltips[WLTFIELDS.AddressTypes], 7, 0)
+      layout.addWidget(labelNames[WLTFIELDS.AddressTypes], 7, 1)
+      layout.addWidget(self.labelValues[WLTFIELDS.AddressTypes], 7, 2)
+
+      layout.addWidget(tooltips[WLTFIELDS.DefaultAddrType], 8, 0)
+      layout.addWidget(labelNames[WLTFIELDS.DefaultAddrType], 8, 1)
+      layout.addWidget(self.labelValues[WLTFIELDS.DefaultAddrType], 8, 2)
 
       layout.addWidget(tooltips[WLTFIELDS.Version], 0, 3)
       layout.addWidget(labelNames[WLTFIELDS.Version], 0, 4)

--- a/qtdialogs/qtdefines.py
+++ b/qtdialogs/qtdefines.py
@@ -24,7 +24,8 @@ from armorycolors import htmlColor
 USERMODE        = enum('Standard', 'Advanced', 'Expert')
 NETWORKMODE     = enum('Offline', 'Full', 'Disconnected')
 WLTFIELDS       = enum('Name', 'Descr', 'WltID', 'NumAddr', 'Secure',
-   'BelongsTo', 'Crypto', 'Time', 'Mem', 'Version')
+   'BelongsTo', 'Crypto', 'Time', 'Mem', 'Version',
+   'AccountName', 'AddressTypes', 'DefaultAddrType')
 MSGBOX          = enum('Good','Info', 'Question', 'Warning',
    'Critical', 'Error')
 DASHBTNS        = enum('Close', 'Browse', 'Settings')

--- a/qtdialogs/setupmanager/WalletTab.py
+++ b/qtdialogs/setupmanager/WalletTab.py
@@ -168,13 +168,13 @@ class WalletTab(QtWidgets.QWidget):
          item.setData(qtdefines.WLTLISTCOLS.Checkbox, QtCore.Qt.UserRole,
             walletEntry)
          if walletEntry.isLegacy:
-            def migrateWlt(_):
-               self.migrateWallet(walletEntry)
+            def migrateWlt(_, entry=walletEntry):
+               self.migrateWallet(entry)
             self._addActionButton(
                item, self.tr('Migrate'), migrateWlt)
          elif walletEntry.isEncrypted:
-            def unlockWlt(_):
-               self.unlockWallet(walletEntry)
+            def unlockWlt(_, entry=walletEntry):
+               self.unlockWallet(entry)
             self._addActionButton(
                item, self.tr('Unlock'), unlockWlt)
 


### PR DESCRIPTION
Improve multi-account wallet representation in the GUI and scope bridge key export to a single account or to all accounts in a wallet file.

Bridge export handlers now honor `accountId` on wallet requests: a valid id restricts `collectExportedKeys` to that account; an empty id exports every account in the file. Each exported row carries `accountId` and `isUsed`. `WalletData` adds `accountName`, `seedTypeName`, and `derivationScheme` so the lobby, wallet properties, and key-list header can show account and address-type metadata without extra round-trips.

The lobby gains an Account column (appended after Balance). Wallet properties show account name and eligible/default address types. The key list dialog prompts when a wallet file has multiple accounts, supports export-all with human-readable section headers, warns on large exports, and offers hide-unused. Watch-only wallets use the public export path. Review follow-ups: BIP32 account naming accepts any hardened account index (not only 0′), in both `AccountType_BIP32::name()` and the bridge helper; scoped private-key export is tested on a multi-account BIP32 wallet; closing the scope prompt cancels instead of defaulting to export-all. Manual testing also turned up setup-manager unlock wiring, control-header file lookup, multi-key unlock prompts, and BIP44/49/84 lobby naming fixes, included in this commit.

Closes #772
Closes #773
Closes #774

Tested with:
`cd cppForSwig/gtest && ../../build/cppForSwig/gtest/WalletTests --gtest_filter='WalletsTest.BIP32Name_HardenedAccountIndex'` — passed
`cd cppForSwig/gtest && ../../build/cppForSwig/gtest/BridgeTests --gtest_filter='BridgeWalletTests.Export*'` — passed (5/5)
`python3 -m py_compile` on changed Python modules — passed
Manual GUI test: seeded offline datadir with structured BIP32 (3 accounts) and legacy wallets, unlocked and staged both in Setup Manager, accepted into main UI — passed
Manual GUI test: lobby showed four rows (BIP44, BIP49, BIP84, Armory Legacy); wallet properties account and address-type fields matched each row — passed
Manual GUI test: key list export in Expert mode — multi-account scope prompt, per-account and export-all headers, cancel on close, private-key columns after unlock with testpass; legacy wallet exported without scope prompt — passed