### PR TITLE
Hash each address preimage once and reuse the address-hash map

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -33,6 +33,7 @@ Unreleased (0.97_rc2)
    - Take std::filesystem::path in WalletManager::unlockControlHeader.
    - Show Armory Legacy and N/A derivation-scheme display names for legacy and import accounts.
    - Pass exported private keys as BinaryDataRef instead of naked SecureBinaryData pointers.
+   - Hash each address preimage once and reuse the account address-hash map in getUsedAddressMap.
    - Fix setup manager unlock and migrate button handlers to capture each wallet row.
    - Label receive and change key chains separately in the key list export.
    - Rename wallet properties and key list address-type labels to eligible address type and default address types.

--- a/cppForSwig/Wallets/Accounts/AddressAccounts.cpp
+++ b/cppForSwig/Wallets/Accounts/AddressAccounts.cpp
@@ -1172,8 +1172,12 @@ std::map<AssetId, std::shared_ptr<AddressEntry>>
 AddressAccount::getUsedAddressMap() const
 {
    /***
-   Expensive call, as addresses are built on the fly
+   Expensive call, as addresses are built on the fly.
+   Warm the address-hash map first so Hash160 work is shared with
+   getAddressHashMap / BDV registration.
    ***/
+
+   const_cast<AddressAccount*>(this)->updateAddressHashMap();
 
    std::map<AssetId, std::shared_ptr<AddressEntry>> result;
    for (auto& account : accountDataMap_) {
@@ -1183,16 +1187,25 @@ AddressAccount::getUsedAddressMap() const
       if (usedIndex == -1) {
          continue;
       }
+
+      const auto& hashMap = aa.getAddressHashMap();
       for (AssetKeyType i = 0; i <= usedIndex; i++) {
          auto assetPtr = aa.getAssetForKey(i);
          auto& assetID = assetPtr->getID();
 
-         std::shared_ptr<AddressEntry> addrPtr;
-         auto iter = instantiatedAddressTypes_.find(assetID);
-         if (iter == instantiatedAddressTypes_.end()) {
-            addrPtr = AddressEntry::instantiate(assetPtr, defaultAddressEntryType_);
-         } else {
-            addrPtr = AddressEntry::instantiate(assetPtr, iter->second);
+         AddressEntryType aeType = defaultAddressEntryType_;
+         auto typeIter = instantiatedAddressTypes_.find(assetID);
+         if (typeIter != instantiatedAddressTypes_.end()) {
+            aeType = typeIter->second;
+         }
+
+         auto addrPtr = AddressEntry::instantiate(assetPtr, aeType);
+         auto hashMapIter = hashMap.find(assetID);
+         if (hashMapIter != hashMap.end()) {
+            auto typeHashIter = hashMapIter->second.find(aeType);
+            if (typeHashIter != hashMapIter->second.end()) {
+               addrPtr->setCachedPrefixedHash(typeHashIter->second);
+            }
          }
          result.emplace(assetID, addrPtr);
       }

--- a/cppForSwig/Wallets/Addresses.cpp
+++ b/cppForSwig/Wallets/Addresses.cpp
@@ -36,6 +36,15 @@ AddressEntryType AddressEntry::getType() const
    return type_;
 }
 
+void AddressEntry::setCachedPrefixedHash(BinaryData prefixed)
+{
+   if (prefixed.getSize() < 2) {
+      throw AddressException("invalid prefixed hash");
+   }
+   prefixedHash_ = std::move(prefixed);
+   hash_ = prefixedHash_.getSliceCopy(1, prefixedHash_.getSize() - 1);
+}
+
 size_t AddressEntry::getWitnessDataSize() const
 {
    throw std::runtime_error("no witness data");
@@ -130,14 +139,7 @@ const BinaryData& AddressEntry_P2PKH::getHash() const
       }
 
       default:
-         const auto& preimage = getPreimage();
-         auto hash1 = BtcUtils::getHash160(preimage);
-         auto hash2 = BtcUtils::getHash160(preimage);
-
-         if (hash1 != hash2) {
-            throw AddressException("failed to hash preimage");
-         }
-         hash_ = hash1;
+         hash_ = BtcUtils::getHash160(getPreimage());
       }
    }
    return hash_;
@@ -300,13 +302,7 @@ const BinaryData& AddressEntry_P2WPKH::getPreimage() const
 const BinaryData& AddressEntry_P2WPKH::getHash() const
 {
    if (hash_.empty()) {
-      const auto& preimage = getPreimage();
-      auto hash1 = BtcUtils::getHash160(preimage);
-      auto hash2 = BtcUtils::getHash160(preimage);
-      if (hash1 != hash2) {
-         throw AddressException("failed to hash preimage");
-      }
-      hash_ = hash1;
+      hash_ = BtcUtils::getHash160(getPreimage());
    }
    return hash_;
 }
@@ -625,14 +621,7 @@ const BinaryData& AddressEntry_P2SH::getHash() const
          }
 
          default:
-            const auto& preimage = getPreimage();
-            auto hash1 = BtcUtils::getHash160(preimage);
-            auto hash2 = BtcUtils::getHash160(preimage);
-
-            if (hash1 != hash2) {
-               throw AddressException("failed to hash preimage");
-            }
-            hash_ = hash1;
+            hash_ = BtcUtils::getHash160(getPreimage());
       }
    }
    return hash_;
@@ -719,14 +708,7 @@ const BinaryData& AddressEntry_P2WSH::getPreimage() const
 const BinaryData& AddressEntry_P2WSH::getHash() const
 {
    if (hash_.empty()) {
-      const auto& preimage = getPreimage();
-      auto hash1 = BtcUtils::getSha256(preimage);
-      auto hash2 = BtcUtils::getSha256(preimage);
-
-      if (hash1 != hash2) {
-         throw AddressException("failed to compute hash");
-      }
-      hash_ = hash1;
+      hash_ = BtcUtils::getSha256(getPreimage());
    }
    return hash_;
 }

--- a/cppForSwig/Wallets/Addresses.h
+++ b/cppForSwig/Wallets/Addresses.h
@@ -56,6 +56,7 @@ public:
 
    //local
    virtual AddressEntryType getType(void) const;
+   void setCachedPrefixedHash(BinaryData);
 
    //virtual
    virtual const Armory::Wallets::AssetId& getID(void) const = 0;

--- a/cppForSwig/gtest/WalletTests.cpp
+++ b/cppForSwig/gtest/WalletTests.cpp
@@ -7172,6 +7172,37 @@ TEST_F(WalletsTest, WalletDisplayNames)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+TEST_F(WalletsTest, UsedAddressMapReusesHashMap)
+{
+   auto wltDir = homedir_ / "used_addr_hash_reuse";
+   std::filesystem::create_directories(wltDir);
+   IO::CreateWalletParams params{
+      wltDir,
+      Passphrase::SetNew{1ms, 0, SecureBinaryData::fromString("test")},
+      Passphrase::SetNew{1ms, 0, controlPass_},
+      nullptr, 8
+   };
+
+   std::unique_ptr<Seeds::ClearTextSeed> seed(new Seeds::ClearTextSeed_Armory());
+   auto wlt = AssetWallet_Single::createFromSeed(std::move(seed), params);
+   for (unsigned i = 0; i < 4; i++) {
+      wlt->getNewAddress();
+   }
+
+   auto acc = wlt->getAccountForID(wlt->getMainAccountID());
+   const auto& addrHashMap = acc->getAddressHashMap();
+   auto usedMap = acc->getUsedAddressMap();
+   ASSERT_FALSE(usedMap.empty());
+
+   for (const auto& pair : usedMap) {
+      const auto& prefixed = pair.second->getPrefixedHash();
+      auto it = addrHashMap.find(prefixed);
+      ASSERT_NE(it, addrHashMap.end());
+      EXPECT_EQ(it->second.first, pair.first);
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
 TEST_F(WalletsTest, BIP32_Chain)
 {
    //BIP32 test 1 seed


### PR DESCRIPTION
Hash160 for used addresses was computed during walletToCapnp and again when building the BDV address map. AddressEntry::getHash also hashed each preimage twice.

Reuse the account address-hash map when building the used-address map, and hash each preimage once.

Tested with:
`./gtest/WalletTests --gtest_filter=WalletsTest.UsedAddressMapReusesHashMap:WalletsTest.WalletDisplayNames` — passed