### PR TITLE
"generic signer error" when creating an unsigned tx with P2SH-P2WPKH inputs

### DIFF
--- a/armoryengine/CppBridge.py
+++ b/armoryengine/CppBridge.py
@@ -1596,7 +1596,7 @@ class BridgeSigner(ProtoWrapper):
       packet.signer.canLegacySerialize = None
 
       fut = self.send(packet)
-      reply = fut.getVal()
+      reply = fut.getVal(nothrow=True)
       return reply.success
 
 ################################################################################


### PR DESCRIPTION
Ticking "Create Unsigned" on a tx with P2SH-P2WPKH inputs throws instead of opening the dialog:

    File "ui/TxFramesOffline.py", line 668, in update
      if self.ustx.signer.canLegacySerialize() and self.selectable:
    ...
    Exception: generic signer error message

canLegacySerialize() returns reply.success, but getVal() throws when success is false, so a "no" never makes it back. Passing nothrow=True fixes it - the dialog opens with Legacy greyed out 

Ubuntu 26.04, 0.97_rc2.