### PR TITLE
Fix Coin Control dialog failing to confirm on current PyQt

### DIFF
--- a/ui/CoinControlUI.py
+++ b/ui/CoinControlUI.py
@@ -113,7 +113,7 @@ class CoinControlDlg(ArmoryDialog):
    #############################################################################
    def accept(self, *args):
       self.saveGeometrySettings()
-      super(CoinControlDlg, self).accept(*args)
+      super(CoinControlDlg, self).accept()
 
    #############################################################################
    def resetTreeData(self):


### PR DESCRIPTION
Clicking Accept in Coin Control does nothing except this in the terminal:

    File "ui/CoinControlUI.py", line 116, in accept
      super(CoinControlDlg, self).accept(*args)
    TypeError: accept(self): too many arguments

The button's clicked() signal passes a checked bool through to QDialog.accept(), which current PyQt rejects. Dropping the argument fixes it - Coin Control confirms and the selection carries into the send.

Ubuntu 26.04 (PyQt via qtpy), 0.97_rc2.