### PR TITLE
"Unknown scenario" traceback when connecting to ArmoryDB by IP

### DIFF
--- a/qtdialogs/setupmanager/DlgSetupManager.py
+++ b/qtdialogs/setupmanager/DlgSetupManager.py
@@ -502,9 +502,11 @@ class DlgSetupManager(ArmoryDialog):
       elif scenario == SCENARIO_REMOTE_PEER:
          success, error = self._connectToPeer(params)
          self._handleConnectionAttemptFinality(success, error)
+         return (success, error)
       elif scenario == SCENARIO_REMOTE_IP:
          success, error = self._connectToIp(params)
          self._handleConnectionAttemptFinality(success, error)
+         return (success, error)
 
       raise ValueError(f"Unknown scenario: {scenario}")
 


### PR DESCRIPTION
Setup Manager > Database Settings > Connect to remote > Connect to IP, then Connect. It connects, but leaves this in the terminal:

    File "qtdialogs/setupmanager/DlgSetupManager.py", line 509, in initiateDbConnection
      raise ValueError(f"Unknown scenario: {scenario}")
    ValueError: Unknown scenario: Connect to IP

The peer and IP cases call _handleConnectionAttemptFinality but don't return, so they fall through to the raise. dev still has the return. With the return back, the same steps give the "Connection Successful" dialog.

Ubuntu 26.04, rc2_fixes (667c1b6).