### PR TITLE
Rotate xor key by file offset in FileCopy::xorMe

### DIFF
--- a/cppForSwig/Utils/FileUtils.cpp
+++ b/cppForSwig/Utils/FileUtils.cpp
@@ -274,8 +274,8 @@ void FileCopy::xorMe(uint64_t xorKey)
       throw std::length_error("xored block data is misaligned");
    }
 
-   //Core's key repeats from the start of the file, so rotate it to
-   //match this copy's starting offset
+   //the xor key is aligned to the start of the file, not the start of
+   //this copy, so rotate it to match offset_
    unsigned shift = (offset_ % 8) * 8;
    if (shift != 0) {
       xorKey = (xorKey >> shift) | (xorKey << (64 - shift));

--- a/cppForSwig/Utils/FileUtils.cpp
+++ b/cppForSwig/Utils/FileUtils.cpp
@@ -274,6 +274,13 @@ void FileCopy::xorMe(uint64_t xorKey)
       throw std::length_error("xored block data is misaligned");
    }
 
+   //Core's key repeats from the start of the file, so rotate it to
+   //match this copy's starting offset
+   unsigned shift = (offset_ % 8) * 8;
+   if (shift != 0) {
+      xorKey = (xorKey >> shift) | (xorKey << (64 - shift));
+   }
+
    auto data64 = (uint64_t*)&data_[0];
    for (unsigned i = 0; i < data_.capacity() / 8; i++) {
       data64[i] ^= xorKey;


### PR DESCRIPTION
Follow-up to the blockxor fix in bb32464. `FileCopy::xorMe()` applies the key from the buffer start, but Core's key repeats from the file start, so any copy beginning at an offset not divisible by 8 decodes to garbage. Full rebuilds work (every file starts at offset 0); incremental parsing after sync silently finds 0 new headers until the next rebuild.

I think this is what my 23 June log on the forum thread was showing (offset 74658309, hours of "found 0 new headers", "Found next block after skipping 15838884 bytes") 

Rotate the key by `offset % 8` bytes. Tested on 0.97_rc2, Ubuntu 26.04 aarch64: same DB went from stuck 10 blocks behind to "found 10 new headers" on restart, and has since picked up live blocks from three different misaligned offsets. Same code is present on core_tab.