### PR TITLE
Fix use-after-move in WebSocketClient::writeService()

### DIFF
--- a/cppForSwig/Network/WebSocketClient.cpp
+++ b/cppForSwig/Network/WebSocketClient.cpp
@@ -149,9 +149,11 @@ void WebSocketClient::writeService()
       }
 
       SerializedMessage ws_msg;
+      //read id before message is moved-from below
+      auto msgId = message->id_;
       ws_msg.construct(std::move(message),
          bip151Connection_.get(),
-         message->id_);
+         msgId);
       writeQueue_->push_back(ws_msg);
    }
 }


### PR DESCRIPTION
Fixes #776.

Tested on RC1 (aarch64, Ubuntu 26.04, gcc 15.2); haven't recompiled this exact
change on 0.97_rc2, but it's the same call site. Happy to build on rc2 if useful.