### PR TITLE
Migrate unencrypted 1.35 wallets with their private keys

### DIFF
--- a/cppForSwig/BridgeAPI/Wallets/Loader.cpp
+++ b/cppForSwig/BridgeAPI/Wallets/Loader.cpp
@@ -514,6 +514,21 @@ std::shared_ptr<Wallets::AssetWallet_Single> Armory135Header::migrate(
          };
          decryptedRoot = std::move(decryptPrivKey(passLbd, rootAddrObj));
       }
+      else if (rootAddrObj.hasPrivKey() && !rootAddrObj.isEncrypted()) {
+         /*
+         Unencrypted legacy wallet: the root private key sits in the file in
+         the clear. Verify it against the stored public key before trusting it,
+         same check the decryption path performs.
+         */
+         const auto& clearRoot = rootAddrObj.privKey();
+         auto computedPubKey = Cryptography::ECDSA::computePublicKey(
+            clearRoot, false);
+         if (rootAddrObj.pubKey() != computedPubKey) {
+            throw std::runtime_error(
+               "clear text root private key does not match stored public key");
+         }
+         decryptedRoot = clearRoot;
+      }
    }
 
    //create wallet


### PR DESCRIPTION
Migrating an unencrypted Armory 1.35 wallet produces a watching-only wallet.
No error, no warning - the user is told the migration succeeded and ends up
with a wallet that cannot spend.

`Armory135Header::migrate()` guards private key recovery on the wallet being
encrypted:

```cpp
if (isEncrypted_ &&
    rootAddrObj.hasPrivKey() &&
    rootAddrObj.isEncrypted()) {
   ... prompt for passphrase, decrypt ...
   decryptedRoot = std::move(decryptPrivKey(passLbd, rootAddrObj));
}
// no else

std::unique_ptr<Seeds::ClearTextSeed> seed;
if (decryptedRoot.empty()) {
   seed = std::make_unique<Seeds::ClearTextSeed_ArmoryPublic>(...);
```

There is no branch for `hasPrivKey() && !isEncrypted()`. For a wallet with no
passphrase the whole block is skipped, `decryptedRoot` stays empty, and
`createFromPublicSeed()` writes `armory_<id>_WatchingOnly.lmdb` - even though
the root private key is sitting in the file in the clear.

Unencrypted 1.35 wallets are not exotic: Armory allowed creating wallets
without encryption, and users who removed the passphrase from a backup copy
land here too. This is exactly the population 0.97's migration path exists to
serve.

**Reproducing**: migrate any 1.35 wallet whose header flags have bit 0 clear.
The migrated file is named `_WatchingOnly.lmdb` instead of `_wallet.lmdb`.

**The fix** adds the missing branch and verifies the clear text key against the
stored public key before using it, so a corrupt file throws instead of silently
migrating to a wallet that controls nothing.

**Testing**: verified against a real 1.35 wallet created in 2014 with no
passphrase. Before the patch the migration produced
`armory_<id>_WatchingOnly.lmdb`; after it, `armory_<id>_wallet.lmdb`, and the
wallet loads with its original wallet ID and reports encryption enabled.

I did not add a regression test: `WalletManagerTests.Migrate_Legacy` uses
`input_files/legacy.wallet`, which is encrypted, and there is no unencrypted
fixture in the tree nor tooling to generate one. Happy to add
`Migrate_Legacy_Unencrypted` if you can point me at how `legacy.wallet` was
produced.
---

Targeting `0.97_rc2` rather than `dev`: that is where every PR since #767 has landed, including yours. The README still points at `dev`, which is 26 commits behind.
