### PR TITLE
Pass a file mode to open() when creating the ArmoryDB key file

### DIFF
--- a/cppForSwig/BridgeAPI/BlockchainDbClient.cpp
+++ b/cppForSwig/BridgeAPI/BlockchainDbClient.cpp
@@ -353,7 +353,7 @@ Bridge::spawnDb(const std::filesystem::path& satoshiPath,
       }};
 
    //open file and lock it
-   auto fd = open(keyFilePath.c_str(), O_CREAT | O_EXCL | O_RSYNC | O_RDWR);
+   auto fd = open(keyFilePath.c_str(), O_CREAT | O_EXCL | O_RSYNC | O_RDWR, 0600);
    if (fd == -1) {
       throw std::runtime_error("failed to create autodb key file");
    }


### PR DESCRIPTION
`Bridge::spawnDb()` creates the ArmoryDB authentication key file with:

```cpp
auto fd = open(keyFilePath.c_str(), O_CREAT | O_EXCL | O_RSYNC | O_RDWR);
```

`O_CREAT` requires a third argument. Without it the resulting permission bits
come from an indeterminate stack value, on a file that holds the key used to
authenticate the client to ArmoryDB. `0600` is the intended mode.

This also breaks the build outright on any toolchain with `_FORTIFY_SOURCE`
enabled. glibc's `fcntl2.h` rewrites the two argument form into
`__open_missing_mode()`, declared `__attribute__((error(...)))`:

```
fcntl2.h:52:31: error: call to '__open_missing_mode' declared with attribute
error: open with O_CREAT or O_TMPFILE in second argument needs 3 arguments
```

NixOS passes `-D_FORTIFY_SOURCE=3` by default, so `CppBridge` cannot be built
there until this is fixed.
---

Targeting `0.97_rc2` rather than `dev`: that is where every PR since #767 has landed, including yours. The README still points at `dev`, which is 26 commits behind.
