### PR TITLE
Fix python 2 leftover import in parseBitcoinURI

### DIFF
--- a/armoryengine/ArmoryUtils.py
+++ b/armoryengine/ArmoryUtils.py
@@ -2283,7 +2283,7 @@ def parseBitcoinURI(uriStr):
    data = {}
 
    # Split URI into parts. Let Python do the heavy lifting.
-   from urlparse import urlparse, parse_qs
+   from urllib.parse import urlparse, parse_qs
    uri = urlparse(uriStr)
    query = parse_qs(uri.query)
 


### PR DESCRIPTION
`parseBitcoinURI()` still imports from the python 2 module name:

```python
from urlparse import urlparse, parse_qs
```

On python 3 this is `urllib.parse`, so every call raises
`ModuleNotFoundError`. The import is function local, which is why it survived
the port - nothing touches it until a `bitcoin:` URI is handled.

Verified after the change:

```
parseBitcoinURI('bitcoin:1BitcoinEaterAddressDontSendf59kuE?amount=0.5&label=x')
-> {'address': '1BitcoinEaterAddressDontSendf59kuE', 'amount': 50000000, 'label': 'x'}
```
---

Targeting `0.97_rc2` rather than `dev`: that is where every PR since #767 has landed, including yours. The README still points at `dev`, which is 26 commits behind.
