### PR TITLE
Add missing mode argument to open() with O_CREAT in spawnDb

### DIFF
--- a/cppForSwig/BridgeAPI/BlockchainDbClient.cpp
+++ b/cppForSwig/BridgeAPI/BlockchainDbClient.cpp
@@ -353,7 +353,7 @@ Bridge::spawnDb(const std::filesystem::path& satoshiPath,
       }};
 
    //open file and lock it
-   auto fd = open(keyFilePath.c_str(), O_CREAT | O_EXCL | O_RSYNC | O_RDWR);
+   auto fd = open(keyFilePath.c_str(), O_CREAT | O_EXCL | O_RSYNC | O_RDWR, 0600);
    if (fd == -1) {
       throw std::runtime_error("failed to create autodb key file");
    }


### PR DESCRIPTION
`open()` with `O_CREAT` requires a mode argument; glibc's fortified headers turn the missing arg into a hard compile error (`__open_missing_mode`) at `-O2` on current Ubuntu 26.04. Reported on the forum in June — this is the proposed fix. `0600` since it's the autodb key file.